### PR TITLE
Fix for ui-bootstrap datepicker unsupported attrs

### DIFF
--- a/src/Sfx/App/Scripts/Directives/DatePickerDirective.ts
+++ b/src/Sfx/App/Scripts/Directives/DatePickerDirective.ts
@@ -14,18 +14,11 @@ module Sfx {
             minDate: "=?",
             maxDate: "=?",
             initDate: "=?",
-            dateOptions: "=?",
             readOnly: "=?",
             placeHolderText: "=?"
         };
 
         public link($scope: any, element: JQuery, attributes: any) {
-            $scope.dateOptions = $scope.dateOptions || {
-                formatYear: "yy",
-                startingDay: 1,
-                showWeeks: false
-            };
-
             $scope.initDate = $scope.initDate || new Date();
             $scope.readOnly = $scope.readOnly || true;
             $scope.placeHolderText = $scope.placeHolderText || "";

--- a/src/Sfx/App/partials/date-picker.html
+++ b/src/Sfx/App/partials/date-picker.html
@@ -3,7 +3,8 @@
         <input type="text" class="input-flat clear-disabled" uib-datepicker-popup="{{format}}"
             ng-model="ngModel" is-open="opened"
             min-date="minDate" max-date="maxDate" init-date="initDate"
-            datepicker-options="dateOptions" placeholder="{{placeHolderText}}" show-button-bar="false"
+            datepicker-options="{ formatYear: 'yy', startingDay: 1, showWeeks: false, initDate: initDate, minDate: minDate, maxDate: maxDate }"
+            placeholder="{{placeHolderText}}" show-button-bar="false"
             ng-required ng-readonly="readOnly" ng-click="ctrl.popupClick($event)"
             ng-keydown="$event.keyCode === 13 && ctrl.popupFocus($event)" aria-haspopup="true" />
         <span class="input-group-btn">


### PR DESCRIPTION
Starting ver>= 2 of ui-boostrap, the min-date & max-date & init-date are not working anymore.