### PR TITLE
Fix module manager not working in conjection scenarios.

### DIFF
--- a/src/Sfx-Standalone/module-manager/bootstrap.ts
+++ b/src/Sfx-Standalone/module-manager/bootstrap.ts
@@ -8,8 +8,10 @@
  */
 
 import { IModuleManagerConstructorOptions } from "sfx.module-manager";
+import { ICommunicator } from "sfx.remoting";
 
 import "../utilities/utils";
+import * as simpleContext from "./simple-context";
 
 import * as electron from "electron";
 
@@ -17,36 +19,37 @@ import * as appUtils from "../utilities/appUtils";
 import { Communicator } from "../modules/ipc/communicator";
 import { ModuleManager } from "./module-manager";
 
-const brootstrapPromise: Promise<void> = ((): Promise<any> => {
+const bootstrapPromise: Promise<void> = ((): Promise<any> => {
     appUtils.logUnhandledRejection();
 
-    if (electron.ipcMain) {
-        appUtils.injectModuleManager(new ModuleManager(appUtils.getAppVersion()));
-        return;
+    let constructorOptions: IModuleManagerConstructorOptions;
+    let communicator: ICommunicator;
+
+    if (electron.ipcMain) { // Electron main process
+        communicator = undefined;
+        constructorOptions = {
+            hostVersion: appUtils.getAppVersion()
+        };
+
+    } else if (electron.ipcRenderer) { // Electron renderer
+        const contextId = `ModuleManagerConstructorOptions-${electron.remote.getCurrentWindow().id}`;
+        
+        communicator = Communicator.fromChannel(electron.ipcRenderer);
+
+        if (electron.remote.getCurrentWindow().webContents.id === electron.remote.getCurrentWebContents().id) {
+            constructorOptions = JSON.parse(appUtils.getCmdArg(ModuleManager.ConstructorOptionsCmdArgName));
+            simpleContext.writeContext(contextId, constructorOptions);
+        } else {
+            constructorOptions = simpleContext.readContext(contextId);
+        }
+    } else { // Node.js process
+        communicator = Communicator.fromChannel(process);
+        constructorOptions = JSON.parse(appUtils.getCmdArg(ModuleManager.ConstructorOptionsCmdArgName));
     }
 
-    const constructorOptions: IModuleManagerConstructorOptions = JSON.parse(appUtils.getCmdArg(ModuleManager.ConstructorOptionsCmdArgName));
-    const moduleManager = new ModuleManager(constructorOptions.hostVersion, Communicator.fromChannel(electron.ipcRenderer || process));
+    const moduleManager = new ModuleManager(constructorOptions.hostVersion, communicator);
 
     appUtils.injectModuleManager(moduleManager);
-
-    if (electron.remote
-        && electron.remote.getCurrentWindow().webContents.id === electron.remote.getCurrentWebContents().id) {
-        const constructorOptionsArg =
-            appUtils.toCmdArg(
-                ModuleManager.ConstructorOptionsCmdArgName,
-                JSON.stringify(constructorOptions));
-
-        electron.remote.getCurrentWindow()
-            .webContents.on("will-attach-webview",
-                (event, webPreferences, params) => {
-                    if (!Array.isArray(webPreferences.additionalArguments)) {
-                        webPreferences.additionalArguments = [];
-                    }
-
-                    webPreferences.additionalArguments.push(constructorOptionsArg);
-                });
-    }
 
     if (Array.isArray(constructorOptions.initialModules)) {
         return Promise.all(
@@ -57,4 +60,4 @@ const brootstrapPromise: Promise<void> = ((): Promise<any> => {
     return Promise.resolve();
 })();
 
-export default brootstrapPromise;
+export default bootstrapPromise;

--- a/src/Sfx-Standalone/module-manager/module-manager.d.ts
+++ b/src/Sfx-Standalone/module-manager/module-manager.d.ts
@@ -8,7 +8,7 @@ declare module "sfx.module-manager" {
 
     export interface IModuleManagerConstructorOptions {
         hostVersion: string;
-        initialModules: Array<IModuleLoadingConfig>;
+        initialModules?: Array<IModuleLoadingConfig>;
     }
 
     export interface IComponentDescriptor {

--- a/src/Sfx-Standalone/module-manager/simple-context.ts
+++ b/src/Sfx-Standalone/module-manager/simple-context.ts
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License file under the project root for license information.
+//-----------------------------------------------------------------------------
+
+import { IDictionary } from "sfx.common";
+
+import * as electron from "electron";
+
+const ChannelName = "simple-context";
+
+export enum ContextAction {
+    Read = "read-context",
+    Write = "write-context"
+}
+
+export declare function readContext(contextId: string): any;
+export declare function writeContext(contextId: string, contextValue: any): void;
+
+if (electron.ipcMain) {
+    const context: IDictionary<any> = Object.create(null);
+
+    electron.ipcMain.on(ChannelName,
+        (event: Electron.Event, action: ContextAction, contextId: string, contextValue: any) => {
+            if (ContextAction.Read === action) {
+                event.returnValue = context[contextId];
+
+            } else if (ContextAction.Write === action) {
+                context[contextId] = contextValue;
+                event.returnValue = true;
+            }
+        });
+
+    exports.readContext = (contextId: string): any => {
+        return context[contextId];
+    };
+
+    exports.writeContext = (contextId: string, contextValue: any): void => {
+        context[contextId] = contextValue;
+    };
+} else if (electron.ipcRenderer) {
+    exports.readContext = (contextId: string): any => {
+        return electron.ipcRenderer.sendSync(ChannelName, ContextAction.Read, contextId);
+    };
+
+    exports.writeContext = (contextId: string, contextValue: any): void => {
+        electron.ipcRenderer.sendSync(ChannelName, ContextAction.Write, contextId, contextValue);
+    };
+} else {
+    // Not Supported: Only supported in Electron execution context.
+}

--- a/src/Sfx-Standalone/modules/ipc/communicator.ts
+++ b/src/Sfx-Standalone/modules/ipc/communicator.ts
@@ -150,7 +150,7 @@ export class Communicator implements ICommunicator {
                 setTimeout(
                     (reject) => {
                         delete this.ongoingPromiseDict[msg.id];
-                        reject(new Error(`Response for the msg (Id:${msg.id}) is timed out.`));
+                        reject(new Error(utils.format("Response for the ipc message timed out: {}", msg)));
                     },
                     this.timeout,
                     reject);

--- a/src/Sfx-Standalone/utilities/utils.ts
+++ b/src/Sfx-Standalone/utilities/utils.ts
@@ -112,7 +112,9 @@ Error.prototype.toJSON = function (): any {
     return error;
 };
 
-export function defaultStringifier(obj: any): string {
+export function defaultStringifier(obj: any, padding?: number): string {
+    padding = getValue(padding, 0);
+
     if (obj === null) {
         return "null";
     } else if (obj === undefined) {
@@ -126,13 +128,13 @@ export function defaultStringifier(obj: any): string {
                 && obj.toString !== Object.prototype.toString)) {
             return obj.toString();
         } else {
-            let str: string = "{\n";
+            let str: string = `\n${"".padStart(padding)}{\n`;
 
             for (const propertyName of Object.getOwnPropertyNames(obj)) {
-                str += `${propertyName}: ${defaultStringifier(obj[propertyName])}\n`;
+                str += `${"".padStart(padding + 4)}${propertyName}: ${defaultStringifier(obj[propertyName], padding + 4)}\n`;
             }
 
-            str += "}";
+            str += `${"".padStart(padding)}}`;
 
             return str;
         }


### PR DESCRIPTION
* Add SimpleContext to give a workaround to pass constructor options.
* Log the whole message when the reponse of the msg times out.
* Fix DataInfoManager releasing the self-referencing root.
* Make defaultStringifier support padding to provide better format.