### PR TITLE
Expand tree to fit view button

### DIFF
--- a/src/SfxWeb/src/app/app.component.html
+++ b/src/SfxWeb/src/app/app.component.html
@@ -46,11 +46,9 @@
 
   <div>
       <div class="left-panel left-bar"  [ngStyle]="{'width': treeWidth }">
-        <div class="tree-container">
-          <nav>
-            <app-tree-view></app-tree-view>
+          <nav class="tree-container">
+            <app-tree-view (onTreeSize)="resize($event)"></app-tree-view>
           </nav>
-        </div>
         <div class="slider-bar" appDrag (onDrag)="resize($event)">
       </div>
     </div>

--- a/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.scss
@@ -11,9 +11,6 @@
     }
 
     > .self {
-        // padding-right: 24px;
-        overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
         cursor: pointer;
         width: 100%;
@@ -53,9 +50,6 @@
         }
 
         .tree-label {
-            overflow: hidden;
-            text-overflow: ellipsis;
-
             .search-match {
                 color: $tree-node-search-highlight-color;
                 background-color: $tree-node-search-highlight-background-color;
@@ -89,7 +83,6 @@
 .right-action {
     position: absolute;
     right: 0;
-    // float:  right;
     padding: 1px;
 }
 

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
@@ -1,30 +1,35 @@
-<div class="tree-header">
-    <div style="padding: 10px;background-color: #fcf8e3; border-left: #FFC646 solid 8px; margin: 8px; min-width: 330px;">
-        <div style="vertical-align: middle; padding: 4px; color: black; padding-bottom: 8px;" (click)="leaveBeta();">
-            To leave beta <span style="cursor: pointer;">(Click here)</span>
+<div class="tree-wrapper">
+    <div class="tree-header">
+        <div style="padding: 10px;background-color: #fcf8e3; border-left: #FFC646 solid 8px; margin: 8px; min-width: 330px;">
+            <div style="vertical-align: middle; padding: 4px; color: black; padding-bottom: 8px;" (click)="leaveBeta();">
+                To leave beta <span style="cursor: pointer;">(Click here)</span>
+            </div>
+            <div style="border-top: 2px solid #b7b1b1; padding: 4px;">
+                <a href="https://aka.ms/sfxrepo" target="_blank" style="color: black;">You can report any issues you run into (Click here)</a>
+            </div>
         </div>
-        <div style="border-top: 2px solid #b7b1b1; padding: 4px;">
-            <a href="https://aka.ms/sfxrepo" target="_blank" style="color: black;">You can report any issues you run into (Click here)</a>
+        <app-check-box [(state)]="treeService.tree.showOkItems">
+            <app-health-badge [badgeClass]="'badge-ok'" [text]="'OK'"></app-health-badge>
+        </app-check-box>
+        <app-check-box [(state)]="treeService.tree.showWarningItems">
+            <app-health-badge [badgeClass]="'badge-warning'" [text]="'Warning'"></app-health-badge>
+        </app-check-box>
+        <app-check-box [(state)]="treeService.tree.showErrorItems">
+            <app-health-badge [badgeClass]="'badge-error'" [text]="'Error'"></app-health-badge>
+        </app-check-box>
+        <div style="padding: 10px 10px 0px 0px; margin-left: -15px;">
+            <app-input (onChange)="treeService.tree.searchTerm = $event"></app-input>
         </div>
     </div>
-    <app-check-box [(state)]="treeService.tree.showOkItems">
-        <app-health-badge [badgeClass]="'badge-ok'" [text]="'OK'"></app-health-badge>
-    </app-check-box>
-    <app-check-box [(state)]="treeService.tree.showWarningItems">
-        <app-health-badge [badgeClass]="'badge-warning'" [text]="'Warning'"></app-health-badge>
-    </app-check-box>
-    <app-check-box [(state)]="treeService.tree.showErrorItems">
-        <app-health-badge [badgeClass]="'badge-error'" [text]="'Error'"></app-health-badge>
-    </app-check-box>
-    <div style="padding: 10px 10px 0px 0px; margin-left: -15px;">
-        <app-input (onChange)="treeService.tree.searchTerm = $event"></app-input>
-    </div>
-</div>
-<div style="height: 100%; overflow: auto;">
-    <div *ngIf="treeService.tree" class="tree-body">
-        <div *ngIf="!treeService.tree.isLoading && !treeService.tree.isEmpty"  class="tree-view">
-            <div class="tree" style="list-style: none">
-                <app-tree-node [node]="treeService.tree.childGroupViewModel" ></app-tree-node>
+    <div style="flex: 1; overflow: auto;">
+        <div class="tree-body" #tree>
+            <span style="float:right;" *ngIf="canExpand">
+                <button class="simple-button" (click)="setWidth()" title="Expand view to match width of tree"><span class="mif-keyboard-tab"></span></button> 
+            </span>
+            <div *ngIf="treeService.tree && !treeService.tree.isLoading && !treeService.tree.isEmpty"  class="tree-view">
+                <div class="tree" style="list-style: none">
+                    <app-tree-node [node]="treeService.tree.childGroupViewModel" ></app-tree-node>
+                </div>
             </div>
         </div>
     </div>

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
@@ -22,11 +22,13 @@
         </div>
     </div>
     <div style="flex: 1; overflow: auto;">
-        <div class="tree-body" #tree>
-            <span style="float:right;" *ngIf="canExpand">
-                <button class="simple-button" (click)="setWidth()" title="Expand view to match width of tree"><span class="mif-keyboard-tab"></span></button> 
-            </span>
-            <div *ngIf="treeService.tree && !treeService.tree.isLoading && !treeService.tree.isEmpty"  class="tree-view">
+        <span class="expand-panel-wrapper" *ngIf="canExpand">
+            <button class="expand-panel-button" (click)="setWidth()" title="Expand view to match width of tree">
+                <span class=" mif-chevron-right mif-3x"></span>
+            </button> 
+        </span>
+        <div class="tree-body" #tree style="height: 100%" >
+            <div *ngIf="treeService.tree && !treeService.tree.isLoading && !treeService.tree.isEmpty"  class="tree-view" style="position: relative; height: 100%">
                 <div class="tree" style="list-style: none">
                     <app-tree-node [node]="treeService.tree.childGroupViewModel" ></app-tree-node>
                 </div>

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
@@ -1,5 +1,10 @@
 @import "src/styles.scss";
 
+.tree-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
 
 .tree-header {
     white-space: nowrap;
@@ -21,8 +26,8 @@
 }
 
 .tree-body {
-    overflow-x: auto;
-    overflow-y: auto;
+    // overflow-x: auto;
+    // overflow-y: auto;
     bottom: $page-padding-bottom;
     color: $tree-color;
 

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
@@ -26,8 +26,6 @@
 }
 
 .tree-body {
-    // overflow-x: auto;
-    // overflow-y: auto;
     bottom: $page-padding-bottom;
     color: $tree-color;
 

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
@@ -58,3 +58,19 @@
         }
     }
 }
+
+
+.expand-panel-button {
+    padding: 0px;
+    background-color: black;
+    border: 0px;
+    border-radius: 8px 0px 0px 8px;
+    color: white;
+}
+
+.expand-panel-wrapper {
+    position: absolute;
+    right: 10px;
+    z-index: 2;
+    bottom: 50%;
+}

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, OnChanges, AfterViewInit, Output, EventEmitter, DoCheck } from '@angular/core';
 import { TreeService } from 'src/app/services/tree.service';
 
 @Component({
@@ -6,16 +6,27 @@ import { TreeService } from 'src/app/services/tree.service';
   templateUrl: './tree-view.component.html',
   styleUrls: ['./tree-view.component.scss']
 })
-export class TreeViewComponent implements OnInit {
+export class TreeViewComponent implements DoCheck {
 
+  @Output() onTreeSize = new EventEmitter<number>();
+
+  public canExpand = false;
+  @ViewChild("tree") tree: ElementRef;
   constructor(public treeService: TreeService) { }
 
-  ngOnInit() {
+  ngDoCheck(): void {
+    if(this.tree) {
+      this.canExpand = this.tree.nativeElement.scrollWidth > this.tree.nativeElement.clientWidth
+    }
   }
 
   leaveBeta() {
     const originalUrl = location.origin + '/Explorer/index.html' + location.hash;
     window.location.assign(originalUrl);
+    
   }
 
+  setWidth() {
+    this.onTreeSize.emit(this.tree.nativeElement.scrollWidth + 20)
+  }
 }

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
@@ -16,7 +16,7 @@ export class TreeViewComponent implements DoCheck {
 
   ngDoCheck(): void {
     if(this.tree) {
-      this.canExpand = this.tree.nativeElement.scrollWidth > this.tree.nativeElement.clientWidth
+      this.canExpand = this.tree.nativeElement.scrollWidth > this.tree.nativeElement.clientWidth;
     }
   }
 


### PR DESCRIPTION
Now the tree view will allow the user to scroll horizontally instead of using ellipses cut offs and additionally when the view port for the tree view is less than the container width add a button that will match the width and expand(as seen below)
![expand panel](https://user-images.githubusercontent.com/15344718/76566401-e97f5000-6469-11ea-865c-f8931e4973ac.PNG)
 will become when clicking the button.
![expanded](https://user-images.githubusercontent.com/15344718/76566474-16cbfe00-646a-11ea-94ba-0b4ebe49f064.PNG)
