### PR TITLE
Make ObjectDataInfo always contain memberInfos.

### DIFF
--- a/src/Sfx-Standalone/modules/proxy.object/proxy.object.ts
+++ b/src/Sfx-Standalone/modules/proxy.object/proxy.object.ts
@@ -96,10 +96,10 @@ export class ObjectRemotingProxy implements IObjectRemotingProxy, IDelegator {
     public async requestAsync<T>(identifier: string, ...extraArgs: Array<any>): Promise<T & IDisposable> {
         this.validateDisposal();
 
-        const tempReferer = this.dataInfoManager.ReferAsDataInfo(() => undefined);
+        const tempReferer = this.dataInfoManager.referAsDataInfo(() => undefined);
         
         try {
-            const extraArgsDataInfos = extraArgs.map((arg) => this.dataInfoManager.ReferAsDataInfo(arg, tempReferer.id));
+            const extraArgsDataInfos = extraArgs.map((arg) => this.dataInfoManager.referAsDataInfo(arg, tempReferer.id));
 
             const targetDataInfo: IDataInfo =
                 await this.communicator.sendAsync<IRequestResourceProxyMessage, IDataInfo>(
@@ -114,7 +114,7 @@ export class ObjectRemotingProxy implements IObjectRemotingProxy, IDelegator {
             if (targetDataInfo.id) {
                 extraArgsDataInfos.forEach((argDataInfo) => {
                     if (argDataInfo.id) {
-                        this.dataInfoManager.AddReferenceById(argDataInfo.id, targetDataInfo.id);
+                        this.dataInfoManager.addReferenceById(argDataInfo.id, targetDataInfo.id);
                     }
                 });
             }
@@ -255,7 +255,7 @@ export class ObjectRemotingProxy implements IObjectRemotingProxy, IDelegator {
             throw new Error(`Target (${delegationMsg.refId}) doesn't exist.`);
         }
 
-        return this.dataInfoManager.ReferAsDataInfo(await target[delegationMsg.property], delegationMsg.refId);
+        return this.dataInfoManager.referAsDataInfo(await target[delegationMsg.property], delegationMsg.refId);
     }
 
     private onSetPropertyAsync = async (communicator: ICommunicator, path: string, msg: IDelegationProxyMessage): Promise<any> => {
@@ -288,7 +288,7 @@ export class ObjectRemotingProxy implements IObjectRemotingProxy, IDelegator {
                 this.dataInfoManager.realizeDataInfo(delegationMsg.thisArg, delegationMsg.refId),
                 ...delegationMsg.args.map((item) => this.dataInfoManager.realizeDataInfo(item, delegationMsg.refId)));
 
-        return this.dataInfoManager.ReferAsDataInfo(result, delegationMsg.refId);
+        return this.dataInfoManager.referAsDataInfo(result, delegationMsg.refId);
     }
 
     private onDisposeAsync = (communicator: ICommunicator, path: string, msg: IDelegationProxyMessage): Promise<void> => {
@@ -298,16 +298,16 @@ export class ObjectRemotingProxy implements IObjectRemotingProxy, IDelegator {
     }
 
     private onRequestResourceAsync = async (communicator: ICommunicator, path: string, msg: IRequestResourceProxyMessage): Promise<IDataInfo> => {
-        const tempReferer = this.dataInfoManager.ReferAsDataInfo(() => undefined);
+        const tempReferer = this.dataInfoManager.referAsDataInfo(() => undefined);
         const extraArgs = msg.extraArgs.map((argDataInfo) => this.dataInfoManager.realizeDataInfo(argDataInfo, tempReferer.id));
 
         const target = await this.resolveAsync(msg.resourceId, ...extraArgs);
-        const targetDataInfo = this.dataInfoManager.ReferAsDataInfo(target);
+        const targetDataInfo = this.dataInfoManager.referAsDataInfo(target);
 
         if (targetDataInfo.id) {
             msg.extraArgs.forEach((argDataInfo) => {
                 if (argDataInfo.id) {
-                    this.dataInfoManager.AddReferenceById(argDataInfo.id, targetDataInfo.id);
+                    this.dataInfoManager.addReferenceById(argDataInfo.id, targetDataInfo.id);
                 }
             });
         }

--- a/src/Sfx-Standalone/modules/proxy.object/reference-node.ts
+++ b/src/Sfx-Standalone/modules/proxy.object/reference-node.ts
@@ -177,7 +177,7 @@ export class ReferenceNode {
             throw new Error("target cannot be null/undefined or types other than Object or Function.");
         }
 
-        return target[this.symbol_dataInfo];
+        return target[this.symbol_dataInfo] = dataInfo;
     }
 
     public getRefDataInfo(target: Object | Function): IDataInfo {

--- a/src/Sfx-Standalone/modules/proxy.object/reference-node.ts
+++ b/src/Sfx-Standalone/modules/proxy.object/reference-node.ts
@@ -2,7 +2,9 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
 //-----------------------------------------------------------------------------
+
 import { IDictionary } from "sfx.common";
+import { IDataInfo } from "./data-info";
 
 import * as uuidv4 from "uuid/v4";
 
@@ -10,6 +12,8 @@ import * as utils from "../../utilities/utils";
 
 export class ReferenceNode {
     private readonly symbol_refId: symbol;
+
+    private readonly symbol_dataInfo: symbol;
 
     private readonly _root: ReferenceNode;
 
@@ -168,6 +172,22 @@ export class ReferenceNode {
         return target[this.symbol_refId];
     }
 
+    public setRefDataInfo(target: Object | Function, dataInfo: IDataInfo): IDataInfo {
+        if (!Object.isObject(target) && !Function.isFunction(target)) {
+            throw new Error("target cannot be null/undefined or types other than Object or Function.");
+        }
+
+        return target[this.symbol_dataInfo];
+    }
+
+    public getRefDataInfo(target: Object | Function): IDataInfo {
+        if (!Object.isObject(target) && !Function.isFunction(target)) {
+            return undefined;
+        }
+        
+        return target[this.symbol_dataInfo];
+    }
+
     private constructor(root: ReferenceNode, target: Object | Function, refId?: string) {
         if (utils.isNullOrUndefined(root) !== utils.isNullOrUndefined(target)) {
             throw new Error("root and target must be provided togehter or none are provided.");
@@ -182,6 +202,7 @@ export class ReferenceNode {
 
         if (!utils.isNullOrUndefined(root)) {
             this.symbol_refId = this.internalRoot.symbol_refId;
+            this.symbol_dataInfo = this.internalRoot.symbol_dataInfo;
             this.referers = Object.create(null);
 
             this.internalRoot.internallyAddReferee(this);
@@ -189,6 +210,7 @@ export class ReferenceNode {
         } else {
             // When this is a root node.
             this.symbol_refId = Symbol("refId");
+            this.symbol_dataInfo = Symbol("dataInfo");
             this.referers = undefined;
             this.referees[this._id] = this;
         }
@@ -233,6 +255,7 @@ export class ReferenceNode {
 
         if (this._target) {
             delete this._target[this.symbol_refId];
+            delete this._target[this.symbol_dataInfo];
             this._target = undefined;
         }
 


### PR DESCRIPTION
* Put the ObjectDataInfo into the target object.
* Return cached ObjectDataInfo directly when converting an existing object.
* Always return a ObjectDataInfo with memberInfos.