### PR TITLE
Adding networks information to SFX

### DIFF
--- a/src/Sfx/App/Scripts/App.ts
+++ b/src/Sfx/App/Scripts/App.ts
@@ -28,6 +28,8 @@ module Sfx {
             "clusterViewController",
             "nodeViewController",
             "nodesViewController",
+            "networksViewController",
+            "networkViewController",
             "appTypeViewController",
             "appsViewController",
             "appViewController",

--- a/src/Sfx/App/Scripts/Common/ResponseMessageHandlers.ts
+++ b/src/Sfx/App/Scripts/Common/ResponseMessageHandlers.ts
@@ -44,6 +44,26 @@ module Sfx {
         }
     }
 
+    export class PutResponseMessageHandler extends GetResponseMessageHandler {
+        public getSuccessMessage(apiDesc: string, response: ng.IHttpPromiseCallbackArg<any>): string {
+            return `${apiDesc}`;
+        }
+
+        public getErrorMessage(apiDesc: string, response: ng.IHttpPromiseCallbackArg<any>): string {
+            return this.getErrorMessageInternal(apiDesc, response);
+        }
+    }
+
+    export class DeleteResponseMessageHandler extends GetResponseMessageHandler {
+        public getSuccessMessage(apiDesc: string, response: ng.IHttpPromiseCallbackArg<any>): string {
+            return `${apiDesc}`;
+        }
+
+        public getErrorMessage(apiDesc: string, response: ng.IHttpPromiseCallbackArg<any>): string {
+            return this.getErrorMessageInternal(apiDesc, response);
+        }
+    }
+
     export class SilentResponseMessageHandler implements IResponseMessageHandler {
         public getSuccessMessage(apiDesc: string, response: ng.IHttpPromiseCallbackArg<any>): string {
             return null;
@@ -57,8 +77,9 @@ module Sfx {
     export class ResponseMessageHandlers {
         public static getResponseMessageHandler: IResponseMessageHandler = new GetResponseMessageHandler();
         public static postResponseMessageHandler: IResponseMessageHandler = new PostResponseMessageHandler();
-        public static putResponseMessageHandler: IResponseMessageHandler = new PostResponseMessageHandler();
+        public static putResponseMessageHandler: IResponseMessageHandler = new PutResponseMessageHandler();
         public static silentResponseMessageHandler: IResponseMessageHandler = new SilentResponseMessageHandler();
+        public static deleteResponseMessageHandler: IResponseMessageHandler = new DeleteResponseMessageHandler();
     }
 
     export class EventsStoreResponseMessageHandler implements IResponseMessageHandler {

--- a/src/Sfx/App/Scripts/Controllers/AppViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/AppViewController.ts
@@ -16,6 +16,9 @@ module Sfx {
         serviceTypesListSettings: ListSettings;
         deployedApplicationsHealthStates: DeployedApplicationHealthState[];
         appEvents: ApplicationEventList;
+        networks: NetworkOnAppCollection;
+        networkListSettings: ListSettings;
+        clusterManifest: ClusterManifest;
     }
 
     export class AppViewController extends MainViewController {
@@ -70,25 +73,36 @@ module Sfx {
             this.$scope.upgradeProgressUnhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings("upgradeProgressUnhealthyEvaluations");
             this.$scope.appEvents = this.data.createApplicationEventList(this.appId);
 
+            this.$scope.networkListSettings = this.settings.getNewOrExistingListSettings("networks", ["networkDetail.name"], [
+                new ListColumnSettingForLink("networkDetail.name", "Network Name", item => item.viewPath),
+                new ListColumnSetting("networkDetail.type", "Network Type"),
+                new ListColumnSetting("networkDetail.addressPrefix", "Network Address Prefix"),
+                new ListColumnSetting("networkDetail.status", "Network Status"),
+            ]);
+            this.$scope.clusterManifest = new ClusterManifest(this.data);
+            this.$scope.networks = new  NetworkOnAppCollection(this.data, this.appId);
             this.refresh();
         }
 
         protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
-            return this.data.getApp(this.appId, true, messageHandler).then(data => {
-                this.$scope.app = data;
+            return this.$q.all([
+                this.data.getApp(this.appId, true, messageHandler).then(data => {
+                    this.$scope.app = data;
 
-                return this.$scope.app.health.refresh(messageHandler).then(() => {
-                    this.$scope.deployedApplicationsHealthStates = this.$scope.app.health.deployedApplicationHealthStates;
+                    return this.$scope.app.health.refresh(messageHandler).then(() => {
+                        this.$scope.deployedApplicationsHealthStates = this.$scope.app.health.deployedApplicationHealthStates;
 
-                    if (this.$scope.app.health.deploymentsHealthState.text !== HealthStateConstants.OK) {
-                        this.tabs["deployments"].superscriptInHtml = () => {
-                            return `<image class="tab-superscript-badge" src="images/${this.$scope.app.health.deploymentsHealthState.badgeClass}.svg"></image>`;
-                        };
-                    } else {
-                        this.tabs["deployments"].superscriptInHtml = null;
-                    }
-                });
-            });
+                        if (this.$scope.app.health.deploymentsHealthState.text !== HealthStateConstants.OK) {
+                            this.tabs["deployments"].superscriptInHtml = () => {
+                                return `<image class="tab-superscript-badge" src="images/${this.$scope.app.health.deploymentsHealthState.badgeClass}.svg"></image>`;
+                            };
+                        } else {
+                            this.tabs["deployments"].superscriptInHtml = null;
+                        }
+                    });
+                }),
+                this.$scope.clusterManifest.ensureInitialized(false)
+            ]);
         }
 
         private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
@@ -99,7 +113,9 @@ module Sfx {
                     })
                     : this.$q.when(true),
                 this.$scope.app.serviceTypes.refresh(messageHandler),
-                this.$scope.app.services.refresh(messageHandler)]);
+                this.$scope.app.services.refresh(messageHandler),
+                this.$scope.clusterManifest.isNetworkInventoryManagerEnabled ? this.$scope.networks.refresh(messageHandler) : this.$q.when(true)
+                ]);
         }
 
         private refreshManifest(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -1,0 +1,92 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export interface INetworkViewScope extends angular.IScope {
+        network: Network;
+        listSettings: ListSettings;
+        apps: AppOnNetworkCollection;
+        appListSettings: ListSettings;
+        nodes: NodeOnNetworkCollection;
+        nodeListSettings: ListSettings;
+        containers: DeployedContainerOnNetworkCollection;
+        containerListSettings: ListSettings;
+    }
+
+    export class NetworkViewController extends MainViewController {
+        public networkName: string;
+
+        constructor($injector: angular.auto.IInjectorService, public $scope: INetworkViewScope) {
+            super($injector, {
+                "essentials": { name: "Essentials" },
+                "details": { name: "Details" }
+            });
+            this.tabs["essentials"].refresh = (messageHandler) => this.refreshEssentials(messageHandler);
+            this.tabs["details"].refresh = (messageHandler) => this.refreshCommon(messageHandler);
+            this.networkName = IdUtils.getNetworkName(this.routeParams);
+
+            this.selectTreeNode([
+                IdGenerator.cluster(),
+                IdGenerator.networkGroup(),
+                IdGenerator.network(this.networkName)
+            ]);
+            this.$scope.appListSettings = this.settings.getNewOrExistingListSettings("apps", ["appDetail.raw.Name"], [
+                new ListColumnSettingForLink("appDetail.raw.Name", "Application Name", item => item.viewPath),
+                new ListColumnSetting("appDetail.raw.TypeName", "Application Type"),
+                new ListColumnSettingForBadge("appDetail.healthState", "Health State"),
+                new ListColumnSetting("appDetail.raw.Status", "Status"),
+            ]);
+            this.$scope.apps = new AppOnNetworkCollection(this.data, this.networkName);
+            this.$scope.nodeListSettings = this.settings.getNewOrExistingListSettings("nodes", ["nodeDetails.name"], [
+                new ListColumnSettingForLink("nodeDetails.name", "Name", item => item.viewPath),
+                new ListColumnSetting("nodeDetails.raw.IpAddressOrFQDN", "Address"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.Type", "Node Type"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.UpgradeDomain", "Upgrade Domain"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.FaultDomain", "Fault Domain"),
+                new ListColumnSettingWithFilter("nodeDetails.raw.IsSeedNode", "Is Seed Node"),
+                new ListColumnSettingForBadge("nodeDetails.healthState", "Health State"),
+                new ListColumnSettingWithFilter("nodeDetails.nodeStatus", "Status"),
+            ]);
+            this.$scope.nodes = new NodeOnNetworkCollection(this.data, this.networkName);
+            this.$scope.containerListSettings = this.settings.getNewOrExistingListSettings("containers", ["nodeName", "raw.CodePackageName"], [
+                new ListColumnSettingForLink("raw.CodePackageName", "Code Package Name", item => item.viewPath),
+                new ListColumnSetting("nodeName", "Node Name"),
+                new ListColumnSetting("raw.NetworkName", "Network"),
+                new ListColumnSetting("raw.ApplicationName", "Application"),
+                new ListColumnSetting("raw.CodePackageVersion", "Version"),
+                new ListColumnSetting("raw.ServiceManifestName", "Service"),
+                new ListColumnSetting("raw.ServicePackageActivationId", "Activation Id"),
+                new ListColumnSetting("raw.ContainerAddress", "Container addresses"),
+                new ListColumnSetting("raw.ContainerId", "Container Id")
+
+            ]);
+            this.$scope.containers = new DeployedContainerOnNetworkCollection(this.data, this.networkName);
+            this.refresh();
+        }
+
+        protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.getNetwork(this.networkName, true, messageHandler)
+                .then(network => {
+                    this.$scope.network = network;
+                });
+        }
+
+        private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+
+            return this.$q.all([
+                this.$scope.apps.refresh(messageHandler),
+                this.$scope.nodes.refresh(messageHandler),
+                this.$scope.containers.refresh(messageHandler)
+            ]);
+        }
+    }
+
+    (function () {
+
+        let module = angular.module("networkViewController", ["ngRoute", "dataService"]);
+        module.controller("NetworkViewController", ["$injector", "$scope", NetworkViewController]);
+
+    })();
+}

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -20,11 +20,9 @@ module Sfx {
 
         constructor($injector: angular.auto.IInjectorService, public $scope: INetworkViewScope) {
             super($injector, {
-                "essentials": { name: "Essentials" },
-                "details": { name: "Details" }
+                "essentials": { name: "Essentials" }
             });
             this.tabs["essentials"].refresh = (messageHandler) => this.refreshEssentials(messageHandler);
-            this.tabs["details"].refresh = (messageHandler) => this.refreshCommon(messageHandler);
             this.networkName = IdUtils.getNetworkName(this.routeParams);
 
             this.selectTreeNode([

--- a/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworkViewController.ts
@@ -74,7 +74,6 @@ module Sfx {
         }
 
         private refreshEssentials(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
-
             return this.$q.all([
                 this.$scope.apps.refresh(messageHandler),
                 this.$scope.nodes.refresh(messageHandler),

--- a/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
@@ -44,9 +44,7 @@ module Sfx {
         }
     };
     export class ActionCreateIsolatedNetwork extends ActionWithDialog {
-
         public networkName: string;
-
         public networkAddressPrefix: string;
 
         constructor(data: DataService) {
@@ -75,7 +73,6 @@ module Sfx {
             this.networkName = "";
             this.networkAddressPrefix = "";
         }
-
     };
 
     (function () {

--- a/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/NetworksViewController.ts
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export interface INetworksViewScope extends angular.IScope {
+        networks: NetworkCollection;
+        listSettings: ListSettings;
+        actions: ActionCollection;
+    }
+
+    export class NetworksViewController extends MainViewController {
+        constructor($injector: angular.auto.IInjectorService, public $scope: INetworksViewScope) {
+            super($injector);
+
+            this.selectTreeNode([
+                IdGenerator.cluster(),
+                IdGenerator.networkGroup()
+            ]);
+            this.$scope.listSettings = this.settings.getNewOrExistingListSettings("networks", ["name"], [
+                new ListColumnSettingForLink("name", "Name", item => item.viewPath),
+                new ListColumnSetting("type", "Type"),
+                new ListColumnSetting("addressPrefix", "NetworkAddressPrefix"),
+                new ListColumnSetting("status", "NetworkStatus")
+
+            ]);
+            this.$scope.actions = new ActionCollection(this.data.telemetry, this.$q);
+            if (this.data.actionsEnabled) {
+                this.addActions(this.$scope.actions);
+            }
+            this.refresh();
+        }
+
+        protected refreshCommon(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.getNetworks(true, messageHandler)
+                .then(networks => {
+                    this.$scope.networks = networks;
+                });
+        }
+
+        private addActions(actions: ActionCollection) {
+            actions.add(new ActionCreateIsolatedNetwork(this.data));
+        }
+    };
+    export class ActionCreateIsolatedNetwork extends ActionWithDialog {
+
+        public networkName: string;
+
+        public networkAddressPrefix: string;
+
+        constructor(data: DataService) {
+
+            super(
+                data.$uibModal,
+                data.$q,
+                "createIsolatednetwork",
+                "Create Isolated Network",
+                "Creating",
+                () => data.restClient.createNetwork(this.networkName, this.networkAddressPrefix),
+                () => true,
+                <angular.ui.bootstrap.IModalSettings>{
+                    templateUrl: "partials/create-network-dialog.html",
+                    controller: ActionController,
+                    resolve: {
+                        action: () => this
+                    }
+                },
+                null);
+
+            this.reset();
+        }
+
+        private reset(): void {
+            this.networkName = "";
+            this.networkAddressPrefix = "";
+        }
+
+    };
+
+    (function () {
+
+        let module = angular.module("networksViewController", []);
+        module.controller("NetworksViewController", ["$injector", "$scope", NetworksViewController]);
+
+    })();
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
@@ -1,0 +1,27 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class AppOnNetwork extends DataModelBase<IRawAppOnNetwork> {
+
+        public appDetail: Application;
+
+        public constructor(data: DataService, raw?: IRawAppOnNetwork) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getApplication(IdUtils.nameToId(this.raw.ApplicationName), messageHandler).then(items => {
+                this.appDetail = new Application(this.data, items.data);
+                return this.appDetail.refresh().then(() => this.appDetail);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getAppViewPath(this.appDetail.raw.TypeName, this.appDetail.raw.Id);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/AppOnNetwork.ts
@@ -5,7 +5,6 @@
 module Sfx {
 
     export class AppOnNetwork extends DataModelBase<IRawAppOnNetwork> {
-
         public appDetail: Application;
 
         public constructor(data: DataService, raw?: IRawAppOnNetwork) {

--- a/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
@@ -49,6 +49,7 @@ module Sfx {
 
     export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
         public clusterManifestName: string;
+        private _isNetworkInventoryManagerEnabled: boolean = false;
 
         public constructor(data: DataService) {
             super(data);
@@ -62,6 +63,14 @@ module Sfx {
             let $xml = $($.parseXML(this.raw.Manifest));
             let $manifest = $xml.find("ClusterManifest")[0];
             this.clusterManifestName = $manifest.getAttribute("Name");
+            let $nim = $xml.find("Section[Name=NetworkInventoryManager]");
+            if ($nim.length !== 0) {
+                this._isNetworkInventoryManagerEnabled = $nim.find("Parameter").attr("Value") === "true";
+            }
+        }
+
+        public get isNetworkInventoryManagerEnabled(): boolean {
+            return this._isNetworkInventoryManagerEnabled;
         }
     }
 

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -338,7 +338,7 @@ module Sfx {
             });
         }
     }
-    
+
     export class AppOnNetworkCollection extends DataModelCollectionBase<AppOnNetwork> {
         networkName: string;
         public constructor(data: DataService, networkName: string) {

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -338,6 +338,7 @@ module Sfx {
             });
         }
     }
+    
     export class AppOnNetworkCollection extends DataModelCollectionBase<AppOnNetwork> {
         networkName: string;
         public constructor(data: DataService, networkName: string) {

--- a/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class DeployedContainerOnNetwork extends DataModelBase<IRawDeployedContainerOnNetwork> {
+
+        public nodeName: string;
+        public constructor(data: DataService, nodeName: string, raw?: IRawDeployedContainerOnNetwork) {
+            super(data, raw);
+            this.nodeName = nodeName;
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getCodePackageViewPath(
+                this.nodeName,
+                IdUtils.nameToId(this.raw.ApplicationName),
+                 this.raw.ServiceManifestName,
+                 this.raw.ServicePackageActivationId,
+                 this.raw.CodePackageName
+                 );
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/DeployedContainerOnNetwork.ts
@@ -5,8 +5,8 @@
 module Sfx {
 
     export class DeployedContainerOnNetwork extends DataModelBase<IRawDeployedContainerOnNetwork> {
-
         public nodeName: string;
+
         public constructor(data: DataService, nodeName: string, raw?: IRawDeployedContainerOnNetwork) {
             super(data, raw);
             this.nodeName = nodeName;
@@ -22,5 +22,4 @@ module Sfx {
                  );
         }
     }
-
 }

--- a/src/Sfx/App/Scripts/Models/DataModels/Network.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Network.ts
@@ -1,0 +1,70 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class Network extends DataModelBase<IRawNetwork> {
+
+        public constructor(data: DataService, raw?: IRawNetwork) {
+            super(data, raw);
+            if (this.data.actionsEnabled()) {
+                this.setUpActions();
+            }
+        }
+
+        public get name(): string {
+            return this.raw.name;
+        }
+
+        public get type(): string {
+            return this.raw.properties.kind;
+        }
+
+        public get addressPrefix(): string {
+            return this.raw.properties.networkAddressPrefix;
+        }
+
+        public get status(): string {
+            return this.raw.properties.networkStatus;
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.name);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetwork> {
+            return this.data.restClient.getNetwork(this.name, messageHandler).then(response => {
+                return response.data;
+            });
+
+        }
+
+        private setUpActions(): void {
+            this.actions.add(new ActionWithConfirmationDialog(
+                this.data.$uibModal,
+                this.data.$q,
+                "deleteNetwork",
+                "Delete",
+                "Deleting",
+                () => this.delete(),
+                () => this.raw.properties.networkStatus === "Ready",
+                "Confirm Network Deletion",
+                `Delete network '${this.name}' from cluster? `,
+                this.name
+            ));
+        }
+
+        private delete(): angular.IPromise<any> {
+            return this.data.restClient.deleteNetwork(this.name);
+        }
+    }
+
+    export class NetworkProperties extends DataModelBase<IRawNetworkProperties> {
+        public constructor(data: DataService, raw: IRawNetworkProperties) {
+            super(data, raw);
+
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
@@ -5,7 +5,6 @@
 module Sfx {
 
     export class NetworkOnApp extends DataModelBase<IRawNetworkOnApp> {
-
         public networkDetail: Network;
 
         public constructor(data: DataService, raw?: IRawNetworkOnApp) {

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnApp.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class NetworkOnApp extends DataModelBase<IRawNetworkOnApp> {
+
+        public networkDetail: Network;
+
+        public constructor(data: DataService, raw?: IRawNetworkOnApp) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNetwork(this.raw.networkName, messageHandler).then(items => {
+                this.networkDetail = new Network(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.raw.networkName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
@@ -1,7 +1,6 @@
 module Sfx {
 
     export class NetworkOnNode extends DataModelBase<IRawNetworkOnNode> {
-
         public networkDetail: Network;
 
         public constructor(data: DataService, raw?: IRawNetworkOnNode) {

--- a/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NetworkOnNode.ts
@@ -1,0 +1,22 @@
+module Sfx {
+
+    export class NetworkOnNode extends DataModelBase<IRawNetworkOnNode> {
+
+        public networkDetail: Network;
+
+        public constructor(data: DataService, raw?: IRawNetworkOnNode) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNetwork(this.raw.NetworkName, messageHandler).then(items => {
+                this.networkDetail = new Network(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNetworkViewPath(this.raw.NetworkName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+module Sfx {
+
+    export class NodeOnNetwork extends DataModelBase<IRawNodeOnNetwork> {
+
+        nodeDetails: Node;
+
+        public constructor(data: DataService, raw?: IRawNodeOnNetwork) {
+            super(data, raw);
+        }
+
+        protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<any> {
+            return this.data.restClient.getNode(this.raw.nodeName, messageHandler).then(items => {
+                this.nodeDetails = new Node(this.data, items.data);
+            });
+        }
+
+        public get viewPath(): string {
+            return this.data.routes.getNodeViewPath(this.raw.nodeName);
+        }
+    }
+
+}

--- a/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/NodeOnNetwork.ts
@@ -5,7 +5,6 @@
 module Sfx {
 
     export class NodeOnNetwork extends DataModelBase<IRawNodeOnNetwork> {
-
         nodeDetails: Node;
 
         public constructor(data: DataService, raw?: IRawNodeOnNetwork) {

--- a/src/Sfx/App/Scripts/Models/RawDataTypes.ts
+++ b/src/Sfx/App/Scripts/Models/RawDataTypes.ts
@@ -208,6 +208,44 @@ module Sfx {
         Id: string;
     }
 
+    export interface IRawNetwork {
+        name: string;
+        properties: IRawNetworkProperties;
+    }
+
+    export interface IRawNetworkProperties {
+        kind: string;
+        networkAddressPrefix: string;
+        networkStatus: string;
+    }
+
+    export interface IRawNetworkOnApp {
+        networkName: string;
+    }
+
+    export interface IRawNetworkOnNode {
+        NetworkName: string;
+    }
+
+    export interface IRawAppOnNetwork {
+        ApplicationName: string;
+    }
+
+    export interface IRawNodeOnNetwork {
+        nodeName: string;
+    }
+
+    export interface IRawDeployedContainerOnNetwork {
+        ApplicationName: string;
+        NetworkName: string;
+        CodePackageName: string;
+        CodePackageVersion: string;
+        ServiceManifestName: string;
+        ServicePackageActivationId: string;
+        ContainerAddress: string;
+        ContainerId: string;
+    }
+
     export interface IRawNode {
         Name: string;
         IpAddressOrFQDN: string;

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -8,6 +8,7 @@ module Sfx {
     export class ClusterTreeService {
         public tree: TreeViewModel;
         private clusterHealth: ClusterHealth;
+        private cm: ClusterManifest;
 
         constructor(
             private $q: angular.IQService,
@@ -20,6 +21,7 @@ module Sfx {
         public init() {
             this.clusterHealth = new ClusterHealth(this.data, HealthStateFilterFlags.None, HealthStateFilterFlags.None, HealthStateFilterFlags.None);
             this.tree = new TreeViewModel(this.$q, () => this.getRootNode());
+            this.cm = new ClusterManifest(this.data);
         }
 
         public selectTreeNode(path: string[], skipSelectAction?: boolean): ng.IPromise<any> {
@@ -70,6 +72,9 @@ module Sfx {
         }
 
         private getGroupNodes(): angular.IPromise<ITreeNode[]> {
+            //let cm: ClusterManifest = new ClusterManifest(this.data);
+            let cmPromise = this.cm.ensureInitialized(false);
+
             let appsNode;
             let getAppsPromise = this.data.getApps().then(apps => {
                 appsNode = {
@@ -114,8 +119,28 @@ module Sfx {
                 };
             });
 
-            return this.$q.all([getAppsPromise, getNodesPromise, systemNodePromise]).then(() => {
-                return [appsNode, nodesNode, systemAppNode];
+
+
+            return cmPromise.then( () => {
+                //check to see if network inventory manager is enabled and if SFX should display Network information
+                if (this.cm.isNetworkInventoryManagerEnabled) {
+                    let networkNode;
+                    let getNetworkPromise = this.data.getNetworks(true).then(net => {
+                        networkNode = {
+                            nodeId: IdGenerator.networkGroup(),
+                            displayName: () => "Networks",
+                            childrenQuery: () => this.getNetworks(),
+                            selectAction: () => this.routes.navigate(() => net.viewPath),
+                            alwaysVisible: true
+                        };
+                    });
+                    return this.$q.all([getAppsPromise, getNodesPromise, getNetworkPromise, systemNodePromise]).then(() => {
+                        return [appsNode, nodesNode, networkNode, systemAppNode];
+                    });
+                }
+                return this.$q.all([getAppsPromise, getNodesPromise, systemNodePromise]).then(() => {
+                    return [appsNode, nodesNode, systemAppNode];
+                });
             });
         }
 
@@ -157,6 +182,22 @@ module Sfx {
                         mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => {
                             return node.deployedApps.mergeClusterHealthStateChunk(clusterHealthChunk);
                         }
+                    };
+                });
+            });
+        }
+
+        private getNetworks(): angular.IPromise<ITreeNode[]> {
+            // App type groups cannot be inferred from health chunk data, because we need all app types
+            // even there are currently no application instances for them.
+            return this.data.getNetworks(true).then(networks => {
+                return _.map(networks.collection, network => {
+                    return {
+
+                        nodeId: IdGenerator.network(network.name),
+                        displayName: () => network.name,
+                        selectAction: () => this.routes.navigate(() => network.viewPath),
+                        sortBy: () => [network.name]
                     };
                 });
             });

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -197,7 +197,8 @@ module Sfx {
                         nodeId: IdGenerator.network(network.name),
                         displayName: () => network.name,
                         selectAction: () => this.routes.navigate(() => network.viewPath),
-                        sortBy: () => [network.name]
+                        sortBy: () => [network.name],
+                        actions: network.actions
                     };
                 });
             });

--- a/src/Sfx/App/Scripts/Services/DataService.ts
+++ b/src/Sfx/App/Scripts/Services/DataService.ts
@@ -36,7 +36,6 @@ module Sfx {
             this.apps = new ApplicationCollection(this);
             this.nodes = new NodeCollection(this);
             this.networks = new NetworkCollection(this);
-
         }
 
         public actionsEnabled(): boolean {

--- a/src/Sfx/App/Scripts/Services/DataService.ts
+++ b/src/Sfx/App/Scripts/Services/DataService.ts
@@ -13,6 +13,7 @@ module Sfx {
         public appTypeGroups: ApplicationTypeGroupCollection;
         public apps: ApplicationCollection;
         public nodes: NodeCollection;
+        public networks: NetworkCollection;
 
         public constructor(
             public routes: RoutesService,
@@ -34,6 +35,8 @@ module Sfx {
             this.appTypeGroups = new ApplicationTypeGroupCollection(this);
             this.apps = new ApplicationCollection(this);
             this.nodes = new NodeCollection(this);
+            this.networks = new NetworkCollection(this);
+
         }
 
         public actionsEnabled(): boolean {
@@ -114,6 +117,16 @@ module Sfx {
             return this.getNodes(false, messageHandler).then(collection => {
                 return this.tryGetValidItem(collection, name, forceRefresh, messageHandler);
             });
+        }
+
+        public getNetwork(networkName: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<Network> {
+            return this.getNetworks(false, messageHandler).then(collection => {
+                return this.tryGetValidItem(collection, networkName, forceRefresh, messageHandler);
+            });
+        }
+
+        public getNetworks(forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<NetworkCollection> {
+            return this.networks.ensureInitialized(forceRefresh, messageHandler);
         }
 
         public getAppTypeGroups(forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): angular.IPromise<ApplicationTypeGroupCollection> {

--- a/src/Sfx/App/Scripts/Services/RestClientService.ts
+++ b/src/Sfx/App/Scripts/Services/RestClientService.ts
@@ -85,7 +85,7 @@ module Sfx {
         public createNetwork(networkName: string, networkAddressPrefix: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName);
             let body: any = { "name": networkName, "properties" : { "kind": "Local", "networkAddressPrefix": networkAddressPrefix } };
-            return this.put(this.getApiUrl(url, RestClient.apiVersion64), "Isolated Network creation", body, messageHandler);
+            return this.put(this.getApiUrl(url, RestClient.apiVersion64), "Creating isolated network \"" + networkName + "\" succeeded", body, messageHandler);
         }
 
         public getNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawNetwork> {
@@ -99,7 +99,7 @@ module Sfx {
 
         public deleteNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
             let url = "Resources/Networks/" + encodeURIComponent(networkName);
-            return this.delete(this.getApiUrl(url, RestClient.apiVersion64), "Network Deletion", messageHandler);
+            return this.delete(this.getApiUrl(url, RestClient.apiVersion64), "Network \""  + networkName + "\" deleted", messageHandler);
         }
 
         public getNetworksOnApp(appId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnApp[]> {
@@ -691,7 +691,7 @@ module Sfx {
         private delete<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<T> {
             let result = this.wrapInCallbacks<T>(() => this.httpClient.deleteAsync(url));
             if (!messageHandler) {
-                messageHandler = ResponseMessageHandlers.getResponseMessageHandler;
+                messageHandler = ResponseMessageHandlers.deleteResponseMessageHandler;
             }
             this.handleResponse(apiDesc, result, messageHandler);
 

--- a/src/Sfx/App/Scripts/Services/RestClientService.ts
+++ b/src/Sfx/App/Scripts/Services/RestClientService.ts
@@ -14,6 +14,7 @@ module Sfx {
         private static apiVersion40: string = "4.0";
         private static apiVersion60: string = "6.0";
         private static apiVersion62Preview: string = "6.2-preview";
+        private static apiVersion64: string = "6.4";
 
         private cacheAllowanceToken: number = Date.now().valueOf();
 
@@ -79,6 +80,51 @@ module Sfx {
 
         public getClusterHealthChunk(healthDescriptor: IClusterHealthChunkQueryDescription, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
             return this.post(this.getApiUrl("$/GetClusterHealthChunk"), "Get cluster health chunk", healthDescriptor, messageHandler);
+        }
+
+        public createNetwork(networkName: string, networkAddressPrefix: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName);
+            let body: any = { "name": networkName, "properties" : { "kind": "Local", "networkAddressPrefix": networkAddressPrefix } };
+            return this.put(this.getApiUrl(url, RestClient.apiVersion64), "Isolated Network creation", body, messageHandler);
+        }
+
+        public getNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawNetwork> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/";
+            return this.get(this.getApiUrl(url, RestClient.apiVersion64), "Get network", messageHandler);
+        }
+
+        public getNetworks(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetwork[]> {
+            return this.getFullCollection<IRawNetwork>("Resources/Networks/", "Get networks", RestClient.apiVersion64);
+        }
+
+        public deleteNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<{}> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName);
+            return this.delete(this.getApiUrl(url, RestClient.apiVersion64), "Network Deletion", messageHandler);
+        }
+
+        public getNetworksOnApp(appId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnApp[]> {
+            let url = "Applications/" + encodeURIComponent(appId) + "/$/GetNetworks";
+            return this.getFullCollection<IRawNetworkOnApp>(url, "Get networks attached to a application", RestClient.apiVersion60);
+        }
+
+        public getNetworksOnNode(nodeName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNetworkOnNode[]> {
+            let url = "Nodes/" + encodeURIComponent(nodeName) + "/$/GetNetworks";
+            return this.getFullCollection<IRawNetworkOnNode>(url, "Get networks deployed on a node", RestClient.apiVersion60);
+        }
+
+        public getAppsOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawAppOnNetwork[]> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/ApplicationRefs";
+            return this.getFullCollection<IRawAppOnNetwork>(url, "Get applications using current network", RestClient.apiVersion64);
+        }
+
+        public getNodesOnNetwork(networkName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNodeOnNetwork[]> {
+            let url = "Resources/Networks/" + encodeURIComponent(networkName) + "/DeployedNodes";
+            return this.getFullCollection<IRawNodeOnNetwork>(url, "Get nodes, current network is deployed on", RestClient.apiVersion64);
+        }
+
+        public getDeployedContainersOnNetwork(networkName: string, nodeName: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawDeployedContainerOnNetwork[]> {
+            let url = "Nodes/" + encodeURIComponent(nodeName) + "/$/GetNetworks/" + encodeURIComponent(networkName) + "/$/GetCodePackages";
+            return this.getFullCollection<IRawDeployedContainerOnNetwork>(url, "Get containers on network", RestClient.apiVersion60);
         }
 
         public getNodes(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawNode[]> {
@@ -319,12 +365,12 @@ module Sfx {
         }
 
         public getApplications(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawApplication[]> {
-            return this.getFullCollection<IRawApplication>("Applications/", "Get applications", messageHandler);
+            return this.getFullCollection<IRawApplication>("Applications/", "Get applications", null, messageHandler);
         }
 
         public getServices(applicationId: string, messageHandler?: IResponseMessageHandler): angular.IPromise<IRawService[]> {
             let url = "Applications/" + encodeURIComponent(applicationId) + "/$/GetServices";
-            return this.getFullCollection<IRawService>(url, "Get services", messageHandler);
+            return this.getFullCollection<IRawService>(url, "Get services", null, messageHandler);
         }
 
         public getService(applicationId: string, serviceId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawService> {
@@ -431,7 +477,7 @@ module Sfx {
                 + "/$/GetServices/" + encodeURIComponent(serviceId)
                 + "/$/GetPartitions";
 
-            return this.getFullCollection<IRawPartition>(url, "Get partitions", messageHandler);
+            return this.getFullCollection<IRawPartition>(url, "Get partitions", null, messageHandler);
         }
 
         public getPartition(applicationId: string, serviceId: string, partitionId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawPartition> {
@@ -474,7 +520,7 @@ module Sfx {
                 + "/$/GetPartitions/" + encodeURIComponent(partitionId)
                 + "/$/GetReplicas";
 
-            return this.getFullCollection<IRawReplicaOnPartition>(url, "Get replicas on partition", messageHandler);
+            return this.getFullCollection<IRawReplicaOnPartition>(url, "Get replicas on partition", null, messageHandler);
         }
 
         public getReplicaOnPartition(applicationId: string, serviceId: string, partitionId: string, replicaId: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawReplicaOnPartition> {
@@ -597,11 +643,11 @@ module Sfx {
                 `/${path}${path.indexOf("?") === -1 ? "?" : "&"}api-version=${apiVersion ? apiVersion : RestClient.defaultApiVersion}${skipCacheToken === true ? "" : `&_cacheToken=${this.cacheAllowanceToken}`}${continuationToken ? `&ContinuationToken=${continuationToken}` : ""}`;
         }
 
-        private getFullCollection<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler, continuationToken?: string): angular.IPromise<T[]> {
-            let appUrl = this.getApiUrl(url, null, continuationToken);
+        private getFullCollection<T>(url: string, apiDesc: string, apiVersion?: string, messageHandler?: IResponseMessageHandler, continuationToken?: string): angular.IPromise<T[]> {
+            let appUrl = this.getApiUrl(url, apiVersion, continuationToken);
             return this.get<IRawCollection<T>>(appUrl, apiDesc, messageHandler).then(response => {
                 if (response.data.ContinuationToken) {
-                    return this.getFullCollection<T>(url, apiDesc, messageHandler, response.data.ContinuationToken).then(items => {
+                    return this.getFullCollection<T>(url, apiDesc, apiVersion, messageHandler, response.data.ContinuationToken).then(items => {
                         return _.union(response.data.Items, items);
                     });
                 }
@@ -639,6 +685,16 @@ module Sfx {
             this.handleResponse(apiDesc, result, messageHandler);
 
             // Return original response object
+            return result;
+        }
+
+        private delete<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<T> {
+            let result = this.wrapInCallbacks<T>(() => this.httpClient.deleteAsync(url));
+            if (!messageHandler) {
+                messageHandler = ResponseMessageHandlers.getResponseMessageHandler;
+            }
+            this.handleResponse(apiDesc, result, messageHandler);
+
             return result;
         }
 

--- a/src/Sfx/App/Scripts/Services/RoutesService.ts
+++ b/src/Sfx/App/Scripts/Services/RoutesService.ts
@@ -57,6 +57,14 @@ module Sfx {
             return "#/node/" + this.doubleEncode(nodeName);
         }
 
+        public getNetworksViewPath(): string {
+            return "#/networks";
+        }
+
+        public getNetworkViewPath(networkName: string): string {
+            return "#/network/" + this.doubleEncode(networkName);
+        }
+
         public getDeployedAppViewPath(nodeName: string, appId: string): string {
             return "#/node/" + this.doubleEncode(nodeName) + "/deployedapp/" + this.doubleEncode(appId);
         }
@@ -189,6 +197,16 @@ module Sfx {
                 templateUrl: "partials/deployed-app.html",
                 controller: "DeployedAppViewController",
                 controllerAs: "deployedAppCtrl"
+            });
+            whenWithTabs($routeProvider, "/networks", {
+                templateUrl: "partials/networks.html",
+                controller: "NetworksViewController",
+                controllerAs: "networksCtrl"
+            });
+            whenWithTabs($routeProvider, "/network/:networkName", {
+                templateUrl: "partials/network.html",
+                controller: "NetworkViewController",
+                controllerAs: "networkCtrl"
             });
             whenWithTabs($routeProvider,
                 [

--- a/src/Sfx/App/Scripts/Utils/IdGenerator.ts
+++ b/src/Sfx/App/Scripts/Utils/IdGenerator.ts
@@ -22,6 +22,14 @@ module Sfx {
             return "<node group>";
         }
 
+        public static networkGroup(): string {
+            return "<network group>";
+        }
+
+        public static network(networkName: string): string {
+            return networkName;
+        }
+
         public static node(nodeName: string): string {
             return nodeName;
         }

--- a/src/Sfx/App/Scripts/Utils/IdUtils.ts
+++ b/src/Sfx/App/Scripts/Utils/IdUtils.ts
@@ -42,6 +42,10 @@ module Sfx {
             return decodeURIComponent(routeParams.nodeName);
         }
 
+        public static getNetworkName(routeParams: any): string {
+            return decodeURIComponent(routeParams.networkName);
+        }
+
         public static idToName(id: string): string {
             return Constants.FabricPrefix + id;
         }

--- a/src/Sfx/App/partials/app.html
+++ b/src/Sfx/App/partials/app.html
@@ -89,6 +89,11 @@
             <h4>Service Types</h4>
             <sfx-detail-list list="app.serviceTypes" list-settings="serviceTypesListSettings"></sfx-detail-list>
         </div>
+
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled">
+            <h4>Networks</h4>
+            <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
+        </div>
     </script>
 
     <!-- Details tab -->

--- a/src/Sfx/App/partials/create-network-dialog.html
+++ b/src/Sfx/App/partials/create-network-dialog.html
@@ -1,0 +1,21 @@
+<form name="createIsolatedNetworkForm">
+    <div class="modal-header">
+        <h4 class="modal-title">Create Isolated Network</h4>
+    </div>
+    <div class="modal-body">
+        <dl class="dl-horizontal">
+            <dt>Network name</dt>
+            <dd>
+                <input type="text" class="input-flat" ng-model="action.networkName" required>
+            </dd>
+            <dt>Network Address Prefix</dt>
+            <dd>
+                <input type="text" class="input-flat" ng-model="action.networkAddressPrefix" required>
+            </dd>
+        </dl>
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="btn btn-primary" data-dismiss="modal"  ng-click="ok()">{{::action.title}}</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
+    </div>
+</form>

--- a/src/Sfx/App/partials/network.html
+++ b/src/Sfx/App/partials/network.html
@@ -1,0 +1,51 @@
+<sfx-detail-view-navbar ctrl="networkCtrl" actions="network.actions" type="Network" name="{{network.name}}"></sfx-detail-view-navbar>
+
+<section class="main-view">
+    <div sfx-include src="'tab_' + networkCtrl.activeTabId" ng-if="networkCtrl.activeTabId"></div>
+
+    <script type="text/ng-template" id="tab_essentials">
+        <div class="detail-pane essen-pane">
+            <div class="table-responsive">
+                <table class="essen-table">
+                    <tr>
+                        <th>Network Name</th>
+                        <th>Network type</th>
+                    </tr>
+                    <tr>
+                        <td>{{network.name}}</td>
+                        <td>{{network.type}}</td>
+                    </tr>
+                    <tr>
+                        <th>Network Address Prefix</th>
+                        <th>Network Status</th>
+                    </tr>
+
+                    <tr>
+                        <td>{{network.addressPrefix}}</td>
+                        <td>{{network.status}}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="detail-pane">
+            <h4>Deployed Applications</h4>
+            <sfx-detail-list list="apps" list-settings="appListSettings"></sfx-detail-list>
+        </div>
+        <div class="detail-pane">
+            <h4>Attached Nodes</h4>
+            <sfx-detail-list list="nodes" list-settings="nodeListSettings"></sfx-detail-list>
+        </div>
+        <div class="detail-pane">
+            <h4>Containers</h4>
+            <sfx-detail-list list="containers" list-settings="containerListSettings"></sfx-detail-list>
+        </div>
+    </script>
+    <script type="text/ng-template" id="tab_details">
+        <div class="detail-pane">
+            <sfx-detail-view-part data="network"></sfx-detail-view-part>
+        </div>
+    </script>
+
+
+    
+</section>

--- a/src/Sfx/App/partials/network.html
+++ b/src/Sfx/App/partials/network.html
@@ -9,7 +9,7 @@
                 <table class="essen-table">
                     <tr>
                         <th>Network Name</th>
-                        <th>Network type</th>
+                        <th>Network Type</th>
                     </tr>
                     <tr>
                         <td>{{network.name}}</td>
@@ -40,12 +40,5 @@
             <sfx-detail-list list="containers" list-settings="containerListSettings"></sfx-detail-list>
         </div>
     </script>
-    <script type="text/ng-template" id="tab_details">
-        <div class="detail-pane">
-            <sfx-detail-view-part data="network"></sfx-detail-view-part>
-        </div>
-    </script>
-
-
     
 </section>

--- a/src/Sfx/App/partials/networks.html
+++ b/src/Sfx/App/partials/networks.html
@@ -1,0 +1,7 @@
+<sfx-detail-view-navbar ctrl="networksCtrl" type="Networks" actions="actions"></sfx-detail-view-navbar>
+
+<div class="main-view">
+    <div class="detail-pane">
+        <sfx-detail-list list="networks" list-settings="listSettings"></sfx-detail-list>
+    </div>
+</div>

--- a/src/Sfx/App/partials/node.html
+++ b/src/Sfx/App/partials/node.html
@@ -53,6 +53,10 @@
             <h4>Deployed Applications</h4>
             <sfx-detail-list list="deployedApps" list-settings="listSettings"></sfx-detail-list>
         </div>
+        <div class="detail-pane" ng-if="clusterManifest.isNetworkInventoryManagerEnabled">
+            <h4>Networks</h4>
+            <sfx-detail-list list="networks" list-settings="networkListSettings"></sfx-detail-list>
+        </div>
     </script>
 
     <script type="text/ng-template" id="tab_details">


### PR DESCRIPTION
Adding information for the networks on a cluster.

Added two view pages for Network and Networks
Added additional information on Node and Application pages.
Following are the REST Api's that I used for the data
Create a network
Invoke-WebRequest -Method Put -Uri http://HostName:Port/Resources/Networks/testNetwork2?api-version=6.0 -Body $body
 
With $body being:
{
"name": "testNetwork2",
"properties": {
"networkType": "Local",
"networkAddressPrefix": "10.0.0.4/22"
}
}
Delete a network with specific name
Invoke-WebRequest -Method Delete -Uri http://HostName:Port/Resources/Networks/testNetwork2?api-version=6.0

Get all networks
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks?api-version=6.0
 
Get a network with specific name
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork3?api-version=6.0

Get all applications that are members of a network
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork2/ApplicationRefs?api-version=6.0

Get all nodes a network is deployed to
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Resources/Networks/testNetwork2/DeployedNodes?api-version=6.0

Get all networks an application is member of
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Applications/samples~CalculatorApp/$/GetNetworks?api-version=6.0

Get all networks deployed to a node
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Nodes/vm1/$/GetNetworks?api-version=6.0

Get all containers deployed in a network on a node
Invoke-WebRequest -Method Get -Uri http://HostName:Port/Nodes/vm1/$/GetNetworks/TestNetwork/$/GetCodePackages?api-version=6.0