### PR TITLE
adding more tiles to make it easier to see the state of applications/services

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -1,4 +1,4 @@
-﻿import { IRawApplication, IRawApplicationHealth, IRawApplicationManifest, IRawDeployedApplicationHealthState, IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo } from '../RawDataTypes';
+﻿import { IRawApplication, IRawApplicationHealth, IRawApplicationManifest, IRawDeployedApplicationHealthState, IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo, IRawHealthStateCount } from '../RawDataTypes';
 import { DataModelBase, IDecorators } from './Base';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
 import { ServiceTypeCollection, ApplicationBackupConfigurationInfoCollection } from './collections/Collections';

--- a/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
@@ -20,26 +20,11 @@ import { ViewBackupComponent } from 'src/app/modules/backup-restore/view-backup/
 // Licensed under the MIT License. See License file under the project root for license information.
 //-----------------------------------------------------------------------------
 
-export enum HealthStatisticsEntityKind {
-    Node,
-    Application,
-    Service,
-    Partition,
-    Replica,
-    DeployedApplication,
-    DeployedServicePackage
-}
 
 export class ClusterHealth extends HealthBase<IRawClusterHealth> {
 
     //make sure we only check once per session and this object will get destroyed/recreated
     private static certExpirationChecked = false;
-
-    private emptyHealthStateCount: IRawHealthStateCount = {
-        OkCount: 0,
-        ErrorCount: 0,
-        WarningCount: 0
-    };
 
     public constructor(data: DataService,
         protected eventsHealthStateFilter: HealthStateFilterFlags,
@@ -69,16 +54,6 @@ export class ClusterHealth extends HealthBase<IRawClusterHealth> {
         }catch (e) {
             console.log(e);
         }
-    }
-
-    public getHealthStateCount(entityKind: HealthStatisticsEntityKind): IRawHealthStateCount {
-        if (this.raw && this.raw.HealthStatistics) {
-            let entityHealthCount = this.raw.HealthStatistics.HealthStateCountList.find(item => item.EntityKind === HealthStatisticsEntityKind[entityKind]);
-            if (entityHealthCount) {
-                return entityHealthCount.HealthStateCount;
-            }
-        }
-        return this.emptyHealthStateCount;
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/cluster.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/cluster.spec.ts
@@ -1,10 +1,9 @@
 import { DataModelBase } from './Base';
 import { DataService } from 'src/app/services/data.service';
-import { ClusterHealth, HealthStatisticsEntityKind, ClusterManifest, ClusterUpgradeProgress } from './Cluster';
-import { HealthStateFilterFlags } from '../HealthChunkRawDataTypes';
+import { ClusterManifest, ClusterUpgradeProgress } from './Cluster';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { of, Observable } from 'rxjs';
-import { IRawClusterHealth, IRawHealthStateCount, IRawClusterManifest, IRawClusterUpgradeProgress } from '../RawDataTypes';
+import { IRawClusterManifest, IRawClusterUpgradeProgress } from '../RawDataTypes';
 import { RestClientService } from 'src/app/services/rest-client.service';
 
     
@@ -18,122 +17,6 @@ describe('Cluster', () => {
             ensureInitialized: () => of(null)
         }
     } as DataService;
-
-    describe('health', () => {
-        fit('validate getHealthStateCount', async () => {
-            let clusterHealth =  new ClusterHealth(mockDataService, HealthStateFilterFlags.Default, HealthStateFilterFlags.Default, HealthStateFilterFlags.Default);
-    
-            restClientMock.getClusterHealth = (eventsHealthStateFilter:number, 
-                nodesHealthStateFilter:number, 
-                applicationsHealthStateFilter:number,
-                messageHandler?: IResponseMessageHandler): Observable<IRawClusterHealth> => of({
-                     "HealthEvents": [],
-                     "AggregatedHealthState": "Warning",
-                     "UnhealthyEvaluations": [],
-                     "HealthStatistics": {
-                         "HealthStateCountList": [
-                             {
-                                 "EntityKind": "Node",
-                                 "HealthStateCount": {
-                                     "OkCount": 0,
-                                     "ErrorCount": 1,
-                                     "WarningCount": 5
-                                 }
-                             },
-                             {
-                                 "EntityKind": "Replica",
-                                 "HealthStateCount": {
-                                     "OkCount": 41,
-                                     "ErrorCount": 6,
-                                     "WarningCount": 0
-                                 }
-                             },
-                             {
-                                 "EntityKind": "Partition",
-                                 "HealthStateCount": {
-                                     "OkCount": 13,
-                                     "ErrorCount": 5,
-                                     "WarningCount": 0
-                                 }
-                             },
-                             {
-                                 "EntityKind": "Service",
-                                 "HealthStateCount": {
-                                     "OkCount": 4,
-                                     "ErrorCount": 0,
-                                     "WarningCount": 5
-                                 }
-                             },
-                             {
-                                 "EntityKind": "DeployedServicePackage",
-                                 "HealthStateCount": {
-                                     "OkCount": 22,
-                                     "ErrorCount": 0,
-                                     "WarningCount": 0
-                                 }
-                             },
-                             {
-                                 "EntityKind": "DeployedApplication",
-                                 "HealthStateCount": {
-                                     "OkCount": 16,
-                                     "ErrorCount": 0,
-                                     "WarningCount": 0
-                                 }
-                             },
-                             {
-                                 "EntityKind": "Application",
-                                 "HealthStateCount": {
-                                     "OkCount": 0,
-                                     "ErrorCount": 0,
-                                     "WarningCount": 4
-                                 }
-                             }
-                         ]
-                     },
-                     "NodeHealthStates": [],
-                     "ApplicationHealthStates": []
-                    })
-    
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Node)).toEqual({
-                                                                                            OkCount: 0,
-                                                                                            ErrorCount: 0,
-                                                                                            WarningCount: 0})
-    
-            await clusterHealth.ensureInitialized().toPromise();
-            await clusterHealth.refresh().toPromise();
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Node)).toEqual({
-                OkCount: 0,
-                ErrorCount: 1,
-                WarningCount: 5})
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Application)).toEqual({
-                OkCount: 0,
-                ErrorCount: 0,
-                WarningCount: 4})
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Service)).toEqual({
-                OkCount: 4,
-                ErrorCount: 0,
-                WarningCount: 5})
-    
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Partition)).toEqual({
-                OkCount: 13,
-                ErrorCount: 5,
-                WarningCount: 0})
-    
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Replica)).toEqual({
-                OkCount: 41,
-                ErrorCount: 6,
-                WarningCount: 0})
-    
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.DeployedApplication)).toEqual({
-                OkCount: 16,
-                ErrorCount: 0,
-                WarningCount: 0})
-            expect(clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.DeployedServicePackage)).toEqual({
-                OkCount: 22,
-                ErrorCount: 0,
-                WarningCount: 0})
-        })
-    })
 
     describe("manifest", () => {
 

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -99,6 +99,7 @@ import { Node } from './DataModels/Node';
         Name: string;
         ServiceHealthStates: IRawServiceHealthState[];
         DeployedApplicationHealthStates: IRawDeployedApplicationHealthState[];
+        HealthStatistics: IRawHealthStatistics;
     }
 
     export interface IRawApplicationHealthState {
@@ -672,6 +673,7 @@ import { Node } from './DataModels/Node';
     export interface IRawServiceHealth extends IRawHealth {
         Name: string;
         PartitionHealthStates: IRawPartitionHealthState[];
+        HealthStatistics: IRawHealthStatistics;
     }
 
     export interface IRawServiceHealthState {

--- a/src/SfxWeb/src/app/Utils/healthUtils.spec.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.spec.ts
@@ -1,4 +1,4 @@
-import { HealthUtils } from "./healthUtils";
+import { HealthUtils, HealthStatisticsEntityKind } from "./healthUtils";
 import { IRawHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawNodeHealthEvluation, IRawApplicationHealthEvluation, IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation, IRawReplicaHealthEvaluation } from "../Models/RawDataTypes";
 import { DataService } from "../services/data.service";
 import { ApplicationCollection } from "../Models/DataModels/collections/Collections";
@@ -220,4 +220,141 @@ describe('Health Utils', () => {
             });
         })
     });
+
+
+    describe('get health state count', () => {
+        fit('getHealthStateCount valid', async () => {
+            let data = {
+                "HealthEvents": [],
+                "AggregatedHealthState": "Warning",
+                "UnhealthyEvaluations": [],
+                "HealthStatistics": {
+                    "HealthStateCountList": [
+                        {
+                            "EntityKind": "Node",
+                            "HealthStateCount": {
+                                "OkCount": 0,
+                                "ErrorCount": 1,
+                                "WarningCount": 5
+                            }
+                        },
+                        {
+                            "EntityKind": "Replica",
+                            "HealthStateCount": {
+                                "OkCount": 41,
+                                "ErrorCount": 6,
+                                "WarningCount": 0
+                            }
+                        },
+                        {
+                            "EntityKind": "Partition",
+                            "HealthStateCount": {
+                                "OkCount": 13,
+                                "ErrorCount": 5,
+                                "WarningCount": 0
+                            }
+                        },
+                        {
+                            "EntityKind": "Service",
+                            "HealthStateCount": {
+                                "OkCount": 4,
+                                "ErrorCount": 0,
+                                "WarningCount": 5
+                            }
+                        },
+                        {
+                            "EntityKind": "DeployedServicePackage",
+                            "HealthStateCount": {
+                                "OkCount": 22,
+                                "ErrorCount": 0,
+                                "WarningCount": 0
+                            }
+                        },
+                        {
+                            "EntityKind": "DeployedApplication",
+                            "HealthStateCount": {
+                                "OkCount": 16,
+                                "ErrorCount": 0,
+                                "WarningCount": 0
+                            }
+                        },
+                        {
+                            "EntityKind": "Application",
+                            "HealthStateCount": {
+                                "OkCount": 0,
+                                "ErrorCount": 0,
+                                "WarningCount": 4
+                            }
+                        }
+                    ]
+                },
+                "NodeHealthStates": [],
+                "ApplicationHealthStates": []
+               }
+    
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.Node)).toEqual({
+                OkCount: 0,
+                ErrorCount: 1,
+                WarningCount: 5})
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.Application)).toEqual({
+                OkCount: 0,
+                ErrorCount: 0,
+                WarningCount: 4})
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.Service)).toEqual({
+                OkCount: 4,
+                ErrorCount: 0,
+                WarningCount: 5})
+    
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.Partition)).toEqual({
+                OkCount: 13,
+                ErrorCount: 5,
+                WarningCount: 0})
+    
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.Replica)).toEqual({
+                OkCount: 41,
+                ErrorCount: 6,
+                WarningCount: 0})
+    
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.DeployedApplication)).toEqual({
+                OkCount: 16,
+                ErrorCount: 0,
+                WarningCount: 0})
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.DeployedServicePackage)).toEqual({
+                OkCount: 22,
+                ErrorCount: 0,
+                WarningCount: 0})
+
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.DeployedServicePackage)).toEqual({
+                OkCount: 22,
+                ErrorCount: 0,
+                WarningCount: 0})
+        })
+
+        fit('getHealthStateCount queried entity doesnt exist on list', async () => {
+            let data = {
+                "HealthEvents": [],
+                "AggregatedHealthState": "Warning",
+                "UnhealthyEvaluations": [],
+                "HealthStatistics": {
+                    "HealthStateCountList": [
+                        {
+                            "EntityKind": "Application",
+                            "HealthStateCount": {
+                                "OkCount": 0,
+                                "ErrorCount": 0,
+                                "WarningCount": 4
+                            }
+                        }
+                    ]
+                },
+                "NodeHealthStates": [],
+                "ApplicationHealthStates": []
+               }
+
+            expect(HealthUtils.getHealthStateCount(data, HealthStatisticsEntityKind.DeployedServicePackage)).toEqual({
+                OkCount: 0,
+                ErrorCount: 0,
+                WarningCount: 0})
+        })
+    })
 })

--- a/src/SfxWeb/src/app/Utils/healthUtils.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.ts
@@ -1,9 +1,24 @@
 import { IRawUnhealthyEvaluation, IRawHealthEvaluation, IRawNodeHealthEvluation, 
         IRawApplicationHealthEvluation, IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation, 
-        IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation } from '../Models/RawDataTypes';
+        IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation, IRawHealthStateCount } from '../Models/RawDataTypes';
 import { HealthEvaluation } from '../Models/DataModels/Shared';
 import { DataService } from '../services/data.service';
 import { RoutesService } from '../services/routes.service';
+import { ApplicationHealth } from '../Models/DataModels/Application';
+import { ClusterHealth } from '../Models/DataModels/Cluster';
+import { ServiceHealth } from '../Models/DataModels/Service';
+import { ReplicaHealth } from '../Models/DataModels/Replica';
+
+export enum HealthStatisticsEntityKind {
+    Node,
+    Application,
+    Service,
+    Partition,
+    Replica,
+    DeployedApplication,
+    DeployedServicePackage
+}
+
 
 export interface IViewPathData {
     viewPathUrl: string;
@@ -151,5 +166,19 @@ export class HealthUtils {
 
         return {viewPathUrl, 
                 displayName: name };
+    }
+
+    public static getHealthStateCount(data: ApplicationHealth | ClusterHealth | ServiceHealth, entityKind: HealthStatisticsEntityKind): IRawHealthStateCount {
+        if (data.raw && data.raw.HealthStatistics) {
+            let entityHealthCount = data.raw.HealthStatistics.HealthStateCountList.find(item => item.EntityKind === HealthStatisticsEntityKind[entityKind]);
+            if (entityHealthCount) {
+                return entityHealthCount.HealthStateCount;
+            }
+        }
+        return {
+            OkCount: 0,
+            ErrorCount: 0,
+            WarningCount: 0
+        };
     }
 }

--- a/src/SfxWeb/src/app/Utils/healthUtils.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.ts
@@ -1,6 +1,6 @@
 import { IRawUnhealthyEvaluation, IRawHealthEvaluation, IRawNodeHealthEvluation, 
         IRawApplicationHealthEvluation, IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation, 
-        IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation, IRawHealthStateCount } from '../Models/RawDataTypes';
+        IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation, IRawHealthStateCount, IRawApplicationHealth, IRawClusterHealth, IRawServiceHealth } from '../Models/RawDataTypes';
 import { HealthEvaluation } from '../Models/DataModels/Shared';
 import { DataService } from '../services/data.service';
 import { RoutesService } from '../services/routes.service';
@@ -168,9 +168,9 @@ export class HealthUtils {
                 displayName: name };
     }
 
-    public static getHealthStateCount(data: ApplicationHealth | ClusterHealth | ServiceHealth, entityKind: HealthStatisticsEntityKind): IRawHealthStateCount {
-        if (data.raw && data.raw.HealthStatistics) {
-            let entityHealthCount = data.raw.HealthStatistics.HealthStateCountList.find(item => item.EntityKind === HealthStatisticsEntityKind[entityKind]);
+    public static getHealthStateCount(data: IRawApplicationHealth | IRawClusterHealth | IRawServiceHealth, entityKind: HealthStatisticsEntityKind): IRawHealthStateCount {
+        if (data && data.HealthStatistics) {
+            let entityHealthCount = data.HealthStatistics.HealthStateCountList.find(item => item.EntityKind === HealthStatisticsEntityKind[entityKind]);
             if (entityHealthCount) {
                 return entityHealthCount.HealthStateCount;
             }

--- a/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
+++ b/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
@@ -13,6 +13,7 @@ import  isNull  from 'lodash/isNull';
 import  isEmpty  from 'lodash/isEmpty';
 import  isObject  from 'lodash/isObject';
 import  first  from 'lodash/first';
+import { ITextAndBadge } from 'src/app/Utils/ValueResolver';
 
 export class ResolvedObject {
   [index: string]: any;
@@ -153,6 +154,7 @@ export class DetailViewPartComponent implements OnInit, OnChanges {
           } else if (isObject(resolvedValue)) {
               // Deal with badge class as a special case
               if (Utils.isBadge(resolvedValue)) {
+                  resolvedValue = resolvedValue as ITextAndBadge;
                   if (resolvedValue.text && resolvedValue.badgeClass) {
                       resolvedValue = HtmlUtils.getBadgeHtml(resolvedValue);
                   } else {

--- a/src/SfxWeb/src/app/views/application/application.module.ts
+++ b/src/SfxWeb/src/app/views/application/application.module.ts
@@ -16,6 +16,7 @@ import { FormsModule } from '@angular/forms';
 import { NgbTypeaheadModule, NgbDropdownModule, NgbButtonsModule } from '@ng-bootstrap/ng-bootstrap';
 import { ActionRowComponent } from './action-row/action-row.component';
 import { BackupComponent } from './backup/backup.component';
+import { ChartsModule } from 'src/app/modules/charts/charts.module';
 
 @NgModule({
   declarations: [BaseComponent, EssentialsComponent, DetailsComponent, DeploymentsComponent, ManifestComponent, EventsComponent, CreateServiceComponent, ActionRowComponent, BackupComponent],
@@ -28,7 +29,8 @@ import { BackupComponent } from './backup/backup.component';
     FormsModule,
     NgbTypeaheadModule,
     NgbDropdownModule,
-    NgbButtonsModule
+    NgbButtonsModule,
+    ChartsModule
   ]
 })
 export class ApplicationModule { }

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
@@ -57,6 +57,12 @@
   </div>
 </div>
 
+<div>
+  <app-dashboard-tile [data]="servicesDashboard" *ngIf="servicesDashboard"></app-dashboard-tile>
+  <app-dashboard-tile [data]="partitionsDashboard" *ngIf="partitionsDashboard"></app-dashboard-tile>
+  <app-dashboard-tile [data]="replicasDashboard" *ngIf="replicasDashboard"></app-dashboard-tile>
+</div>
+
 <div id="upgradeDetailsSection" *ngIf="upgradeProgress && upgradeProgress.isInitialized" class="detail-pane essen-pane">
     <app-collapse-container [sectionName]="app.isUpgrading ? 'Upgrade In Progress' : 'Latest Upgrade State'">
         <div collapse-header>

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -73,13 +73,13 @@ export class EssentialsComponent extends ApplicationBaseController {
       this.app.serviceTypes.refresh(messageHandler),
       this.app.services.refresh(messageHandler),
       this.app.health.refresh(messageHandler).pipe(map((appHealth: ApplicationHealth) => {
-        let servicesHealthStateCount = HealthUtils.getHealthStateCount(appHealth, HealthStatisticsEntityKind.Service);
+        let servicesHealthStateCount = HealthUtils.getHealthStateCount(appHealth.raw, HealthStatisticsEntityKind.Service);
         this.servicesDashboard = DashboardViewModel.fromHealthStateCount("Services", "Service", false, servicesHealthStateCount);
 
-        let partitionsDashboard = HealthUtils.getHealthStateCount(appHealth, HealthStatisticsEntityKind.Partition);
+        let partitionsDashboard = HealthUtils.getHealthStateCount(appHealth.raw, HealthStatisticsEntityKind.Partition);
         this.partitionsDashboard = DashboardViewModel.fromHealthStateCount("Partitions", "Partition", false, partitionsDashboard);
 
-        let replicasHealthStateCount = HealthUtils.getHealthStateCount(appHealth, HealthStatisticsEntityKind.Replica);
+        let replicasHealthStateCount = HealthUtils.getHealthStateCount(appHealth.raw, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount("Replicas", "Replica", false, replicasHealthStateCount);
       }))
     ]).pipe(map( () => {

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { ClusterUpgradeProgress, ClusterHealth, HealthStatisticsEntityKind } from '../../../Models/DataModels/Cluster';
+import { ClusterUpgradeProgress, ClusterHealth } from '../../../Models/DataModels/Cluster';
 import { HealthStateFilterFlags } from 'src/app/Models/HealthChunkRawDataTypes';
 import { SystemApplication } from 'src/app/Models/DataModels/Application';
 import { Observable, forkJoin, of } from 'rxjs';
@@ -12,6 +12,7 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { map, catchError } from 'rxjs/operators';
 import { IDashboardViewModel, DashboardViewModel } from 'src/app/ViewModels/DashboardViewModels';
 import { RoutesService } from 'src/app/services/routes.service';
+import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUtils';
 
 
 @Component({
@@ -53,19 +54,19 @@ export class EssentialsComponent extends BaseController {
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return forkJoin([
       this.clusterHealth.refresh(messageHandler).pipe(map((clusterHealth: ClusterHealth) => {
-        let nodesHealthStateCount = clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Node);
+        let nodesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth,HealthStatisticsEntityKind.Node);
         this.nodesDashboard = DashboardViewModel.fromHealthStateCount("Nodes", "Node", true, nodesHealthStateCount, this.data.routes, RoutesService.getNodesViewPath());
 
-        let appsHealthStateCount = clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Application);
+        let appsHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Application);
         this.appsDashboard = DashboardViewModel.fromHealthStateCount("Applications", "Application", true, appsHealthStateCount, this.data.routes, RoutesService.getAppsViewPath());
 
-        let servicesHealthStateCount = clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Service);
+        let servicesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Service);
         this.servicesDashboard = DashboardViewModel.fromHealthStateCount("Services", "Service", false, servicesHealthStateCount);
 
-        let partitionsDashboard = clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Partition);
+        let partitionsDashboard = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Partition);
         this.partitionsDashboard = DashboardViewModel.fromHealthStateCount("Partitions", "Partition", false, partitionsDashboard);
 
-        let replicasHealthStateCount = clusterHealth.getHealthStateCount(HealthStatisticsEntityKind.Replica);
+        let replicasHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount("Replicas", "Replica", false, replicasHealthStateCount);
         clusterHealth.checkExpiredCertStatus();
     })),

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
@@ -54,19 +54,19 @@ export class EssentialsComponent extends BaseController {
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return forkJoin([
       this.clusterHealth.refresh(messageHandler).pipe(map((clusterHealth: ClusterHealth) => {
-        let nodesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth,HealthStatisticsEntityKind.Node);
+        let nodesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth.raw,HealthStatisticsEntityKind.Node);
         this.nodesDashboard = DashboardViewModel.fromHealthStateCount("Nodes", "Node", true, nodesHealthStateCount, this.data.routes, RoutesService.getNodesViewPath());
 
-        let appsHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Application);
+        let appsHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth.raw, HealthStatisticsEntityKind.Application);
         this.appsDashboard = DashboardViewModel.fromHealthStateCount("Applications", "Application", true, appsHealthStateCount, this.data.routes, RoutesService.getAppsViewPath());
 
-        let servicesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Service);
+        let servicesHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth.raw, HealthStatisticsEntityKind.Service);
         this.servicesDashboard = DashboardViewModel.fromHealthStateCount("Services", "Service", false, servicesHealthStateCount);
 
-        let partitionsDashboard = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Partition);
+        let partitionsDashboard = HealthUtils.getHealthStateCount(clusterHealth.raw, HealthStatisticsEntityKind.Partition);
         this.partitionsDashboard = DashboardViewModel.fromHealthStateCount("Partitions", "Partition", false, partitionsDashboard);
 
-        let replicasHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth, HealthStatisticsEntityKind.Replica);
+        let replicasHealthStateCount = HealthUtils.getHealthStateCount(clusterHealth.raw, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount("Replicas", "Replica", false, replicasHealthStateCount);
         clusterHealth.checkExpiredCertStatus();
     })),

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.html
@@ -122,6 +122,11 @@
   </div>
 </div>
 
+<div>
+  <app-dashboard-tile [data]="partitionsDashboard" *ngIf="partitionsDashboard"></app-dashboard-tile>
+  <app-dashboard-tile [data]="replicasDashboard" *ngIf="replicasDashboard"></app-dashboard-tile>
+</div>
+
 <div class="detail-pane essen-pane">
   <app-collapse-container sectionName="Unhealthy Evaluations">
     <div collapse-header>

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
@@ -44,10 +44,10 @@ export class EssentialsComponent extends ServiceBaseController {
     return forkJoin([
       this.service.health.refresh(messageHandler).pipe(map((replicaHealth: ServiceHealth) => {
         console.log("test")
-        let partitionsDashboard = HealthUtils.getHealthStateCount(replicaHealth, HealthStatisticsEntityKind.Partition);
+        let partitionsDashboard = HealthUtils.getHealthStateCount(replicaHealth.raw, HealthStatisticsEntityKind.Partition);
         this.partitionsDashboard = DashboardViewModel.fromHealthStateCount("Partitions", "Partition", false, partitionsDashboard);
 
-        let replicasHealthStateCount = HealthUtils.getHealthStateCount(replicaHealth, HealthStatisticsEntityKind.Replica);
+        let replicasHealthStateCount = HealthUtils.getHealthStateCount(replicaHealth.raw, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount("Replicas", "Replica", false, replicasHealthStateCount);
       })),
       this.service.partitions.refresh(messageHandler)

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
@@ -5,6 +5,10 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, forkJoin, of } from 'rxjs';
 import { ServiceBaseController } from '../ServiceBase';
+import { map } from 'rxjs/operators';
+import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUtils';
+import { IDashboardViewModel, DashboardViewModel } from 'src/app/ViewModels/DashboardViewModels';
+import { ServiceHealth } from 'src/app/Models/DataModels/Service';
 
 @Component({
   selector: 'app-essentials',
@@ -15,7 +19,8 @@ export class EssentialsComponent extends ServiceBaseController {
 
   listSettings: ListSettings;
   unhealthyEvaluationsListSettings: ListSettings;
-
+  partitionsDashboard: IDashboardViewModel;
+  replicasDashboard: IDashboardViewModel;
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) { 
     super(data, injector);
@@ -37,7 +42,14 @@ export class EssentialsComponent extends ServiceBaseController {
     this.service.description.refresh(messageHandler).subscribe();
 
     return forkJoin([
-      this.service.health.refresh(messageHandler),
+      this.service.health.refresh(messageHandler).pipe(map((replicaHealth: ServiceHealth) => {
+        console.log("test")
+        let partitionsDashboard = HealthUtils.getHealthStateCount(replicaHealth, HealthStatisticsEntityKind.Partition);
+        this.partitionsDashboard = DashboardViewModel.fromHealthStateCount("Partitions", "Partition", false, partitionsDashboard);
+
+        let replicasHealthStateCount = HealthUtils.getHealthStateCount(replicaHealth, HealthStatisticsEntityKind.Replica);
+        this.replicasDashboard = DashboardViewModel.fromHealthStateCount("Replicas", "Replica", false, replicasHealthStateCount);
+      })),
       this.service.partitions.refresh(messageHandler)
     ]);
   }

--- a/src/SfxWeb/src/app/views/service/service.module.ts
+++ b/src/SfxWeb/src/app/views/service/service.module.ts
@@ -13,6 +13,7 @@ import { EventStoreModule } from 'src/app/modules/event-store/event-store.module
 import { ScaleServiceComponent } from './scale-service/scale-service.component';
 import { BackupComponent } from './backup/backup.component';
 import { FormsModule } from '@angular/forms';
+import { ChartsModule } from 'src/app/modules/charts/charts.module';
 
 
 @NgModule({
@@ -23,7 +24,8 @@ import { FormsModule } from '@angular/forms';
     SharedModule,
     DetailListTemplatesModule,
     EventStoreModule,
-    FormsModule
+    FormsModule,
+    ChartsModule
   ],
   entryComponents: [ScaleServiceComponent]
 })


### PR DESCRIPTION
NOTE: at this time there is not an easy way to obtain deployed applications to provide this at a node level. the node level will likely provide some information but not necessarily health related info as easily due to how the health hierarchy is derived.
![servicetiles](https://user-images.githubusercontent.com/15344718/91346378-9b4ed680-e795-11ea-8963-7741fa9fe7d0.PNG)
![apptiles](https://user-images.githubusercontent.com/15344718/91346381-9be76d00-e795-11ea-87e4-cb6f2fda3df0.PNG)
