### PR TITLE
Expand all/close all on some tree entities

### DIFF
--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -240,8 +240,7 @@ module Sfx {
                         childrenQuery: () => this.getApplicationsForType(appTypeGroup.name),
                         badge: () => appTypeGroup.appsHealthState,
                         sortBy: () => [appTypeGroup.name],
-                        actions: appTypeGroup.actions,
-                        canExpandAll: true
+                        actions: appTypeGroup.actions
                     };
                 });
             });

--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -240,7 +240,8 @@ module Sfx {
                         childrenQuery: () => this.getApplicationsForType(appTypeGroup.name),
                         badge: () => appTypeGroup.appsHealthState,
                         sortBy: () => [appTypeGroup.name],
-                        actions: appTypeGroup.actions
+                        actions: appTypeGroup.actions,
+                        canExpandAll: true
                     };
                 });
             });
@@ -262,7 +263,8 @@ module Sfx {
                         },
                         mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => {
                             return deployedApp.deployedServicePackages.mergeClusterHealthStateChunk(clusterHealthChunk);
-                        }
+                        },
+                        canExpandAll: true
                     };
                 });
             });
@@ -277,7 +279,8 @@ module Sfx {
                         selectAction: () => this.routes.navigate(() => deployedServicePackage.viewPath),
                         childrenQuery: () => this.getDeployedServiceChildrenGroupNodes(nodeName, applicationId, deployedServicePackage.name, deployedServicePackage.servicePackageActivationId),
                         badge: () => deployedServicePackage.health.healthState,
-                        sortBy: () => [deployedServicePackage.uniqueId]
+                        sortBy: () => [deployedServicePackage.uniqueId],
+                        canExpandAll: true
                     };
                 });
             });
@@ -291,7 +294,7 @@ module Sfx {
                     nodeId: IdGenerator.deployedCodePackageGroup(),
                     displayName: () => "Code Packages",
                     childrenQuery: () => this.getDeployedCodePackages(codePkgs, nodeName, applicationId, servicePackageName, servicePackageActivationId),
-                    selectAction: () => this.routes.navigate(() => codePkgs.viewPath)
+                    selectAction: () => this.routes.navigate(() => codePkgs.viewPath),
                 };
             });
 
@@ -303,7 +306,7 @@ module Sfx {
                     displayName: () => replicas.isStatelessService ? "Instances" : "Replicas",
                     childrenQuery: () => this.getDeployedReplicas(replicas, nodeName, applicationId, servicePackageName, servicePackageActivationId),
                     selectAction: () => this.routes.navigate(() => replicas.viewPath),
-                    listSettings: this.settings.getNewOrExistingTreeNodeListSettings(replicas.viewPath)
+                    listSettings: this.settings.getNewOrExistingTreeNodeListSettings(replicas.viewPath),
                 };
             });
 
@@ -357,7 +360,8 @@ module Sfx {
                         },
                         mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => {
                             return app.services.mergeClusterHealthStateChunk(clusterHealthChunk);
-                        }
+                        },
+                        canExpandAll: true
                     };
                 });
             });
@@ -380,7 +384,8 @@ module Sfx {
                         },
                         mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => {
                             return service.partitions.mergeClusterHealthStateChunk(clusterHealthChunk);
-                        }
+                        },
+                        canExpandAll: true
                     };
                 });
             });
@@ -420,7 +425,8 @@ module Sfx {
                         sortBy: () => replica.isStatelessService
                             ? [replica.raw.NodeName]
                             : [replica.replicaRoleSortPriority, replica.raw.NodeName],
-                        actions: replica.actions
+                        actions: replica.actions,
+                        canExpandAll: true
                     };
                 });
             });

--- a/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
+++ b/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
@@ -141,7 +141,7 @@ module Sfx {
 
         public toggleAll(){
             if(!this.childGroupViewModel.isExpanded){
-                this.childGroupViewModel.toggle().then( () => {
+                this.childGroupViewModel.expand().then( () => {
                     this.childGroupViewModel.children.forEach(child => {
                         child.toggleAll();
                     })
@@ -151,11 +151,10 @@ module Sfx {
 
         public closeAll(){
             if(this.childGroupViewModel.isExpanded){
-                this.childGroupViewModel.toggle().then( () => {
-                    this.childGroupViewModel.children.forEach(child => {
-                        child.closeAll();
-                    })
+                this.childGroupViewModel.children.forEach(child => {
+                    child.closeAll();
                 })
+                this.childGroupViewModel.collapse()
             }
         }
 

--- a/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
+++ b/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
@@ -140,27 +140,21 @@ module Sfx {
         }
 
         public toggleAll(){
-            if(!this.isExpanded){
+            if(!this.childGroupViewModel.isExpanded){
                 this.childGroupViewModel.toggle().then( () => {
                     this.childGroupViewModel.children.forEach(child => {
                         child.toggleAll();
                     })
                 })
-            }else{
-                this.closeAll();          
             }
         }
 
         public closeAll(){
-            if(this.isExpanded){
+            if(this.childGroupViewModel.isExpanded){
                 this.childGroupViewModel.toggle().then( () => {
                     this.childGroupViewModel.children.forEach(child => {
                         child.closeAll();
                     })
-                })
-            }else{
-                this.childGroupViewModel.children.forEach(child => {
-                    child.closeAll();
                 })
             }
         }

--- a/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
+++ b/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
@@ -137,6 +137,32 @@ module Sfx {
             this.childGroupViewModel.toggle();
         }
 
+        public toggleAll(){
+            if(!this.isExpanded){
+                this.childGroupViewModel.toggle().then( () => {
+                    this.childGroupViewModel.children.forEach(child => {
+                        child.toggleAll();
+                    })
+                })
+            }else{
+                this.closeAll();          
+            }
+        }
+
+        public closeAll(){
+            if(this.isExpanded){
+                this.childGroupViewModel.toggle().then( () => {
+                    this.childGroupViewModel.children.forEach(child => {
+                        child.closeAll();
+                    })
+                })
+            }else{
+                this.childGroupViewModel.children.forEach(child => {
+                    child.closeAll();
+                })
+            }
+        }
+
         public contextMenuToggled(open: boolean) {
             if (open) {
                 HtmlUtils.repositionContextMenu();

--- a/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
+++ b/src/Sfx/App/Scripts/ViewModels/TreeNodeViewModel.ts
@@ -17,7 +17,7 @@ module Sfx {
         public updateHealthChunkQueryDescription: (clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription) => void;
         public mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => angular.IPromise<any>;
         public actions: ActionCollection;
-
+        public canExpandAll: boolean = false;
         public get depth(): number {
             if (this.parent) {
                 return this.parent.depth + 1;
@@ -131,6 +131,8 @@ module Sfx {
             } else {
                 this.childGroupViewModel = new TreeNodeGroupViewModel(this._tree, this, this._node.childrenQuery);
             }
+
+            this.canExpandAll = node.canExpandAll;
         }
 
         public toggle() {

--- a/src/Sfx/App/Scripts/ViewModels/TreeTypes.ts
+++ b/src/Sfx/App/Scripts/ViewModels/TreeTypes.ts
@@ -20,6 +20,7 @@ module Sfx {
         addHealthStateFiltersForChildren?: (clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription) => void;
         // If current node is expanded, merge the health chunk data back to the data models for current node and its children.
         mergeClusterHealthStateChunk?: (clusterHealthChunk: IClusterHealthChunk) => angular.IPromise<any>;
+        canExpandAll?: boolean;
     }
 }
 

--- a/src/Sfx/App/partials/tree-node.html
+++ b/src/Sfx/App/partials/tree-node.html
@@ -24,7 +24,7 @@
                       ng-class="{ 'bowtie-chevron-right-light': child.isCollapsed, 'bowtie-chevron-down-light': child.isExpanded }"
                       ng-style="::{ 'left': (child.paddingLeft - 18) + 'px' }">
                 </span>
-                <span tabindex="-1" class="icon bowtie-icon" aria-hidden="true"
+                <span tabindex="-1" class="icon bowtie-icon" aria-hidden="true" ng-if="child.canExpandAll"
                 ng-click="child.toggleAll(); $event.stopPropagation()" ng-show="child.hasExpander"
                 ng-class="{ 'bowtie-math-plus-heavy': child.isCollapsed, 'bowtie-math-minus': child.isExpanded }"
                 title="{{child.isCollapsed ? 'Expand All' : 'Collapse All'}}">

--- a/src/Sfx/App/partials/tree-node.html
+++ b/src/Sfx/App/partials/tree-node.html
@@ -25,7 +25,7 @@
                       ng-style="::{ 'left': (child.paddingLeft - 18) + 'px' }">
                 </span>
                 <span tabindex="-1" class="icon bowtie-icon" aria-hidden="true" ng-if="child.canExpandAll"
-                ng-click="child.toggleAll(); $event.stopPropagation()" ng-show="child.hasExpander"
+                ng-click="child.isExpanded? child.closeAll() : child.toggleAll(); $event.stopPropagation()" ng-show="child.hasExpander"
                 ng-class="{ 'bowtie-math-plus-heavy': child.isCollapsed, 'bowtie-math-minus': child.isExpanded }"
                 title="{{child.isCollapsed ? 'Expand All' : 'Collapse All'}}">
                 </span>

--- a/src/Sfx/App/partials/tree-node.html
+++ b/src/Sfx/App/partials/tree-node.html
@@ -24,6 +24,11 @@
                       ng-class="{ 'bowtie-chevron-right-light': child.isCollapsed, 'bowtie-chevron-down-light': child.isExpanded }"
                       ng-style="::{ 'left': (child.paddingLeft - 18) + 'px' }">
                 </span>
+                <span tabindex="-1" class="icon bowtie-icon" aria-hidden="true"
+                ng-click="child.toggleAll(); $event.stopPropagation()" ng-show="child.hasExpander"
+                ng-class="{ 'bowtie-math-plus-heavy': child.isCollapsed, 'bowtie-math-minus': child.isExpanded }"
+                title="{{child.isCollapsed ? 'Expand All' : 'Collapse All'}}">
+                </span>
                 <image ng-if="child.badge && child.badge() && child.badge().badgeClass && child.badge().badgeClass !== 'badge-ok'"
                        class="tree-badge" title="{{child.badge().text}}"
                        ng-src="images/{{child.badge().badgeClass}}.svg" role="presentation"></image>


### PR DESCRIPTION
added another way to open children on the following entities in the tree view
under Applications:
- application type
-  application
-  service partition

under Nodes:
- Deployed application
- Deployed Service Package

under System
- Service

![expandall](https://user-images.githubusercontent.com/15344718/63613423-98734180-c595-11e9-8ae5-c272c6addbc2.PNG)
