### PR TITLE
Adding network information to the SFX

### DIFF
--- a/src/Sfx-Standalone/main.ts
+++ b/src/Sfx-Standalone/main.ts
@@ -31,7 +31,7 @@ async function startup(): Promise<void> {
         global["TargetClusterUrl"] = clusterUrl;
         const mainWindow = await sfxModuleManager.getComponentAsync("browser-window", null, true, clusterUrl);
 
-        mainWindow.setMenuBarVisibility(true);
+        mainWindow.setMenuBarVisibility(false);
 
         log.writeEventAsync("connect-cluster", { "clusterId": uuidv5(clusterUrl, uuidv5.URL) });
         mainWindow.loadURL(resolve("sfx/index.html"));

--- a/src/Sfx-Standalone/main.ts
+++ b/src/Sfx-Standalone/main.ts
@@ -31,7 +31,7 @@ async function startup(): Promise<void> {
         global["TargetClusterUrl"] = clusterUrl;
         const mainWindow = await sfxModuleManager.getComponentAsync("browser-window", null, true, clusterUrl);
 
-        mainWindow.setMenuBarVisibility(false);
+        mainWindow.setMenuBarVisibility(true);
 
         log.writeEventAsync("connect-cluster", { "clusterId": uuidv5(clusterUrl, uuidv5.URL) });
         mainWindow.loadURL(resolve("sfx/index.html"));

--- a/src/Sfx/App/Scripts/App.ts
+++ b/src/Sfx/App/Scripts/App.ts
@@ -28,6 +28,8 @@ module Sfx {
             "clusterViewController",
             "nodeViewController",
             "nodesViewController",
+            "networksViewController",
+            "networkViewController",
             "appTypeViewController",
             "appsViewController",
             "appViewController",

--- a/src/Sfx/App/Scripts/Common/RestClient.ts
+++ b/src/Sfx/App/Scripts/Common/RestClient.ts
@@ -81,6 +81,51 @@ module Sfx {
             return this.post(this.getApiUrl("$/GetClusterHealthChunk"), "Get cluster health chunk", healthDescriptor, messageHandler);
         }
 
+        public createNetwork(networkName: string, networkAddressPrefix: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName);
+            let body: any = { "name": networkName, "properties" : { "kind": "Local", "networkAddressPrefix": networkAddressPrefix } };
+            return this.put(this.getApiUrl(url, RestClient.apiVersion60), "Isolated Network creation", body, messageHandler);
+        }
+
+        public getNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawNetwork> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/";
+            return this.get(this.getApiUrl(url), "Get network", messageHandler);
+        }
+
+        public getNetworks(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetwork[]> {
+            return this.getFullCollection<IRawNetwork>("Resources/Networks/", "Get networks", RestClient.apiVersion60);
+        }
+
+        public deleteNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName);
+            return this.delete(this.getApiUrl(url), "Network Deletion", messageHandler);
+        }
+
+        public getNetworksOnApp(appId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnApp[]> {
+            let url = "Applications/" + encodeURIComponent(appId) + "/$/GetNetworks";
+            return this.getFullCollection<IRawNetworkOnApp>(url, "Get networks attached to a application", RestClient.apiVersion60);
+        }
+
+        public getNetworksOnNode(nodeName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnNode[]> {
+            let url = "Nodes/" + encodeURIComponent(nodeName) + "/$/GetNetworks";
+            return this.getFullCollection<IRawNetworkOnNode>(url, "Get networks deployed on a node", RestClient.apiVersion60);
+        }
+
+        public getAppsOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawAppOnNetwork[]> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/ApplicationRefs";
+            return this.getFullCollection<IRawAppOnNetwork>(url, "Get applications using current network", RestClient.apiVersion60);
+        }
+
+        public getNodesOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNodeOnNetwork[]> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/DeployedNodes";
+            return this.getFullCollection<IRawNodeOnNetwork>(url, "Get nodes, current network is deployed on", RestClient.apiVersion60);
+        }
+
+        public getDeployedContainersOnNetwork(networkName: string, nodeName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawDeployedContainerOnNetwork[]> {
+            let url = "Nodes/" + encodeURIComponent(nodeName) + "/$/GetNetworks/" + encodeURIComponent(networkName) + "/$/GetCodePackages";
+            return this.getFullCollection<IRawDeployedContainerOnNetwork>(url, "Get containers on network", RestClient.apiVersion60);
+        }
+
         public getNodes(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNode[]> {
             return this.getFullCollection<IRawNode>("Nodes/", "Get nodes");
         }
@@ -319,12 +364,12 @@ module Sfx {
         }
 
         public getApplications(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawApplication[]> {
-            return this.getFullCollection<IRawApplication>("Applications/", "Get applications", messageHandler);
+            return this.getFullCollection<IRawApplication>("Applications/", "Get applications", null, messageHandler);
         }
 
         public getServices(applicationId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawService[]> {
             let url = "Applications/" + encodeURIComponent(applicationId) + "/$/GetServices";
-            return this.getFullCollection<IRawService>(url, "Get services", messageHandler);
+            return this.getFullCollection<IRawService>(url, "Get services", null, messageHandler);
         }
 
         public getService(applicationId: string, serviceId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawService> {
@@ -431,7 +476,7 @@ module Sfx {
                 + "/$/GetServices/" + encodeURIComponent(serviceId)
                 + "/$/GetPartitions";
 
-            return this.getFullCollection<IRawPartition>(url, "Get partitions", messageHandler);
+            return this.getFullCollection<IRawPartition>(url, "Get partitions", null, messageHandler);
         }
 
         public getPartition(applicationId: string, serviceId: string, partitionId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawPartition> {
@@ -474,7 +519,7 @@ module Sfx {
                 + "/$/GetPartitions/" + encodeURIComponent(partitionId)
                 + "/$/GetReplicas";
 
-            return this.getFullCollection<IRawReplicaOnPartition>(url, "Get replicas on partition", messageHandler);
+            return this.getFullCollection<IRawReplicaOnPartition>(url, "Get replicas on partition", null, messageHandler);
         }
 
         public getReplicaOnPartition(applicationId: string, serviceId: string, partitionId: string, replicaId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawReplicaOnPartition> {
@@ -597,11 +642,11 @@ module Sfx {
                 `/${path}${path.indexOf("?") === -1 ? "?" : "&"}api-version=${apiVersion ? apiVersion : RestClient.defaultApiVersion}${skipCacheToken === true ? "" : `&_cacheToken=${this.cacheAllowanceToken}`}${continuationToken ? `&ContinuationToken=${continuationToken}` : ""}`;
         }
 
-        private getFullCollection<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler, continuationToken?: string): angular.IPromise<T[]> {
-            let appUrl = this.getApiUrl(url, null, continuationToken);
+        private getFullCollection<T>(url: string, apiDesc: string, apiVersion?: string, messageHandler?: IResponseMessageHandler, continuationToken?: string): angular.IPromise<T[]> {
+            let appUrl = this.getApiUrl(url, apiVersion, continuationToken);
             return this.get<IRawCollection<T>>(appUrl, apiDesc, messageHandler).then(response => {
                 if (response.data.ContinuationToken) {
-                    return this.getFullCollection<T>(url, apiDesc, messageHandler, response.data.ContinuationToken).then(items => {
+                    return this.getFullCollection<T>(url, apiDesc, apiVersion, messageHandler, response.data.ContinuationToken).then(items => {
                         return _.union(response.data.Items, items);
                     });
                 }
@@ -639,6 +684,16 @@ module Sfx {
             this.handleResponse(apiDesc, result, messageHandler);
 
             // Return original response object
+            return result;
+        }
+
+        private delete<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<T> {
+            let result = this.wrapInCallbacks(() => this.$http.delete<any>(url));
+            if (!messageHandler) {
+                messageHandler = ResponseMessageHandlers.getResponseMessageHandler;
+            }
+            this.handleResponse(apiDesc, result, messageHandler);
+
             return result;
         }
 

--- a/src/Sfx/App/Scripts/Common/RestClient.ts
+++ b/src/Sfx/App/Scripts/Common/RestClient.ts
@@ -14,6 +14,7 @@ module Sfx {
         private static apiVersion40: string = "4.0";
         private static apiVersion60: string = "6.0";
         private static apiVersion62Preview: string = "6.2-preview";
+        private static apiVersion64: string = "6.4";
 
         private cacheAllowanceToken: number = Date.now().valueOf();
 
@@ -84,21 +85,21 @@ module Sfx {
         public createNetwork(networkName: string, networkAddressPrefix: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName);
             let body: any = { "name": networkName, "properties" : { "kind": "Local", "networkAddressPrefix": networkAddressPrefix } };
-            return this.put(this.getApiUrl(url, RestClient.apiVersion60), "Isolated Network creation", body, messageHandler);
+            return this.put(this.getApiUrl(url, RestClient.apiVersion64), "Isolated Network creation", body, messageHandler);
         }
 
         public getNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawNetwork> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/";
-            return this.get(this.getApiUrl(url), "Get network", messageHandler);
+            return this.get(this.getApiUrl(url, RestClient.apiVersion64), "Get network", messageHandler);
         }
 
         public getNetworks(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetwork[]> {
-            return this.getFullCollection<IRawNetwork>("Resources/Networks/", "Get networks", RestClient.apiVersion60);
+            return this.getFullCollection<IRawNetwork>("Resources/Networks/", "Get networks", RestClient.apiVersion64);
         }
 
         public deleteNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName);
-            return this.delete(this.getApiUrl(url), "Network Deletion", messageHandler);
+            return this.delete(this.getApiUrl(url, RestClient.apiVersion64), "Network Deletion", messageHandler);
         }
 
         public getNetworksOnApp(appId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnApp[]> {
@@ -113,12 +114,12 @@ module Sfx {
 
         public getAppsOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawAppOnNetwork[]> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/ApplicationRefs";
-            return this.getFullCollection<IRawAppOnNetwork>(url, "Get applications using current network", RestClient.apiVersion60);
+            return this.getFullCollection<IRawAppOnNetwork>(url, "Get applications using current network", RestClient.apiVersion64);
         }
 
         public getNodesOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNodeOnNetwork[]> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/DeployedNodes";
-            return this.getFullCollection<IRawNodeOnNetwork>(url, "Get nodes, current network is deployed on", RestClient.apiVersion60);
+            return this.getFullCollection<IRawNodeOnNetwork>(url, "Get nodes, current network is deployed on", RestClient.apiVersion64);
         }
 
         public getDeployedContainersOnNetwork(networkName: string, nodeName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawDeployedContainerOnNetwork[]> {

--- a/src/Sfx/App/Scripts/Controllers/AppViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/AppViewController.ts
@@ -16,6 +16,8 @@ module Sfx {
         serviceTypesListSettings: ListSettings;
         deployedApplicationsHealthStates: DeployedApplicationHealthState[];
         appEvents: ApplicationEventList;
+        networks: NetworkOnAppCollection;
+        networkListSettings: ListSettings;
     }
 
     export class AppViewController extends MainViewController {
@@ -70,6 +72,13 @@ module Sfx {
             this.$scope.upgradeProgressUnhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings("upgradeProgressUnhealthyEvaluations");
             this.$scope.appEvents = this.data.createApplicationEventList(this.appId);
 
+            this.$scope.networkListSettings = this.settings.getNewOrExistingListSettings("networks", ["networkDetail.name"], [
+                new ListColumnSettingForLink("networkDetail.name", "Network Name", item => item.viewPath),
+                new ListColumnSetting("networkDetail.type", "Network Type"),
+                new ListColumnSetting("networkDetail.addressPrefix", "Network Address Prefix"),
+                new ListColumnSetting("networkDetail.status", "Network Status"),
+            ]);
+            this.$scope.networks = new  NetworkOnAppCollection(this.data, this.appId);
             this.refresh();
         }
 
@@ -99,7 +108,8 @@ module Sfx {
                     })
                     : this.$q.when(true),
                 this.$scope.app.serviceTypes.refresh(messageHandler),
-                this.$scope.app.services.refresh(messageHandler)]);
+                this.$scope.app.services.refresh(messageHandler),
+                this.$scope.networks.refresh(messageHandler)]);
         }
 
         private refreshManifest(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {

--- a/src/Sfx/App/Scripts/Controllers/AppViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/AppViewController.ts
@@ -114,7 +114,7 @@ module Sfx {
                     : this.$q.when(true),
                 this.$scope.app.serviceTypes.refresh(messageHandler),
                 this.$scope.app.services.refresh(messageHandler),
-                this.$scope.clusterManifest.isNetworkInventoryManagerEnabled() ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true)
+                this.$scope.clusterManifest.isNetworkInventoryManagerEnabled ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true)
                 ]);
         }
 

--- a/src/Sfx/App/Scripts/Controllers/AppViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/AppViewController.ts
@@ -18,6 +18,7 @@ module Sfx {
         appEvents: ApplicationEventList;
         networks: NetworkOnAppCollection;
         networkListSettings: ListSettings;
+        clusterManifest: ClusterManifest;
     }
 
     export class AppViewController extends MainViewController {
@@ -78,26 +79,30 @@ module Sfx {
                 new ListColumnSetting("networkDetail.addressPrefix", "Network Address Prefix"),
                 new ListColumnSetting("networkDetail.status", "Network Status"),
             ]);
+            this.$scope.clusterManifest = new ClusterManifest(this.data);
             this.$scope.networks = new  NetworkOnAppCollection(this.data, this.appId);
             this.refresh();
         }
 
         protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
-            return this.data.getApp(this.appId, true, messageHandler).then(data => {
-                this.$scope.app = data;
+            return this.$q.all([
+                this.data.getApp(this.appId, true, messageHandler).then(data => {
+                    this.$scope.app = data;
 
-                return this.$scope.app.health.refresh(messageHandler).then(() => {
-                    this.$scope.deployedApplicationsHealthStates = this.$scope.app.health.deployedApplicationHealthStates;
+                    return this.$scope.app.health.refresh(messageHandler).then(() => {
+                        this.$scope.deployedApplicationsHealthStates = this.$scope.app.health.deployedApplicationHealthStates;
 
-                    if (this.$scope.app.health.deploymentsHealthState.text !== HealthStateConstants.OK) {
-                        this.tabs["deployments"].superscriptInHtml = () => {
-                            return `<image class="tab-superscript-badge" src="images/${this.$scope.app.health.deploymentsHealthState.badgeClass}.svg"></image>`;
-                        };
-                    } else {
-                        this.tabs["deployments"].superscriptInHtml = null;
-                    }
-                });
-            });
+                        if (this.$scope.app.health.deploymentsHealthState.text !== HealthStateConstants.OK) {
+                            this.tabs["deployments"].superscriptInHtml = () => {
+                                return `<image class="tab-superscript-badge" src="images/${this.$scope.app.health.deploymentsHealthState.badgeClass}.svg"></image>`;
+                            };
+                        } else {
+                            this.tabs["deployments"].superscriptInHtml = null;
+                        }
+                    });
+                }),
+                this.$scope.clusterManifest.ensureInitialized(false)
+            ]);
         }
 
         private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
@@ -109,7 +114,8 @@ module Sfx {
                     : this.$q.when(true),
                 this.$scope.app.serviceTypes.refresh(messageHandler),
                 this.$scope.app.services.refresh(messageHandler),
-                this.$scope.networks.refresh(messageHandler)]);
+                this.$scope.clusterManifest.isNetworkInventoryManagerEnabled() ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true)
+                ]);
         }
 
         private refreshManifest(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -32,7 +32,6 @@ module Sfx {
                 IdGenerator.networkGroup(),
                 IdGenerator.network(this.networkName)
             ]);
-            console.log("where am i");
             this.$scope.appListSettings = this.settings.getNewOrExistingListSettings("apps", ["appDetail.raw.Name"], [
                 new ListColumnSettingForLink("appDetail.raw.Name", "Application Name", item => item.viewPath),
                 new ListColumnSetting("appDetail.raw.TypeName", "Application Type"),
@@ -40,7 +39,6 @@ module Sfx {
                 new ListColumnSetting("appDetail.raw.Status", "Status"),
             ]);
             this.$scope.apps = new AppOnNetworkCollection(this.data, this.networkName);
-            console.log("where am i 2");
             this.$scope.nodeListSettings = this.settings.getNewOrExistingListSettings("nodes", ["nodeDetails.name"], [
                 new ListColumnSettingForLink("nodeDetails.name", "Name", item => item.viewPath),
                 new ListColumnSetting("nodeDetails.raw.IpAddressOrFQDN", "Address"),
@@ -66,14 +64,12 @@ module Sfx {
             ]);
             this.$scope.containers = new DeployedContainerOnNetworkCollection(this.data, this.networkName);
             this.refresh();
-            console.log("constructor ends");
         }
 
         protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
             return this.data.getNetwork(this.networkName, true, messageHandler)
                 .then(network => {
                     this.$scope.network = network;
-                    console.log("NetworkViewController refresh common");
                 });
         }
 

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -1,0 +1,92 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export interface INetworkViewScope extends angular.IScope {
+        network: Network;
+        listSettings: ListSettings;
+        apps: AppOnNetworkCollection;
+        appListSettings: ListSettings;
+        nodes: NodeOnNetworkCollection;
+        nodeListSettings: ListSettings;
+        containers: DeployedContainerOnNetworkCollection;
+        containerListSettings: ListSettings;
+    }
+
+    export class NetworkViewController extends MainViewController {
+        public networkName: string;
+
+        constructor($injector: angular.auto.IInjectorService, public $scope: INetworkViewScope) {
+            super($injector, {
+                "essentials": { name: "Essentials" },
+                "details": { name: "Details" }
+            });
+            this.tabs["essentials"].refresh = (messageHandler) => this.refreshEssentials(messageHandler);
+            this.tabs["details"].refresh = (messageHandler) => this.refreshCommon(messageHandler);
+            this.networkName = IdUtils.getNetworkName(this.routeParams);
+
+            this.selectTreeNode([
+                IdGenerator.cluster(),
+                IdGenerator.networkGroup(),
+                IdGenerator.network(this.networkName)
+            ]);
+            this.$scope.appListSettings = this.settings.getNewOrExistingListSettings("apps", ["appDetail.raw.Name"], [
+                new ListColumnSettingForLink("appDetail.raw.Name", "Application Name", item => item.viewPath),
+                new ListColumnSetting("appDetail.raw.TypeName", "Application Type"),
+                new ListColumnSettingForBadge("appDetail.healthState", "Health State"),
+                new ListColumnSetting("appDetail.raw.Status", "Status"),
+            ]);
+            this.$scope.apps = new AppOnNetworkCollection(this.data, this.networkName);
+            this.$scope.nodeListSettings = this.settings.getNewOrExistingListSettings("nodes", ["nodeDetails.name"], [
+                new ListColumnSettingForLink("nodeDetails.name", "Name", item => item.viewPath),
+                new ListColumnSetting("nodeDetails.raw.IpAddressOrFQDN", "Address"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.Type", "Node Type"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.UpgradeDomain", "Upgrade Domain"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.FaultDomain", "Fault Domain"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.IsSeedNode", "Is Seed Node"),
+                new ListColumnSettingForBadge("nodeDetails.healthState", "Health State"),
+                new ListColumnSettingWithFilter("nodeDetails.nodeStatus", "Status"),
+            ]);
+            this.$scope.nodes = new NodeOnNetworkCollection(this.data, this.networkName);
+            this.$scope.containerListSettings = this.settings.getNewOrExistingListSettings("containers", ["nodeName, raw.CodePackageName"], [
+                new ListColumnSettingForLink("raw.CodePackageName", "Code Package Name", item => item.viewPath),
+                new ListColumnSetting("nodeName", "Node Name"),
+                new ListColumnSetting("raw.NetworkName", "Network"),
+                new ListColumnSetting("raw.ApplicationName", "Application"),
+                new ListColumnSetting("raw.CodePackageVersion", "Version"),
+                new ListColumnSetting("raw.ServiceManifestName", "Service"),
+                new ListColumnSetting("raw.ServicePackageActivationId", "Activation Id"),
+                new ListColumnSetting("raw.ContainerAddress", "Container addresses"),
+                new ListColumnSetting("raw.ContainerId", "Container Id")
+
+            ]);
+            this.$scope.containers = new DeployedContainerOnNetworkCollection(this.data, this.networkName);
+            this.refresh();
+        }
+
+        protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.getNetwork(this.networkName, true, messageHandler)
+                .then(network => {
+                    this.$scope.network = network;
+                });
+        }
+
+        private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+
+            return this.$q.all([
+                this.$scope.apps.refresh(messageHandler),
+                this.$scope.nodes.refresh(messageHandler),
+                this.$scope.containers.refresh(messageHandler)
+            ]);
+        }
+    }
+
+    (function () {
+
+        let module = angular.module("networkViewController", ["ngRoute", "dataService"]);
+        module.controller("NetworkViewController", ["$injector", "$scope", NetworkViewController]);
+
+    })();
+}

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -32,6 +32,7 @@ module Sfx {
                 IdGenerator.networkGroup(),
                 IdGenerator.network(this.networkName)
             ]);
+            console.log("where am i");
             this.$scope.appListSettings = this.settings.getNewOrExistingListSettings("apps", ["appDetail.raw.Name"], [
                 new ListColumnSettingForLink("appDetail.raw.Name", "Application Name", item => item.viewPath),
                 new ListColumnSetting("appDetail.raw.TypeName", "Application Type"),
@@ -39,6 +40,7 @@ module Sfx {
                 new ListColumnSetting("appDetail.raw.Status", "Status"),
             ]);
             this.$scope.apps = new AppOnNetworkCollection(this.data, this.networkName);
+            console.log("where am i 2");
             this.$scope.nodeListSettings = this.settings.getNewOrExistingListSettings("nodes", ["nodeDetails.name"], [
                 new ListColumnSettingForLink("nodeDetails.name", "Name", item => item.viewPath),
                 new ListColumnSetting("nodeDetails.raw.IpAddressOrFQDN", "Address"),
@@ -50,7 +52,7 @@ module Sfx {
                 new ListColumnSettingWithFilter("nodeDetails.nodeStatus", "Status"),
             ]);
             this.$scope.nodes = new NodeOnNetworkCollection(this.data, this.networkName);
-            this.$scope.containerListSettings = this.settings.getNewOrExistingListSettings("containers", ["nodeName, raw.CodePackageName"], [
+            this.$scope.containerListSettings = this.settings.getNewOrExistingListSettings("containers", ["nodeName", "raw.CodePackageName"], [
                 new ListColumnSettingForLink("raw.CodePackageName", "Code Package Name", item => item.viewPath),
                 new ListColumnSetting("nodeName", "Node Name"),
                 new ListColumnSetting("raw.NetworkName", "Network"),
@@ -64,12 +66,14 @@ module Sfx {
             ]);
             this.$scope.containers = new DeployedContainerOnNetworkCollection(this.data, this.networkName);
             this.refresh();
+            console.log("constructor ends");
         }
 
         protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
             return this.data.getNetwork(this.networkName, true, messageHandler)
                 .then(network => {
                     this.$scope.network = network;
+                    console.log("NetworkViewController refresh common");
                 });
         }
 

--- a/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export interface INetworksViewScope extends angular.IScope {
+        networks: NetworkCollection;
+        listSettings: ListSettings;
+        actions: ActionCollection;
+    }
+
+    export class NetworksViewController extends MainViewController {
+        constructor($injector: angular.auto.IInjectorService, public $scope: INetworksViewScope) {
+            super($injector);
+
+            this.selectTreeNode([
+                IdGenerator.cluster(),
+                IdGenerator.networkGroup()
+            ]);
+            this.$scope.listSettings = this.settings.getNewOrExistingListSettings("networks", ["name"], [
+                new ListColumnSettingForLink("name", "Name", item => item.viewPath),
+                new ListColumnSetting("type", "Type"),
+                new ListColumnSetting("addressPrefix", "NetworkAddressPrefix"),
+                new ListColumnSetting("status", "NetworkStatus")
+
+            ]);
+            this.$scope.actions = new ActionCollection(this.data.telemetry, this.$q);
+            if (this.data.actionsEnabled) {
+                this.addActions(this.$scope.actions);
+            }
+            this.refresh();
+        }
+
+        protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.getNetworks(true, messageHandler)
+                .then(networks => {
+                    this.$scope.networks = networks;
+                });
+        }
+
+        private addActions(actions: ActionCollection) {
+            actions.add(new ActionCreateIsolatedNetwork(this.data));
+        }
+    };
+    export class ActionCreateIsolatedNetwork extends ActionWithDialog {
+
+        public networkName: string;
+
+        public networkAddressPrefix: string;
+
+        constructor(data: DataService) {
+
+            super(
+                data.$uibModal,
+                data.$q,
+                "createIsolatednetwork",
+                "Create Isolated Network",
+                "Creating",
+                () => data.restClient.createNetwork(this.networkName, this.networkAddressPrefix),
+                () => true,
+                <angular.ui.bootstrap.IModalSettings>{
+                    templateUrl: "partials/create-network-dialog.html",
+                    controller: ActionController,
+                    resolve: {
+                        action: () => this
+                    }
+                },
+                null);
+
+            this.reset();
+        }
+
+        private reset(): void {
+            this.networkName = "";
+            this.networkAddressPrefix = "";
+        }
+
+    };
+
+    (function () {
+
+        let module = angular.module("networksViewController", []);
+        module.controller("NetworksViewController", ["$injector", "$scope", NetworksViewController]);
+
+    })();
+}

--- a/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
@@ -89,7 +89,7 @@ module Sfx {
                     this.$scope.deployedApps = deployedApps;
                 }),
                 //this.$scope.clusterManifest.ensureInitialized(false).then(() => {
-                    this.$scope.clusterManifest.isNetworkInventoryManagerEnabled() ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true),
+                    this.$scope.clusterManifest.isNetworkInventoryManagerEnabled ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true),
                 //})
             ]);
 

--- a/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
@@ -21,6 +21,8 @@ module Sfx {
         healthEventsListSettings: ListSettings;
         unhealthyEvaluationsListSettings: ListSettings;
         nodeEvents: NodeEventList;
+        networks: NetworkOnNodeCollection;
+        networkListSettings: ListSettings;
     }
 
     export class NodeViewController extends MainViewController {
@@ -54,6 +56,13 @@ module Sfx {
             this.$scope.unhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings();
             this.$scope.nodeEvents = this.data.createNodeEventList(this.nodeName);
 
+            this.$scope.networkListSettings = this.settings.getNewOrExistingListSettings("networks", ["networkDetail.name"], [
+                new ListColumnSettingForLink("networkDetail.name", "Network Name", item => item.viewPath),
+                new ListColumnSetting("networkDetail.type", "Network Type"),
+                new ListColumnSetting("networkDetail.addressPrefix", "Network Address Prefix"),
+                new ListColumnSetting("networkDetail.status", "Network Status"),
+            ]);
+            this.$scope.networks = new NetworkOnNodeCollection(this.data, this.nodeName);
             this.refresh();
         }
 
@@ -71,9 +80,11 @@ module Sfx {
         }
 
         private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
-            return this.$scope.node.deployedApps.refresh(messageHandler).then(deployedApps => {
-                this.$scope.deployedApps = deployedApps;
-            });
+            return this.$q.all([
+                this.$scope.node.deployedApps.refresh(messageHandler).then(deployedApps => {
+                    this.$scope.deployedApps = deployedApps;
+                }),
+            this.$scope.networks.refresh(messageHandler)]);
         }
 
         private refreshEvents(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {

--- a/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NodeViewController.ts
@@ -23,6 +23,7 @@ module Sfx {
         nodeEvents: NodeEventList;
         networks: NetworkOnNodeCollection;
         networkListSettings: ListSettings;
+        clusterManifest: ClusterManifest;
     }
 
     export class NodeViewController extends MainViewController {
@@ -63,16 +64,19 @@ module Sfx {
                 new ListColumnSetting("networkDetail.status", "Network Status"),
             ]);
             this.$scope.networks = new NetworkOnNodeCollection(this.data, this.nodeName);
+            this.$scope.clusterManifest = new ClusterManifest(this.data);
             this.refresh();
         }
 
         protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
-            return this.data.getNode(this.nodeName, true, messageHandler)
+            return this.$q.all([
+                this.data.getNode(this.nodeName, true, messageHandler)
                 .then(node => {
                     this.$scope.node = node;
-
                     return this.$scope.node.health.refresh(messageHandler);
-                });
+                }),
+                this.$scope.clusterManifest.ensureInitialized(false)
+            ]);
         }
 
         private refreshDetails(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
@@ -84,7 +88,11 @@ module Sfx {
                 this.$scope.node.deployedApps.refresh(messageHandler).then(deployedApps => {
                     this.$scope.deployedApps = deployedApps;
                 }),
-            this.$scope.networks.refresh(messageHandler)]);
+                //this.$scope.clusterManifest.ensureInitialized(false).then(() => {
+                    this.$scope.clusterManifest.isNetworkInventoryManagerEnabled() ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true),
+                //})
+            ]);
+
         }
 
         private refreshEvents(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {

--- a/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
@@ -16,13 +16,10 @@ module Sfx {
             return this.data.restClient.getApplication(IdUtils.nameToId(this.raw.ApplicationName), messageHandler).then(items => {
                 this.appDetail = new Application(this.data, items.data);
                 return this.appDetail.refresh().then(() => this.appDetail);
-                //console.log("refresh function");
             });
         }
 
         public get viewPath(): string {
-            console.log("view path");
-            console.log(this.appDetail.name);
             return this.data.routes.getAppViewPath(this.appDetail.raw.TypeName, this.appDetail.raw.Id);
         }
     }

--- a/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class AppOnNetwork extends DataModelBase<IRawAppOnNetwork> {
+
+        public appDetail: Application;
+
+        public constructor(data: DataService, raw?: IRawAppOnNetwork) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getApplication(IdUtils.nameToId(this.raw.ApplicationName), messageHandler).then(items => {
+                this.appDetail = new Application(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getAppViewPath(this.appDetail.raw.TypeName, this.appDetail.raw.Id);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
@@ -15,10 +15,14 @@ module Sfx {
         protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
             return this.data.restClient.getApplication(IdUtils.nameToId(this.raw.ApplicationName), messageHandler).then(items => {
                 this.appDetail = new Application(this.data, items.data);
+                return this.appDetail.refresh().then(() => this.appDetail);
+                //console.log("refresh function");
             });
         }
 
         public get viewPath(): string {
+            console.log("view path");
+            console.log(this.appDetail.name);
             return this.data.routes.getAppViewPath(this.appDetail.raw.TypeName, this.appDetail.raw.Id);
         }
     }

--- a/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
@@ -63,6 +63,15 @@ module Sfx {
             let $manifest = $xml.find("ClusterManifest")[0];
             this.clusterManifestName = $manifest.getAttribute("Name");
         }
+
+        public isNetworkInventoryManagerEnabled(): boolean {
+            let $xml = $($.parseXML(this.raw.Manifest));
+            let $nim = $xml.find("Section[Name=NetworkInventoryManager]");
+            if ($nim.length !== 0) {
+            return $nim.find("Parameter").attr("Value") === "true";
+            }
+            return false;
+        }
     }
 
     export class ClusterUpgradeProgress extends DataModelBase<IRawClusterUpgradeProgress> {

--- a/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
@@ -49,6 +49,7 @@ module Sfx {
 
     export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
         public clusterManifestName: string;
+        private _isNetworkInventoryManagerEnabled: boolean = false;
 
         public constructor(data: DataService) {
             super(data);
@@ -62,15 +63,14 @@ module Sfx {
             let $xml = $($.parseXML(this.raw.Manifest));
             let $manifest = $xml.find("ClusterManifest")[0];
             this.clusterManifestName = $manifest.getAttribute("Name");
-        }
-
-        public isNetworkInventoryManagerEnabled(): boolean {
-            let $xml = $($.parseXML(this.raw.Manifest));
             let $nim = $xml.find("Section[Name=NetworkInventoryManager]");
             if ($nim.length !== 0) {
-            return $nim.find("Parameter").attr("Value") === "true";
+                this._isNetworkInventoryManagerEnabled = $nim.find("Parameter").attr("Value") === "true";
             }
-            return false;
+        }
+
+        public get isNetworkInventoryManagerEnabled(): boolean {
+            return this._isNetworkInventoryManagerEnabled;
         }
     }
 

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -348,7 +348,6 @@ module Sfx {
         protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
             let collection = [];
             return this.data.restClient.getAppsOnNetwork(this.networkName, messageHandler).then(items => {
-                console.log("AppOnNetworkCollection retreive new collwction");
                 let tasks = _.map(items, raw => {
                     let application = new AppOnNetwork(this.data, raw);
                     return application.refresh().then(() => collection.push(application));

--- a/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class DeployedContainerOnNetwork extends DataModelBase<IRawDeployedContainerOnNetwork> {
+
+        public nodeName: string;
+        public constructor(data: DataService, nodeName: string, raw?: IRawDeployedContainerOnNetwork) {
+            super(data, raw);
+            this.nodeName = nodeName;
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getCodePackageViewPath(
+                this.nodeName,
+                IdUtils.nameToId(this.raw.ApplicationName),
+                 this.raw.ServiceManifestName,
+                 this.raw.ServicePackageActivationId,
+                 this.raw.CodePackageName
+                 );
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/Network.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Network.ts
@@ -1,0 +1,70 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class Network extends DataModelBase<IRawNetwork> {
+
+        public constructor(data: DataService, raw?: IRawNetwork) {
+            super(data, raw);
+            if (this.data.actionsEnabled()) {
+                this.setUpActions();
+            }
+        }
+
+        public get name(): string {
+            return this.raw.name;
+        }
+
+        public get type(): string {
+            return this.raw.properties.kind;
+        }
+
+        public get addressPrefix(): string {
+            return this.raw.properties.networkAddressPrefix;
+        }
+
+        public get status(): string {
+            return this.raw.properties.networkStatus;
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.name);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetwork> {
+            return this.data.restClient.getNetwork(this.name, messageHandler).then(response => {
+                return response.data;
+            });
+
+        }
+
+        private setUpActions(): void {
+            this.actions.add(new ActionWithConfirmationDialog(
+                this.data.$uibModal,
+                this.data.$q,
+                "deleteNetwork",
+                "Delete",
+                "Deleting",
+                () => this.delete(),
+                () => this.raw.properties.networkStatus === "Ready",
+                "Confirm Network Deletion",
+                `Delete network '${this.name}' from cluster? `,
+                this.name
+            ));
+        }
+
+        private delete(): angular.IPromise<any> {
+            return this.data.restClient.deleteNetwork(this.name);
+        }
+    }
+
+    export class NetworkProperties extends DataModelBase<IRawNetworkProperties> {
+        public constructor(data: DataService, raw: IRawNetworkProperties) {
+            super(data, raw);
+
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class NetworkOnApp extends DataModelBase<IRawNetworkOnApp> {
+
+        public networkDetail: Network;
+
+        public constructor(data: DataService, raw?: IRawNetworkOnApp) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNetwork(this.raw.networkName, messageHandler).then(items => {
+                this.networkDetail = new Network(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.raw.networkName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
@@ -1,0 +1,22 @@
+module Sfx {
+
+    export class NetworkOnNode extends DataModelBase<IRawNetworkOnNode> {
+
+        public networkDetail: Network;
+
+        public constructor(data: DataService, raw?: IRawNetworkOnNode) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNetwork(this.raw.NetworkName, messageHandler).then(items => {
+                this.networkDetail = new Network(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.raw.NetworkName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class NodeOnNetwork extends DataModelBase<IRawNodeOnNetwork> {
+
+        nodeDetails: Node;
+
+        public constructor(data: DataService, raw?: IRawNodeOnNetwork) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNode(this.raw.nodeName, messageHandler).then(items => {
+                this.nodeDetails = new Node(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNodeViewPath(this.raw.nodeName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/RawDataTypes.ts
+++ b/src/Sfx/App/Scripts/Models/RawDataTypes.ts
@@ -208,6 +208,44 @@ module Sfx {
         Id: string;
     }
 
+    export interface IRawNetwork {
+        name: string;
+        properties: IRawNetworkProperties;
+    }
+
+    export interface IRawNetworkProperties {
+        kind: string;
+        networkAddressPrefix: string;
+        networkStatus: string;
+    }
+
+    export interface IRawNetworkOnApp {
+        networkName: string;
+    }
+
+    export interface IRawNetworkOnNode {
+        NetworkName: string;
+    }
+
+    export interface IRawAppOnNetwork {
+        ApplicationName: string;
+    }
+
+    export interface IRawNodeOnNetwork {
+        nodeName: string;
+    }
+
+    export interface IRawDeployedContainerOnNetwork {
+        ApplicationName: string;
+        NetworkName: string;
+        CodePackageName: string;
+        CodePackageVersion: string;
+        ServiceManifestName: string;
+        ServicePackageActivationId: string;
+        ContainerAddress: string;
+        ContainerId: string;
+    }
+
     export interface IRawNode {
         Name: string;
         IpAddressOrFQDN: string;

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -121,7 +121,7 @@ module Sfx {
 
             return cmPromise.then( () => {
                 //check to see if network inventory manager is enabled and if SFX should display Network information
-                if (cm.isNetworkInventoryManagerEnabled()) {
+                if (cm.isNetworkInventoryManagerEnabled) {
                     let networkNode;
                     let getNetworkPromise = this.data.getNetworks(true).then(net => {
                         networkNode = {

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -8,6 +8,7 @@ module Sfx {
     export class ClusterTreeService {
         public tree: TreeViewModel;
         private clusterHealth: ClusterHealth;
+        private cm: ClusterManifest;
 
         constructor(
             private $q: angular.IQService,
@@ -20,6 +21,7 @@ module Sfx {
         public init() {
             this.clusterHealth = new ClusterHealth(this.data, HealthStateFilterFlags.None, HealthStateFilterFlags.None, HealthStateFilterFlags.None);
             this.tree = new TreeViewModel(this.$q, () => this.getRootNode());
+            this.cm = new ClusterManifest(this.data);
         }
 
         public selectTreeNode(path: string[], skipSelectAction?: boolean): ng.IPromise<any> {
@@ -70,8 +72,8 @@ module Sfx {
         }
 
         private getGroupNodes(): angular.IPromise<ITreeNode[]> {
-            let cm: ClusterManifest = new ClusterManifest(this.data);
-            let cmPromise = cm.ensureInitialized(false);
+            //let cm: ClusterManifest = new ClusterManifest(this.data);
+            let cmPromise = this.cm.ensureInitialized(false);
 
             let appsNode;
             let getAppsPromise = this.data.getApps().then(apps => {
@@ -121,7 +123,7 @@ module Sfx {
 
             return cmPromise.then( () => {
                 //check to see if network inventory manager is enabled and if SFX should display Network information
-                if (cm.isNetworkInventoryManagerEnabled) {
+                if (this.cm.isNetworkInventoryManagerEnabled) {
                     let networkNode;
                     let getNetworkPromise = this.data.getNetworks(true).then(net => {
                         networkNode = {

--- a/src/Sfx/App/Scripts/Services/DataService.ts
+++ b/src/Sfx/App/Scripts/Services/DataService.ts
@@ -13,6 +13,7 @@ module Sfx {
         public appTypeGroups: ApplicationTypeGroupCollection;
         public apps: ApplicationCollection;
         public nodes: NodeCollection;
+        public networks: NetworkCollection;
 
         public restClient: RestClient;
 
@@ -36,6 +37,7 @@ module Sfx {
             this.appTypeGroups = new ApplicationTypeGroupCollection(this);
             this.apps = new ApplicationCollection(this);
             this.nodes = new NodeCollection(this);
+            this.networks = new NetworkCollection(this);
 
             this.restClient = new RestClient($http, message);
         }
@@ -118,6 +120,16 @@ module Sfx {
             return this.getNodes(false, messageHandler).then(collection => {
                 return this.tryGetValidItem(collection, name, forceRefresh, messageHandler);
             });
+        }
+
+        public getNetwork(networkName: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<Network> {
+            return this.getNetworks(false, messageHandler).then(collection => {
+                return this.tryGetValidItem(collection, networkName, forceRefresh, messageHandler);
+            });
+        }
+
+        public getNetworks(forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<NetworkCollection> {
+            return this.networks.ensureInitialized(forceRefresh, messageHandler);
         }
 
         public getAppTypeGroups(forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<ApplicationTypeGroupCollection> {

--- a/src/Sfx/App/Scripts/Services/RoutesService.ts
+++ b/src/Sfx/App/Scripts/Services/RoutesService.ts
@@ -57,6 +57,14 @@ module Sfx {
             return "#/node/" + this.doubleEncode(nodeName);
         }
 
+        public getNetworksViewPath(): string {
+            return "#/networks";
+        }
+
+        public getNetworkViewPath(networkName: string): string {
+            return "#/network/" + this.doubleEncode(networkName);
+        }
+
         public getDeployedAppViewPath(nodeName: string, appId: string): string {
             return "#/node/" + this.doubleEncode(nodeName) + "/deployedapp/" + this.doubleEncode(appId);
         }
@@ -189,6 +197,16 @@ module Sfx {
                 templateUrl: "partials/deployed-app.html",
                 controller: "DeployedAppViewController",
                 controllerAs: "deployedAppCtrl"
+            });
+            whenWithTabs($routeProvider, "/networks", {
+                templateUrl: "partials/networks.html",
+                controller: "NetworksViewController",
+                controllerAs: "networksCtrl"
+            });
+            whenWithTabs($routeProvider, "/network/:networkName", {
+                templateUrl: "partials/network.html",
+                controller: "NetworkViewController",
+                controllerAs: "networkCtrl"
             });
             whenWithTabs($routeProvider,
                 [

--- a/src/Sfx/App/Scripts/Utils/IdGenerator.ts
+++ b/src/Sfx/App/Scripts/Utils/IdGenerator.ts
@@ -22,6 +22,14 @@ module Sfx {
             return "<node group>";
         }
 
+        public static networkGroup(): string {
+            return "<network group>";
+        }
+
+        public static network(networkName: string): string {
+            return networkName;
+        }
+
         public static node(nodeName: string): string {
             return nodeName;
         }

--- a/src/Sfx/App/Scripts/Utils/IdUtils.ts
+++ b/src/Sfx/App/Scripts/Utils/IdUtils.ts
@@ -42,6 +42,10 @@ module Sfx {
             return decodeURIComponent(routeParams.nodeName);
         }
 
+        public static getNetworkName(routeParams: any): string {
+            return decodeURIComponent(routeParams.networkName);
+        }
+
         public static idToName(id: string): string {
             return Constants.FabricPrefix + id;
         }

--- a/src/Sfx/App/partials/app.html
+++ b/src/Sfx/App/partials/app.html
@@ -90,7 +90,7 @@
             <sfx-detail-list list="app.serviceTypes" list-settings="serviceTypesListSettings"></sfx-detail-list>
         </div>
 
-        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled()">
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled">
             <h4>Networks</h4>
             <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
         </div>

--- a/src/Sfx/App/partials/app.html
+++ b/src/Sfx/App/partials/app.html
@@ -90,7 +90,7 @@
             <sfx-detail-list list="app.serviceTypes" list-settings="serviceTypesListSettings"></sfx-detail-list>
         </div>
 
-        <div class="detail-pane">
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled()">
             <h4>Networks</h4>
             <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
         </div>

--- a/src/Sfx/App/partials/app.html
+++ b/src/Sfx/App/partials/app.html
@@ -89,6 +89,11 @@
             <h4>Service Types</h4>
             <sfx-detail-list list="app.serviceTypes" list-settings="serviceTypesListSettings"></sfx-detail-list>
         </div>
+
+        <div class="detail-pane">
+            <h4>Networks</h4>
+            <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
+        </div>
     </script>
 
     <!-- Details tab -->

--- a/src/Sfx/App/partials/create-network-dialog.html
+++ b/src/Sfx/App/partials/create-network-dialog.html
@@ -1,0 +1,21 @@
+<form name="createIsolatedNetworkForm">
+    <div class="modal-header">
+        <h4 class="modal-title">Create Isolated Network</h4>
+    </div>
+    <div class="modal-body">
+        <dl class="dl-horizontal">
+            <dt>Network name</dt>
+            <dd>
+                <input type="text" class="input-flat" ng-model="action.networkName" required>
+            </dd>
+            <dt>Network Address Prefix</dt>
+            <dd>
+                <input type="text" class="input-flat" ng-model="action.networkAddressPrefix" required>
+            </dd>
+        </dl>
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="btn btn-primary" data-dismiss="modal"  ng-click="ok()">{{::action.title}}</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
+    </div>
+</form>

--- a/src/Sfx/App/partials/network.html
+++ b/src/Sfx/App/partials/network.html
@@ -1,0 +1,51 @@
+<sfx-detail-view-navbar ctrl="networkCtrl" actions="network.actions" type="Network" name="{{network.name}}"></sfx-detail-view-navbar>
+
+<section class="main-view">
+    <div sfx-include src="'tab_' + networkCtrl.activeTabId" ng-if="networkCtrl.activeTabId"></div>
+
+    <script type="text/ng-template" id="tab_essentials">
+        <div class="detail-pane essen-pane">
+            <div class="table-responsive">
+                <table class="essen-table">
+                    <tr>
+                        <th>Network Name</th>
+                        <th>Network type</th>
+                    </tr>
+                    <tr>
+                        <td>{{network.name}}</td>
+                        <td>{{network.type}}</td>
+                    </tr>
+                    <tr>
+                        <th>Network Address Prefix</th>
+                        <th>Network Status</th>
+                    </tr>
+
+                    <tr>
+                        <td>{{network.addressPrefix}}</td>
+                        <td>{{network.status}}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="detail-pane">
+            <h4>Deployed Applications</h4>
+            <sfx-detail-list list="apps" list-settings="appListSettings"></sfx-detail-list>
+        </div>
+        <div class="detail-pane">
+            <h4>Attached Nodes</h4>
+            <sfx-detail-list list="nodes" list-settings="nodeListSettings"></sfx-detail-list>
+        </div>
+        <div class="detail-pane">
+            <h4>Containers</h4>
+            <sfx-detail-list list="containers" list-settings="containerListSettings"></sfx-detail-list>
+        </div>
+    </script>
+    <script type="text/ng-template" id="tab_details">
+        <div class="detail-pane">
+            <sfx-detail-view-part data="network"></sfx-detail-view-part>
+        </div>
+    </script>
+
+
+    
+</section>

--- a/src/Sfx/App/partials/networks.html
+++ b/src/Sfx/App/partials/networks.html
@@ -1,0 +1,7 @@
+<sfx-detail-view-navbar ctrl="networksCtrl" type="Networks" actions="actions"></sfx-detail-view-navbar>
+
+<div class="main-view">
+    <div class="detail-pane">
+        <sfx-detail-list list="networks" list-settings="listSettings"></sfx-detail-list>
+    </div>
+</div>

--- a/src/Sfx/App/partials/node.html
+++ b/src/Sfx/App/partials/node.html
@@ -53,6 +53,10 @@
             <h4>Deployed Applications</h4>
             <sfx-detail-list list="deployedApps" list-settings="listSettings"></sfx-detail-list>
         </div>
+        <div class="detail-pane">
+            <h4>Networks</h4>
+            <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
+        </div>
     </script>
 
     <script type="text/ng-template" id="tab_details">

--- a/src/Sfx/App/partials/node.html
+++ b/src/Sfx/App/partials/node.html
@@ -53,7 +53,7 @@
             <h4>Deployed Applications</h4>
             <sfx-detail-list list="deployedApps" list-settings="listSettings"></sfx-detail-list>
         </div>
-        <div class="detail-pane">
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled()">
             <h4>Networks</h4>
             <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
         </div>

--- a/src/Sfx/App/partials/node.html
+++ b/src/Sfx/App/partials/node.html
@@ -53,7 +53,7 @@
             <h4>Deployed Applications</h4>
             <sfx-detail-list list="deployedApps" list-settings="listSettings"></sfx-detail-list>
         </div>
-        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled()">
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled">
             <h4>Networks</h4>
             <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
         </div>

--- a/src/Sfx/appsettings.json
+++ b/src/Sfx/appsettings.json
@@ -1,5 +1,5 @@
 {
   "TargetCluster": {
-    "Url": "http://localhost:19080"
+    "Url": "http://syzaitest1810181843.westus.cloudapp.azure.com:19080"
   }
 }


### PR DESCRIPTION
Adding information for the networks on a cluster.
- Added two view pages for Network and Networks
- Added additional information on Node and Application pages.
Following are the REST Api's that I used for the data
Create a network 
Invoke-WebRequest -Method Put -Uri http://HostName:Port/Resources/Networks/testNetwork2?api-version=6.0 -Body $body 
  
With $body being: 
{ 
"name": "testNetwork2", 
"properties": { 
"networkType": "Local", 
"networkAddressPrefix": "10.0.0.4/22" 
} 
} 
 
 
Delete a network with specific name 
Invoke-WebRequest -Method Delete -Uri http://HostName:Port/Resources/Networks/testNetwork2?api-version=6.0 
 
Get all networks 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks?api-version=6.0 
  
Get a network with specific name  
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork3?api-version=6.0 
 
Get all applications that are members of a network 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork2/ApplicationRefs?api-version=6.0 
 
Get all nodes a network is deployed to 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork2/DeployedNodes?api-version=6.0 
 
Get all networks an application is member of 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Applications/samples~CalculatorApp/$/GetNetworks?api-version=6.0 
 
Get all networks deployed to a node 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Nodes/vm1/$/GetNetworks?api-version=6.0 
 
Get all containers deployed in a network on a node 
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Nodes/vm1/$/GetNetworks/TestNetwork/$/GetCodePackages?api-version=6.0 