### PR TITLE
Add Resource Governance Metrics to Metrics View

### DIFF
--- a/src/Sfx/App/Scripts/Models/DataModels/Shared.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Shared.ts
@@ -80,8 +80,16 @@ module Sfx {
             return this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0;
         }
 
+        public get isResourceGovernanceMetric(): boolean {
+            return _.startsWith(this.raw.Name, "servicefabric:/_");
+        }
+
         public get isSystemMetric(): boolean {
             return _.startsWith(this.raw.Name, "__") && _.endsWith(this.raw.Name, "__");
+        }
+
+        public get isLoadMetric(): boolean {
+            return !(this.isResourceGovernanceMetric || this.isSystemMetric);
         }
 
         public get loadCapacityRatio(): number {
@@ -90,6 +98,10 @@ module Sfx {
 
         public get loadCapacityRatioString(): string {
             return (this.loadCapacityRatio * 100).toFixed(1) + "%";
+        }
+
+        public get displayName(): string {
+            return this.name.replace(/^servicefabric:\/_/, "Reserved ");
         }
 
         public constructor(data: DataService, raw: IRawLoadMetricInformation) {

--- a/src/Sfx/App/Styles/Modules/_metrics.scss
+++ b/src/Sfx/App/Styles/Modules/_metrics.scss
@@ -5,8 +5,8 @@ $metric-chart-height: 630px;
 $metric-chart-body-width: 760px;
 $metric-chart-left-width: 80px;
 $metric-chart-right-width: 100px;
-$metric-column-width: 230px;
-$metric-column-height: 483px;
+$metric-column-width: 250px;
+$metric-column-height: 428px;
 $metric-container-margin: 12px;
 $metric-container-padding: 6px;
 
@@ -17,12 +17,16 @@ $metrics-view-expander-hover-color: lighten($essen-pane-background-color, 10%);
 .metrics-view {
     white-space: nowrap;
 
-    .metrics-view-options {
-        margin-bottom: $metric-container-margin;
-        width: $metric-chart-left-width + $metric-chart-body-width + $metric-column-width;
+    .chart-column {
+        display: inline-block;
+        vertical-align: top;
+        width: $metric-chart-left-width + $metric-chart-body-width;
 
         .checkbox-container {
             display: inline-block;
+            margin-left: 65px;
+            margin-bottom: $metric-container-margin;
+            height: 19px;
 
             &:not(:first-child) {
                 margin-left: 130px;
@@ -40,89 +44,87 @@ $metrics-view-expander-hover-color: lighten($essen-pane-background-color, 10%);
                 }
             }
         }
-    }
 
-    .metrics-chart {
-        display: inline-block;
-        vertical-align: top;
-        height: $metric-chart-height;
-
-        text {
-            fill: $chart-text-color;
-        }
-
-        .axis path, line {
-            fill: none;
-            stroke: $chart-text-color;
-            shape-rendering: crispEdges;
-        }
-
-        .metrics-chart-left {
-            display: inline-block;
-            vertical-align: top;
-            width: $metric-chart-left-width;
+        .metrics-chart {
             height: $metric-chart-height;
-        }
 
-        .metrics-chart-right {
-            display: inline-block;
-            vertical-align: top;
-            width: $metric-chart-right-width;
-            height: $metric-chart-height;
-        }
+            text {
+                fill: $chart-text-color;
+            }
 
-        .metrics-chart-body-container {
-            display: inline-block;
-            vertical-align: top;
-            position: relative;
-            width: $metric-chart-body-width;
-            height: $metric-chart-height;
-            overflow-x: auto;
-            overflow-y: visible;
+            .axis path, line {
+                fill: none;
+                stroke: $chart-text-color;
+                shape-rendering: crispEdges;
+            }
 
-            .metrics-chart-body {
-                // leave 25 pixel for the horizontal scroll bar
-                height: $metric-chart-height - 25px;
+            .metrics-chart-left {
+                display: inline-block;
+                vertical-align: top;
+                width: $metric-chart-left-width;
+                height: $metric-chart-height;
+            }
 
-                .metric:hover {
-                    fill: $azure-blue !important;
-                }
+            .metrics-chart-right {
+                display: inline-block;
+                vertical-align: top;
+                width: $metric-chart-right-width;
+                height: $metric-chart-height;
+            }
 
-                .metric-rect {
-                    shape-rendering: crispEdges;
+            .metrics-chart-body-container {
+                display: inline-block;
+                vertical-align: top;
+                position: relative;
+                width: $metric-chart-body-width;
+                height: $metric-chart-height;
+                overflow-x: auto;
+                overflow-y: visible;
 
-                    &[is-capacity-violation=true] {
-                        fill: $metric-capacity-violation-fill-color;
-                    }
+                .metrics-chart-body {
+                    // leave 25 pixel for the horizontal scroll bar
+                    height: $metric-chart-height - 25px;
 
-                    &[is-capacity-violation=false] {
-                        fill: unset;
-                    }
-                }
-
-                .metric-cap-rect {
-                    shape-rendering: crispEdges;
-                    fill: $essen-pane-background-color;
-                    fill-opacity: 1;
-
-                    &:hover {
+                    .metric:hover {
                         fill: $azure-blue !important;
-                        fill-opacity: 0.4;
                     }
 
-                    &[is-capacity-violation=true] {
-                        stroke: lighten($metric-capacity-violation-stroke-color, 20%);
-                        fill: lighten($metric-capacity-violation-fill-color, 30%);
-                        fill-opacity: 0.4;
+                    .metric-rect {
+                        shape-rendering: crispEdges;
+
+                        &[is-capacity-violation=true] {
+                            fill: $metric-capacity-violation-fill-color;
+                        }
+
+                        &[is-capacity-violation=false] {
+                            fill: unset;
+                        }
                     }
-                }
 
-                .mean-line {
-                    stroke: $metric-capacity-violation-stroke-color;
-                }
+                    .metric-cap-rect {
+                        shape-rendering: crispEdges;
+                        fill: $essen-pane-background-color;
+                        fill-opacity: 1;
 
-                .mean-label {
-                    fill: $chart-text-color;
+                        &:hover {
+                            fill: $azure-blue !important;
+                            fill-opacity: 0.4;
+                        }
+
+                        &[is-capacity-violation=true] {
+                            stroke: lighten($metric-capacity-violation-stroke-color, 20%);
+                            fill: lighten($metric-capacity-violation-fill-color, 30%);
+                            fill-opacity: 0.4;
+                        }
+                    }
+
+                    .mean-line {
+                        stroke: $metric-capacity-violation-stroke-color;
+                    }
+
+                    .mean-label {
+                        fill: $chart-text-color;
+                    }
                 }
             }
         }
@@ -130,6 +132,19 @@ $metrics-view-expander-hover-color: lighten($essen-pane-background-color, 10%);
 
     .metrics-column-container {
         display: inline-block;
+
+        .checkbox-container {
+            display: inline-block;
+            margin-bottom: $metric-container-margin;
+
+            &:not(:first-child) {
+                margin-left: 130px;
+            }
+
+            label {
+                display: block;
+            }
+        }
 
         .metric-column-title {
             margin-bottom: $metric-container-margin;
@@ -170,7 +185,7 @@ $metrics-view-expander-hover-color: lighten($essen-pane-background-color, 10%);
                     text-overflow: ellipsis;
                     white-space: nowrap;
                     padding-left: $metric-container-padding;
-                    padding-right: 55px;
+                    padding-right: 25px;
                 }
 
                 .metric-ratio {

--- a/src/Sfx/App/partials/metrics-view.html
+++ b/src/Sfx/App/partials/metrics-view.html
@@ -1,19 +1,12 @@
 ﻿<div class="metrics-view">
-    <div class="metrics-view-options">
+    <div class="metrics-column-container">
         <div class="checkbox-container">
+            <label><input type="checkbox" ng-model="metrics.showResourceGovernanceMetrics" /><label><!-- this is left empty intentionally --></label>Show resource capacity</label>
+            <label><input type="checkbox" ng-model="metrics.showLoadMetrics" /><label><!-- this is left empty intentionally --></label>Show load metrics</label>
             <label><input type="checkbox" ng-model="metrics.showSystemMetrics" /><label><!-- this is left empty intentionally --></label>Show system metrics</label>
         </div>
-        <div class="checkbox-container" ng-if="metrics.selectedMetrics.length > 0 && metrics.selectedMetrics[0].hasCapacity">
-            <label><input type="checkbox" ng-model="metrics.normalizeMetricsData" /><label><!-- this is left empty intentionally --></label>Normalize metric data</label>
-        </div>
-        <div class="metrics-view-expander" ng-if="metrics.isExpanderEnabled">
-            <a class="bowtie-icon bowtie-view-full-screen-exit" title="Collapse the chart" ng-if="metrics.isFullScreen" ng-click="metrics.toggleFullScreen(false)"></a>
-            <a class="bowtie-icon bowtie-view-full-screen" title="Expand the chart" ng-if="!metrics.isFullScreen" ng-click="metrics.toggleFullScreen(true)"></a>
-        </div>
-    </div>
-    <div class="metrics-column-container">
         <div class="metric-column-title">
-            <span class="pull-right">Capacity</span>
+            <span class="pull-right">Used Capacity</span>
             <span>Metric Name</span>
         </div>
         <div class="metrics-column">
@@ -27,13 +20,22 @@
                  tooltip-popup-delay="600"
                  ng-repeat="metric in metrics.filteredMetrics | orderBy: ['!hasCapacity', 'isSystemCapacity'] track by metric.name">
                 <div class="metric-legend" ng-style="{'background-color': metrics.getLegendColor(metric.name)}"></div>
-                <div class="metric-title">{{::metric.name}}</div>
+                <div class="metric-title">{{::metric.displayName}}</div>
                 <div class="metric-ratio" is-capacity-violation="{{metric.hasCapacity && metric.raw.IsClusterCapacityViolation}}">{{metric.hasCapacity? metric.loadCapacityRatioString : "N/A"}}</div>
             </div>
         </div>
     </div>
 
-    <div sfx-metrics-bar-chart class="metrics-chart"></div>
+    <div class="chart-column">
+        <div class="checkbox-container">
+            <label ng-if="metrics.selectedMetrics.length > 0 && metrics.selectedMetrics[0].hasCapacity"><input type="checkbox" ng-model="metrics.normalizeMetricsData" /><label><!-- this is left empty intentionally --></label>Normalize metric data</label>
+        </div>
+        <div class="metrics-view-expander" ng-if="metrics.isExpanderEnabled">
+            <a class="bowtie-icon bowtie-view-full-screen-exit" title="Collapse the chart" ng-if="metrics.isFullScreen" ng-click="metrics.toggleFullScreen(false)"></a>
+            <a class="bowtie-icon bowtie-view-full-screen" title="Expand the chart" ng-if="!metrics.isFullScreen" ng-click="metrics.toggleFullScreen(true)"></a>
+        </div>
+        <div sfx-metrics-bar-chart class="metrics-chart"></div>
+    </div>
 
     <script type="text/ng-template" id="metric-tooltip.html">
         <div ng-if="metric.hasCapacity && metric.raw.IsClusterCapacityViolation"><b>Capacity Violation</b></div>


### PR DESCRIPTION
This change adds resource governance metrics to Clusters' Metrics View. These metrics are shown even when they are not enabled for applications on the cluster, in order to improve discoverability.