### PR TITLE
advanced actions are now hidden by read only status

### DIFF
--- a/src/Sfx/App/Scripts/Controllers/ImageStoreViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/ImageStoreViewController.ts
@@ -5,7 +5,11 @@ module Sfx {
 
             this.$scope.fileListSettings = this.settings.getNewOrExistingListSettings("imagestore", ["name"], [
                 new ListColumnSetting("", "", null, true, (item: ImageStoreItem, property) => {
-                    return `<sfx-image-store-file-view item="item"></sfx-image-store-file-view>`;
+                    if(this.$scope.imagestoreroot.data.actionsEnabled()){
+                        return `<sfx-image-store-file-view item="item"></sfx-image-store-file-view>`;
+                    }
+
+                    return "";
                 }),
                 new ListColumnSetting("displayName", "name", ["isFolder", "displayName"], false, (item: any, property) => {
                     if (!!item["fileCount"]) {

--- a/src/Sfx/App/Scripts/Services/DataService.ts
+++ b/src/Sfx/App/Scripts/Services/DataService.ts
@@ -47,7 +47,7 @@ module Sfx {
         }
 
         public actionsAdvancedEnabled(): boolean {
-            return this.storage.getValueBoolean(Constants.AdvancedModeKey, false);
+            return this.actionsEnabled && this.storage.getValueBoolean(Constants.AdvancedModeKey, false);
         }
 
         public invalidateBrowserRestResponseCache(): void {


### PR DESCRIPTION
 and image store viewer also follows the read only.