### PR TITLE
Fix the aad token renew bug.

### DIFF
--- a/src/Sfx-Standalone/modules/http/response-handlers/auth.aad.sf.ts
+++ b/src/Sfx-Standalone/modules/http/response-handlers/auth.aad.sf.ts
@@ -62,27 +62,24 @@ export default function createResponseHandler(): HttpResponseHandler {
         if (response.statusCode !== 401 && response.statusCode !== 403) {
             return undefined;
         }
-    
+
         const siteId = url.parse(request.url).host;
-    
-        if (!request.headers.find((header) => header.name === "Authorization")) {
-            const record = siteMap[siteId];
-    
-            if (record instanceof Promise) {
-                return record.then(() => pipeline.requestAsync(request));
-    
-            } else if (record === "Retry") {
-                return pipeline.requestAsync(request);
-                
-            } else if (record === "NotSupported") {
-                return undefined;
-            }
+        const record = siteMap[siteId];
+
+        if (record instanceof Promise) {
+            return record.then(() => pipeline.requestAsync(request));
+
+        } else if (record === "Retry") {
+            return pipeline.requestAsync(request);
+
+        } else if (record === "NotSupported") {
+            return undefined;
         }
-    
+
         const tokenPromise = siteMap[siteId] = acquireTokenAsync(pipeline, request, response);
-    
+
         tokenPromise.then((response) => siteMap[siteId] = response ? "Retry" : "NotSupported");
-    
+
         return tokenPromise;
     };
 }


### PR DESCRIPTION
* Fix there are too many Authorization headers when renewing the token.
* Remove the header check in sf aad handler as the aad handler will do it automatically.