### PR TITLE
banner fix only to show in SFRP clusters

### DIFF
--- a/src/Sfx-Proxy/appsettings.json
+++ b/src/Sfx-Proxy/appsettings.json
@@ -1,7 +1,6 @@
 {
   "TargetCluster": {
-  "Url": "https://jejarryacesstesting.eastus.cloudapp.azure.com:19080",
-  "PFXLocation": "//winfabfs/scratch2/jejarry/certs/jejarryaccess-accesstesting-20190827.pfx", "PFXPassPhrase": "" 
+    "Url": "http://localhost:19080"
   },
   "recordFileBase": "playbackRecordings/"
- }
+}

--- a/src/Sfx-Proxy/appsettings.json
+++ b/src/Sfx-Proxy/appsettings.json
@@ -1,6 +1,7 @@
 {
   "TargetCluster": {
-    "Url": "http://localhost:19080"
+  "Url": "https://jejarryacesstesting.eastus.cloudapp.azure.com:19080",
+  "PFXLocation": "//winfabfs/scratch2/jejarry/certs/jejarryaccess-accesstesting-20190827.pfx", "PFXPassPhrase": "" 
   },
   "recordFileBase": "playbackRecordings/"
-}
+ }

--- a/src/Sfx/App/Scripts/Controllers/ClusterViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/ClusterViewController.ts
@@ -91,6 +91,14 @@ module Sfx {
             this.$scope.settings = this.settings;
             this.$scope.clusterTimelineGenerator = new ClusterTimelineGenerator();
             this.refresh();
+
+            this.$scope.nodes.refresh().then( () => {
+                this.$scope.clusterManifest.ensureInitialized().then( ()=> {
+                    //if < 5 seed nodes display warning for SFRP and <3 for on prem.
+                        const expectedCount = this.$scope.clusterManifest.isSfrpCluster ? 5 : 3;
+                        this.$scope.nodes.checkSeedNodeCount(expectedCount);
+                })
+            })
         }
 
         public getNodesForDomains(upgradeDomain: string, faultDomain: string): Node[] {

--- a/src/Sfx/App/Scripts/Controllers/ClusterViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/ClusterViewController.ts
@@ -94,9 +94,10 @@ module Sfx {
 
             this.$scope.nodes.refresh().then( () => {
                 this.$scope.clusterManifest.ensureInitialized().then( ()=> {
-                    //if < 5 seed nodes display warning for SFRP and <3 for on prem.
-                        const expectedCount = this.$scope.clusterManifest.isSfrpCluster ? 5 : 3;
-                        this.$scope.nodes.checkSeedNodeCount(expectedCount);
+                    //if < 5 seed nodes display warning for SFRP
+                    if(this.$scope.clusterManifest.isSfrpCluster){
+                        this.$scope.nodes.checkSeedNodeCount(5);
+                    }
                 })
             })
         }

--- a/src/Sfx/App/Scripts/Directives/StatusWarningsDirective.ts
+++ b/src/Sfx/App/Scripts/Directives/StatusWarningsDirective.ts
@@ -41,5 +41,20 @@ module Sfx {
             this.alerts.removeNotificationById(alert.id, hidePermenantly);
         }
 
+        public removeWithConfirm(alert: IStatusWarning): void {
+            new ActionWithConfirmationDialog(
+                this.data.$uibModal,
+                this.data.$q,
+                "",
+                "Accept",
+                "acknowledge",
+                () => this.data.$q.when(this.alerts.removeNotificationById(alert.id, true)),
+                () => true,
+                "Acknowledge",
+                alert.confirmText,
+                "Accept").runWithCallbacks( () => null, () => {});
+
+        }
+
     }
 }

--- a/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
@@ -158,7 +158,6 @@ module Sfx {
 
             try {
                 let $sfrp = $("Section[Name='UpgradeService']", $manifest);
-                console.log($sfrp)
                 this.isSfrpCluster = $sfrp.length > 0
             } catch(e) {
                 console.log(e)

--- a/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Cluster.ts
@@ -130,6 +130,7 @@ module Sfx {
 
     export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
         public clusterManifestName: string;
+        public isSfrpCluster: boolean = false;
         private _imageStoreConnectionString: string;
         private _isNetworkInventoryManagerEnabled: boolean = false;
 
@@ -153,6 +154,14 @@ module Sfx {
             let $nimEnabledParameter = $("Section[Name=NetworkInventoryManager] > Parameter[Name='IsEnabled']", $manifest);
             if ($nimEnabledParameter.length > 0) {
                 this._isNetworkInventoryManagerEnabled = $nimEnabledParameter.attr("Value").toLowerCase() === "true";
+            }
+
+            try {
+                let $sfrp = $("Section[Name='UpgradeService']", $manifest);
+                console.log($sfrp)
+                this.isSfrpCluster = $sfrp.length > 0
+            } catch(e) {
+                console.log(e)
             }
         }
 

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -320,23 +320,22 @@ module Sfx {
             this.disabledNodes = `${disabledNodes}/${disablingNodes}`;
             this.seedNodeCount = seedNodes.length;
 
-            this.checkSeedNodeCount(this.seedNodeCount);
             this.checkOneNodeScenario();
 
             this.healthySeedNodes = seedNodes.length.toString() + " (" +
                 Math.round(healthyNodes.length / seedNodes.length * 100).toString() + "%)";
         }
 
-        private checkSeedNodeCount(count: number) {
-            //if < 5 seed nodes display warning
-            //if count is 1, it is one box/test only scenario
-            if (count < 5 && count !== 1) {
+        public checkSeedNodeCount(expected: number) {
+            if (this.seedNodeCount < expected && this.seedNodeCount !== 1) {
                 this.data.warnings.addOrUpdateNotification({
-                    message: "Cluster is degraded because it does not have 5 seed nodes. See link for more details",
-                    level: StatusWarningLevel.Error,
+                    message: `This cluster is currently running on the bronze reliability tier. For production workloads a reliability level of silver or greater is recommended. 
+                    <br>See <a href="https://aka.ms/servicefabric/durability" target="_black">link</a> for more details`,
+                    level: StatusWarningLevel.Warning,
                     priority: 2,
                     id: BannerWarningID.ClusterDegradedState,
-                    link: "https://aka.ms/servicefabric/durability"
+                    confirmText: `This cluster is currently running on the bronze reliability tier which indicates a test/staging environment. For production workloads a reliability level of silver or greater is recommended. For more information on the reliability characteristics of a cluster, please see
+                    https://aka.ms/sfreliabilitytiers.`
                 });
             }else {
                 this.data.warnings.removeNotificationById(BannerWarningID.ClusterDegradedState);

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -329,13 +329,13 @@ module Sfx {
         public checkSeedNodeCount(expected: number) {
             if (this.seedNodeCount < expected && this.seedNodeCount !== 1) {
                 this.data.warnings.addOrUpdateNotification({
-                    message: `This cluster is currently running on the bronze reliability tier. For production workloads, a reliability level of silver or greater is recommended. 
-                    <br>See <a href="https://aka.ms/servicefabric/durability" style="color: #ec0000 !important;" target="_black">( link )</a> for more details`,
+                    message: `This cluster is currently running on the bronze reliability tier. For production workloads, only a reliability level of silver or greater is supported 
+                    <br>See <a href="https://aka.ms/servicefabric/reliability" target="_black">( link )</a> for more details`,
                     level: StatusWarningLevel.Warning,
                     priority: 2,
                     id: BannerWarningID.ClusterDegradedState,
-                    confirmText: `This cluster is currently running on the bronze reliability tier which indicates a test/staging environment. For production workloads a reliability, 
-                    level of silver or greater is recommended. For more information on the reliability characteristics of a cluster, please see https://aka.ms/sfreliabilitytiers.`
+                    confirmText: `This cluster is currently running on the bronze reliability tier which indicates a test/staging environment. For production workloads, only a reliability
+                    level of silver or greater is supported. For more information on the reliability characteristics of a cluster, please see https://aka.ms/sfreliabilitytiers`
                 });
             }else {
                 this.data.warnings.removeNotificationById(BannerWarningID.ClusterDegradedState);

--- a/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/Collections.ts
@@ -329,13 +329,13 @@ module Sfx {
         public checkSeedNodeCount(expected: number) {
             if (this.seedNodeCount < expected && this.seedNodeCount !== 1) {
                 this.data.warnings.addOrUpdateNotification({
-                    message: `This cluster is currently running on the bronze reliability tier. For production workloads a reliability level of silver or greater is recommended. 
-                    <br>See <a href="https://aka.ms/servicefabric/durability" target="_black">link</a> for more details`,
+                    message: `This cluster is currently running on the bronze reliability tier. For production workloads, a reliability level of silver or greater is recommended. 
+                    <br>See <a href="https://aka.ms/servicefabric/durability" style="color: #ec0000 !important;" target="_black">( link )</a> for more details`,
                     level: StatusWarningLevel.Warning,
                     priority: 2,
                     id: BannerWarningID.ClusterDegradedState,
-                    confirmText: `This cluster is currently running on the bronze reliability tier which indicates a test/staging environment. For production workloads a reliability level of silver or greater is recommended. For more information on the reliability characteristics of a cluster, please see
-                    https://aka.ms/sfreliabilitytiers.`
+                    confirmText: `This cluster is currently running on the bronze reliability tier which indicates a test/staging environment. For production workloads a reliability, 
+                    level of silver or greater is recommended. For more information on the reliability characteristics of a cluster, please see https://aka.ms/sfreliabilitytiers.`
                 });
             }else {
                 this.data.warnings.removeNotificationById(BannerWarningID.ClusterDegradedState);

--- a/src/Sfx/App/Scripts/Services/StatusWarningService.ts
+++ b/src/Sfx/App/Scripts/Services/StatusWarningService.ts
@@ -7,6 +7,7 @@ module Sfx {
         level: string;
         priority: number;
         id: string;
+        confirmText?: string;
     }
 
     export class StatusWarningService {

--- a/src/Sfx/App/partials/status-warnings.html
+++ b/src/Sfx/App/partials/status-warnings.html
@@ -1,23 +1,24 @@
 <div>
     <div style="display: flex;" ng-repeat="alert in ctrl.alerts.notifications">
-        <div ng-if="$first || ctrl.displayAll " class="detail-pane alert alert-{{alert.level}} status-warning" role="alert">
+        <div style="display: flex;" ng-if="$first || ctrl.displayAll " class="detail-pane alert alert-{{alert.level}} status-warning" role="alert">
             <div style="display: inline-flex">
                 <strong>{{alert.level | warningPrefix}}:</strong>
             </div>
-            <span style="display: inline-flex" ng-bind-html="alert.message"></span>
-            <span ng-if="alert.level === 'info'">
-                    <span ng-click="ctrl.remove(alert, true)" class="dropdown-toggle dark-background-link bowtie-icon bowtie-status-failure" style="font-size: 15pt; vertical-align: bottom; float: right;"></span>
-            </span>
+            <span ng-bind-html="alert.message"></span>
             <span ng-if="alert.link">
                     <a class="light-background-link" target="_blank" href="{{alert.link}}">{{alert.linkText || "(link)"}}</a>
             </span>
-
-            <div style="float: right;" ng-click="ctrl.toggleViewed()" ng-if="ctrl.alerts.notifications.length > 1 && $first">
+            <div ng-if="alert.level === 'info'" style="flex: auto">
+                    <span ng-click="ctrl.remove(alert, true)" class="dropdown-toggle dark-background-link bowtie-icon bowtie-status-failure" style="font-size: 15pt; vertical-align: bottom; float: right;"></span>
+            </div>
+            <span ng-if="alert.level === 'warning'" style="flex: auto">
+                    <span ng-click="ctrl.removeWithConfirm(alert, true)" class="dropdown-toggle dark-background-link bowtie-icon bowtie-status-failure" style="font-size: 15pt; vertical-align: bottom; float: right;"></span>
+            </span>
+            <div style="float: right; margin-left: auto;" ng-click="ctrl.toggleViewed()" ng-if="ctrl.alerts.notifications.length > 1 && $first">
                     <span ng-if="!ctrl.displayAll" class="dropdown-toggle dark-background-link bowtie-icon bowtie-triangle-down" style="font-size: 20pt; vertical-align: bottom;"></span>
                     <span ng-if="ctrl.displayAll" class="dropdown-toggle dark-background-link bowtie-icon bowtie-triangle-up" style="font-size: 20pt; vertical-align: bottom;"></span>
                         ({{ctrl.alerts.notifications.length}})
             </div>
-
         </div>
     </div>
 </div>


### PR DESCRIPTION
Now check if is a SFRP cluster first before deciding whether or not to display a message relative to the amount of seed nodes. SFRP checks for 5 and on prem checks for 3. THis should also remove the issue of the warning showing in one box.