### PR TITLE
feature: ClusterTreeService.ts add Deactivation Intent to node name suffix if intent not set to 'invalid'

### DIFF
--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -182,6 +182,9 @@ module Sfx {
                                     suffix = "Down (Stopped)";
                                 } else {
                                     suffix = node.raw.NodeStatus;
+                                    if (node.raw.NodeDeactivationInfo.NodeDeactivationIntent !== NodeStatusConstants.Invalid) {
+                                        suffix += "->" + node.raw.NodeDeactivationInfo.NodeDeactivationIntent;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
add deactivation intent to node name suffix if intent not set to 'invalid' to assist in administration and triaging of cluster

a couple of examples:

![image](https://user-images.githubusercontent.com/18124982/78382547-0ad4e700-75a5-11ea-8d64-509266e12fb5.png)

![image](https://user-images.githubusercontent.com/18124982/78383016-b716cd80-75a5-11ea-9c1d-9abef3bff1dd.png)

