### PR TITLE
feature: ClusterTreeService.ts add expander to root nodes in treeview

### DIFF
--- a/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
+++ b/src/Sfx/App/Scripts/Services/ClusterTreeService.ts
@@ -78,6 +78,7 @@ module Sfx {
                         childrenQuery: () => this.getGroupNodes(),
                         selectAction: () => this.routes.navigate(() => this.routes.getClusterViewPath()),
                         badge: () => clusterHealth.healthState,
+                        canExpandAll: true,
                         alwaysVisible: true,
                         startExpanded: true,
                         mergeClusterHealthStateChunk: (clusterHealthChunk: IClusterHealthChunk) => {
@@ -107,6 +108,7 @@ module Sfx {
                     childrenQuery: () => this.getApplicationTypes(),
                     badge: () => apps.healthState,
                     selectAction: () => this.routes.navigate(() => apps.viewPath),
+                    canExpandAll: true,
                     alwaysVisible: true
                 };
             });
@@ -120,6 +122,7 @@ module Sfx {
                     childrenQuery: () => this.getNodes(),
                     badge: () => nodes.healthState,
                     listSettings: this.settings.getNewOrExistingTreeNodeListSettings(nodes.viewPath),
+                    canExpandAll: true,
                     alwaysVisible: true
                 };
             });
@@ -132,6 +135,7 @@ module Sfx {
                     selectAction: () => this.routes.navigate(() => systemApp.viewPath),
                     childrenQuery: () => this.getServices(Constants.SystemAppId),
                     badge: () => systemApp.healthState,
+                    canExpandAll: true,
                     alwaysVisible: true,
                     addHealthStateFiltersForChildren: (clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription) => {
                         // System app node is expanded, modify health filters to include system services
@@ -155,6 +159,7 @@ module Sfx {
                             displayName: () => "Networks",
                             childrenQuery: () => this.getNetworks(),
                             selectAction: () => this.routes.navigate(() => net.viewPath),
+                            canExpandAll: true,
                             alwaysVisible: true
                         };
                     });


### PR DESCRIPTION
# ClusterTreeService.ts add expander to root nodes in treeview to assist with searching tree.
## Applies to 'Cluster' root, and 'Applications', 'Nodes', 'System', 'Network' child nodes.

## defaults to root and collapsed child node views same as before:

![image](https://user-images.githubusercontent.com/18124982/78384963-1fb37980-75a9-11ea-8dd0-d81bb4ef34b8.png)

## to toggle full cluster view would be a double click on the cluster expander (collapse-all -> expand-all) since it is partially expanded:

![image](https://user-images.githubusercontent.com/18124982/78385892-9dc45000-75aa-11ea-801f-ec61b60c826d.png)

![image](https://user-images.githubusercontent.com/18124982/78385052-3fe33880-75a9-11ea-8327-bd0e8cfea8eb.png)

## chevrons work same as before.

![image](https://user-images.githubusercontent.com/18124982/78385440-d9124f00-75a9-11ea-8b33-5cbe1dfb3d6a.png)

## expand-all -> collapse-all -> expand will not leave all children expanded

![image](https://user-images.githubusercontent.com/18124982/78385716-53db6a00-75aa-11ea-9190-431c1472bb8a.png)

![image](https://user-images.githubusercontent.com/18124982/78385737-5b9b0e80-75aa-11ea-8e4a-9a40b4d554e1.png)


