### PR TITLE
better solution for handling routing between version

### DIFF
--- a/src/Sfx/App/Scripts/Controllers/TreeViewController.ts
+++ b/src/Sfx/App/Scripts/Controllers/TreeViewController.ts
@@ -19,7 +19,7 @@ module Sfx {
         }
 
         public enterBeta() {
-            const originalUrl = location.origin + '/Explorer/beta.html' + location.hash;
+            const originalUrl =  location.href.replace('index.html', 'beta.html');
             window.location.assign(originalUrl);
         }
     }

--- a/src/SfxWeb/package.json
+++ b/src/SfxWeb/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "start-local": "ng serve --proxy-config=proxy.conf.json --port 3000",
     "build": "ng build",
-    "build:prod": "ng build --prod  --base-href=/Explorer/beta.html  --output-hashing=none",
+    "build:prod": "ng build --prod  --output-hashing=none",
     "build:stats": "ng build --stats-json",
     "test": "ng test",
     "lint": "ng lint",

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
@@ -21,9 +21,8 @@ export class TreeViewComponent implements DoCheck {
   }
 
   leaveBeta() {
-    const originalUrl = location.origin + '/Explorer/index.html' + location.hash;
+    const originalUrl =  location.href.replace('beta.html', 'index.html');
     window.location.assign(originalUrl);
-    
   }
 
   setWidth() {

--- a/src/SfxWeb/src/beta.html
+++ b/src/SfxWeb/src/beta.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>Service Fabric Explorer (Beta)</title>
-  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="explorer/favicon.png">
+  <link rel="icon" type="image/x-icon" href="favicon.png">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>


### PR DESCRIPTION
Removing the base href should make SFX switching version for SFRP  work properly.