### PR TITLE
display a more meaningful role name for replica

### DIFF
--- a/src/Sfx/App/Scripts/Controllers/DeployedServiceReplicasViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/DeployedServiceReplicasViewController.ts
@@ -48,7 +48,7 @@ module Sfx {
                             new ListColumnSettingForLink("id", "Id", item => item.viewPath),
                             new ListColumnSetting("raw.PartitionId", "Partition Id"),
                             new ListColumnSettingWithFilter("raw.ServiceKind", "Service Kind"),
-                            new ListColumnSettingWithFilter("raw.ReplicaRole", "Replica Role", defaultSortProperties),
+                            new ListColumnSettingWithFilter("role", "Replica Role", defaultSortProperties),
                             new ListColumnSettingWithFilter("raw.ReplicaStatus", "Status")
                         ];
 

--- a/src/Sfx/App/Scripts/Controllers/PartitionViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/PartitionViewController.ts
@@ -65,7 +65,7 @@ module Sfx {
                         let columnSettings = [
                             new ListColumnSettingForLink("id", "Id", item => item.viewPath),
                             new ListColumnSetting("raw.NodeName", "Node Name"),
-                            new ListColumnSettingWithFilter("raw.ReplicaRole", "Replica Role", defaultSortProperties),
+                            new ListColumnSettingWithFilter("role", "Replica Role", defaultSortProperties),
                             new ListColumnSettingForBadge("healthState", "Health State"),
                             new ListColumnSettingWithFilter("raw.ReplicaStatus", "Status")
                         ];

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -345,7 +345,7 @@ module Sfx {
                         nodeId: IdGenerator.replica(replica.id),
                         displayName: () => replica.isStatelessService
                             ? replica.raw.NodeName
-                            : `${replica.raw.ReplicaRole} (${replica.raw.NodeName})`,
+                            : `${replica.role} (${replica.raw.NodeName})`,
                         selectAction: () => this.routes.navigate(() => replica.viewPath),
                         badge: () => replica.healthState,
                         sortBy: () => replica.isStatelessService

--- a/src/Sfx/App/partials/deployed-replica.html
+++ b/src/Sfx/App/partials/deployed-replica.html
@@ -28,7 +28,7 @@
                         <th ng-if="replica.servicePackageActivationId">Service Package Activation Id</th>
                     </tr>
                     <tr>
-                        <td ng-if="replica.isStatefulService">{{replica.raw.ReplicaRole}}</td>
+                        <td ng-if="replica.isStatefulService">{{replica.role}}</td>
                         <td ng-if="replica.servicePackageActivationId">{{replica.servicePackageActivationId}}</td>
                     </tr>
                 </table>

--- a/src/Sfx/App/partials/replica.html
+++ b/src/Sfx/App/partials/replica.html
@@ -27,7 +27,7 @@
                         <th ng-if="replica.isStatefulService">Role</th>
                     </tr>
                     <tr>
-                        <td ng-if="replica.isStatefulService">{{replica.raw.ReplicaRole}}</td>
+                        <td ng-if="replica.isStatefulService">{{replica.role}}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
add "Reconfiguraiton - Target:" prefix to the actual role name for replicas when partition is being reconfigured.