### PR TITLE
refresh rate clean up.

### DIFF
--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -11,7 +11,7 @@ export class Constants {
     public static FabricPrefix: string = "fabric:/";
 
     // Storage key names
-    public static AutoRefreshIntervalStorageKey: string = "sfxAutoRefreshInterval";
+    public static AutoRefreshIntervalStorageKey: string = "sfxAutoRefreshIntervalV2";
     public static SplitterLeftWidth: string = "sfxSplitterleftWidth";
     public static ThemeNameStorageKey: string = "sfxThemeName";
     public static PaginationLimitStorageKey: string = "sfxPaginationLimit";

--- a/src/SfxWeb/src/app/Models/Action.ts
+++ b/src/SfxWeb/src/app/Models/Action.ts
@@ -1,5 +1,5 @@
 ﻿import { Observable, of } from 'rxjs';
-import { mergeMap, map } from 'rxjs/operators';
+import { mergeMap, finalize } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ActionDialogComponent } from '../shared/component/action-dialog/action-dialog.component';
 import { ComponentType } from '@angular/cdk/portal';
@@ -44,11 +44,9 @@ export class Action {
         if (this.canRun()) {
             this._running = true;
             const executing = this.execute();
-            executing.pipe(map( ()=> {
+            return executing.pipe(finalize( ()=> {
                 this._running = false;
-            })).subscribe();
-            return executing;
-
+            }))
         }
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -11,8 +11,8 @@ import { HealthBase } from './HealthEvent';
 import { TimeUtils } from 'src/app/Utils/TimeUtils';
 import { HealthEvaluation, UpgradeDescription, UpgradeDomain } from './Shared';
 import { Utils } from 'src/app/Utils/Utils';
-import { Observable, forkJoin } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, forkJoin, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
 import { HealthUtils } from 'src/app/Utils/healthUtils';
 import { ServiceCollection } from './collections/ServiceCollection';
 import { ActionWithConfirmationDialog, IsolatedAction } from '../Action';
@@ -140,12 +140,15 @@ export class Application extends DataModelBase<IRawApplication> {
 
                 let replicaQueries = nodes.collection.map((node) =>
                     this.data.restClient.getReplicasOnNode(node.name, this.id)
-                        .subscribe((response) => response.forEach((replica) => {
-                            replicas.push({
-                                Replica: replica,
-                                NodeName: node.name
-                            });
-                        })));
+                        .pipe(catchError(err => of([])), 
+                            map((response) => (response || []).forEach((replica) => {
+                                replicas.push({
+                                    Replica: replica,
+                                    NodeName: node.name
+                                });
+                            }))
+                        )
+                    );
 
                 forkJoin(replicaQueries).pipe(map(() => {
                     replicas.forEach(replicaInfo =>

--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -32,6 +32,9 @@ export abstract class BaseController implements  OnInit, OnDestroy {
              this.subscriptions.add(this.common().pipe(mergeMap( () => this.refresh())).subscribe(
                  () => {
                     this.refreshService.insertRefreshSubject("current controller" + this.getClassName(), this.refresh.bind(this, this.messageService));
+                 },
+                 () => {
+                     this.router.navigate(["/"]);
                  }
              ));
         }))

--- a/src/SfxWeb/src/app/services/refresh.service.spec.ts
+++ b/src/SfxWeb/src/app/services/refresh.service.spec.ts
@@ -1,12 +1,89 @@
 import { TestBed } from '@angular/core/testing';
 
 import { RefreshService } from './refresh.service';
+import { StorageService } from './storage.service';
+import { of, timer, throwError } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Constants } from '../Common/Constants';
 
 describe('RefreshService', () => {
+  localStorage.setItem(Constants.AutoRefreshIntervalStorageKey, '15');
+
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [StorageService]
+  }));
+
   beforeEach(() => TestBed.configureTestingModule({}));
 
-  it('should be created', () => {
+  fit('should be created', () => {
     const service: RefreshService = TestBed.get(RefreshService);
     expect(service).toBeTruthy();
   });
+
+
+  fit('add and remove refresh subject', () => {
+    const service: RefreshService = TestBed.get(RefreshService);
+    
+    const keyName = "test";
+    const func = () => of(null)
+
+    service.insertRefreshSubject(keyName, func);
+    expect(service["_refreshSubjectsMap"][keyName]).toBe(func);
+    expect(service["refreshSubjects"].length).toBe(1);
+
+    service.removeRefreshSubject(keyName);
+    expect(service["_refreshSubjectsMap"][keyName]).toBeUndefined();
+    expect(service["refreshSubjects"].length).toBe(0);
+
+  });
+
+  fit('refresh all', async () => {
+    const service: RefreshService = TestBed.get(RefreshService);
+    let done = false;
+    const keyName = "test";
+    const func = () => of(null).pipe(map( () => done = true))
+
+    service.insertRefreshSubject(keyName, func);
+    expect(service["_refreshSubjectsMap"][keyName]).toBe(func);
+    expect(service["refreshSubjects"].length).toBe(1);
+
+    service.refreshAll()
+
+    await timer(1000).toPromise();
+
+    expect(service.isRefreshing).toBeFalsy();
+    expect(done).toBeTruthy();
+  });
+
+  fit('refresh withError', async () => {
+    const service: RefreshService = TestBed.get(RefreshService);
+    const keyName = "test";
+    const func = () =>  throwError("error");
+    let done = false;
+    const keyName2 = "success";
+    const func2 = () => of(null).pipe(map( () => done = true));
+
+    service.insertRefreshSubject(keyName, func);
+    service.insertRefreshSubject(keyName2, func2);
+    expect(service["refreshSubjects"].length).toBe(2);
+
+    service.refreshAll();
+
+    await timer(1500).toPromise();
+
+    expect(service.isRefreshing).toBeFalsy();
+    expect(done).toBeTruthy();
+  });
+
+  fit('update refresh interval', async () => {
+    const service: RefreshService = TestBed.get(RefreshService);
+    service.init();
+
+    expect(service.refreshRate).toBe("15");
+    
+    service.updateRefreshInterval("10");
+    expect(service.refreshRate).toBe("10");
+
+  });
+
 });

--- a/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.html
+++ b/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.html
@@ -3,8 +3,8 @@
     REFRESH RATE {{displayRate === "0" ? 'OFF' : displayRate}} 
   </div>
   <button (click)="change(0)"> OFF </button>
-  <input [(ngModel)]="refreshRate" type="range" list="tickmarks" step="1" min="0" max="6" (click)="changed()" aria-label="Set the refresh rate">
-  <button (click)="change(6)"> FAST </button>
+  <input [(ngModel)]="refreshRate" type="range" list="tickmarks" step="1" min="0" max="5" (click)="changed()" aria-label="Set the refresh rate">
+  <button (click)="change(5)"> FAST </button>
   <button (click)="forceRefresh()" class="mif-refresh mif-2x" [ngClass]="{'rotate': refresh}" aria-label="Force a refresh"> </button>  
 </div>
 
@@ -15,5 +15,4 @@
   <option value="3"></option>
   <option value="4"></option>
   <option value="5"></option>
-  <option value="6"></option>
 </datalist> 

--- a/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
+++ b/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
@@ -25,7 +25,6 @@ export class RefreshRateComponent {
     3: "30",
     4: "10",
     5: "5",
-    6: "2"
   }
 
   changed() {

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -54,7 +54,11 @@ export class EssentialsComponent extends ApplicationBaseController {
   }
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
-    this.data.refreshBackupPolicies(messageHandler);
+    this.data.clusterManifest.ensureInitialized().subscribe(() => {
+      if(this.data.clusterManifest.isBackupRestoreEnabled) {
+        this.data.refreshBackupPolicies(messageHandler);
+      }
+    });
 
     return forkJoin([
       this.clusterManifest.ensureInitialized(false),


### PR DESCRIPTION
This is intended to clean up a few scenarios with refreshing.

Removing the 2 second refresh rate given fairly often its skipped because of an ongoing refresh.
Removes the refresh check and will just request a new refresh loop, where right now one request in the chain could be timing out and blocking all other requests.
Most shared resources SHOULD be dealing with multiple requests for the data at once and handling it under one Subject object to avoid concurrent requests to the cluster.
Navigating to a resource that has been deleted should redirect back to the cluster landing page instead of sitting at a page erroring out.