### PR TITLE
manual linting fixes

### DIFF
--- a/src/SfxWeb/src/app/Common/StandaloneIntegration.ts
+++ b/src/SfxWeb/src/app/Common/StandaloneIntegration.ts
@@ -3,85 +3,85 @@
 // Licensed under the MIT License. See License file under the project root for license information.
 // -----------------------------------------------------------------------------
 
-export declare namespace Standalone.http {
-    type HttpMethod =
-        'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' |
-        'HEAD' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 
-    interface IHttpHeader {
-        name: string;
-        value: string;
-    }
+type HttpMethod =
+    'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' |
+    'HEAD' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 
-    interface IHttpResponse {
-        httpVersion: string;
-        statusCode: number;
-        statusMessage: string;
-
-        data: any;
-
-        headers: Array<IHttpHeader>;
-        body: Array<number>;
-    }
-
-    interface IHttpRequest {
-        method: HttpMethod;
-        url: string;
-        headers?: Array<IHttpHeader>;
-        body?: any;
-    }
-
-    interface IHttpClient {
-        getRequestTemplateAsync(): Promise<IHttpRequest>;
-
-        setRequestTemplateAsync(template: IHttpRequest): Promise<void>;
-
-        getAsync<T>(url: string): Promise<T>;
-
-        postAsync<T>(url: string, data: any): Promise<T>;
-
-        putAsync<T>(url: string, data: any): Promise<T>;
-
-        patchAsync<T>(url: string, data: any): Promise<T>;
-
-        deleteAsync<T>(url: string): Promise<T>;
-
-        headAsync<T>(url: string): Promise<T>;
-
-        optionsAsync<T>(url: string, data: any): Promise<T>;
-
-        traceAsync<T>(url: string, data: any): Promise<T>;
-
-        requestAsync(request: IHttpRequest): Promise<IHttpResponse>;
-    }
+interface IHttpHeader {
+    name: string;
+    value: string;
 }
+
+interface IHttpResponse {
+    httpVersion: string;
+    statusCode: number;
+    statusMessage: string;
+
+    data: any;
+
+    headers: Array<IHttpHeader>;
+    body: Array<number>;
+}
+
+interface IHttpRequest {
+    method: HttpMethod;
+    url: string;
+    headers?: Array<IHttpHeader>;
+    body?: any;
+}
+
+interface IHttpClient {
+    getRequestTemplateAsync(): Promise<IHttpRequest>;
+
+    setRequestTemplateAsync(template: IHttpRequest): Promise<void>;
+
+    getAsync<T>(url: string): Promise<T>;
+
+    postAsync<T>(url: string, data: any): Promise<T>;
+
+    putAsync<T>(url: string, data: any): Promise<T>;
+
+    patchAsync<T>(url: string, data: any): Promise<T>;
+
+    deleteAsync<T>(url: string): Promise<T>;
+
+    headAsync<T>(url: string): Promise<T>;
+
+    optionsAsync<T>(url: string, data: any): Promise<T>;
+
+    traceAsync<T>(url: string, data: any): Promise<T>;
+
+    requestAsync(request: IHttpRequest): Promise<IHttpResponse>;
+}
+
 
 declare const sfxModuleManager: {
     getComponentAsync<T>(componentIdentity: string, ...extraArgs: Array<any>): Promise<T>;
 };
 
 export class StandaloneIntegration {
-    private static _clusterUrl: string = null;
+    private static iclusterUrl: string = null;
 
     public static isStandalone(): boolean {
         return typeof sfxModuleManager !== 'undefined' && sfxModuleManager !== null;
     }
 
     public static get clusterUrl(): string {
-        if (StandaloneIntegration._clusterUrl == null) {
+        if (StandaloneIntegration.iclusterUrl == null) {
             if (StandaloneIntegration.isStandalone()) {
-                StandaloneIntegration._clusterUrl = StandaloneIntegration.extractQueryItem(window.location.search, 'targetcluster');
+                StandaloneIntegration.iclusterUrl = StandaloneIntegration.extractQueryItem(window.location.search, 'targetcluster');
             } else {
-                StandaloneIntegration._clusterUrl = '';
+                StandaloneIntegration.iclusterUrl = '';
             }
         }
 
-        return StandaloneIntegration._clusterUrl;
+        return StandaloneIntegration.iclusterUrl;
     }
 
-    public static getHttpClient(): Promise<Standalone.http.IHttpClient> {
+    public static getHttpClient(): Promise<IHttpClient> {
         if (this.isStandalone()) {
-            return sfxModuleManager.getComponentAsync<Standalone.http.IHttpClient>('http.http-client.service-fabric');
+            return sfxModuleManager.getComponentAsync<IHttpClient>('http.http-client.service-fabric');
         }
 
         return undefined;
@@ -91,8 +91,8 @@ export class StandaloneIntegration {
         if (queryString) {
             const urlParameters = window.location.search.split('?')[1];
             const queryParams = urlParameters.split('&');
-            for (let i = 0; i < queryParams.length; i++) {
-                const queryParam = queryParams[i].split('=');
+            for (const q of queryParams) {
+                const queryParam = q.split('=');
                 if (queryParam[0] === name) {
                     return decodeURIComponent(queryParam[1]);
                 }

--- a/src/SfxWeb/src/app/Models/Action.ts
+++ b/src/SfxWeb/src/app/Models/Action.ts
@@ -10,14 +10,10 @@ import { ComponentType } from '@angular/cdk/portal';
 // -----------------------------------------------------------------------------
 
 export class Action {
-    private _running: boolean;
-
-    public get running(): boolean {
-        return this._running;
-    }
+    public running: boolean;
 
     public get displayTitle(): string {
-        return this._running ? this.runningTitle : this.title;
+        return this.running ? this.runningTitle : this.title;
     }
 
     constructor(
@@ -28,7 +24,7 @@ export class Action {
         public canRun: () => boolean,
         public isAdvanced: boolean = false) {
 
-        this._running = false;
+        this.running = false;
     }
 
     public run(...params: any[]) {
@@ -42,10 +38,10 @@ export class Action {
     protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
 
         if (this.canRun()) {
-            this._running = true;
+            this.running = true;
             const executing = this.execute();
             return executing.pipe(finalize( () => {
-                this._running = false;
+                this.running = false;
             }));
         }
     }

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -1,4 +1,4 @@
-import { IRawApplication, IRawApplicationHealth, IRawApplicationManifest, IRawDeployedApplicationHealthState, IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo, IRawHealthStateCount } from '../RawDataTypes';
+import { IRawApplication, IRawApplicationHealth, IRawApplicationManifest, IRawDeployedApplicationHealthState, IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo } from '../RawDataTypes';
 import { DataModelBase, IDecorators } from './Base';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
 import { ServiceTypeCollection, ApplicationBackupConfigurationInfoCollection } from './collections/Collections';
@@ -16,7 +16,7 @@ import { map, catchError } from 'rxjs/operators';
 import { HealthUtils } from 'src/app/Utils/healthUtils';
 import { ServiceCollection } from './collections/ServiceCollection';
 import { ActionWithConfirmationDialog, IsolatedAction } from '../Action';
-import   isEmpty from 'lodash/isEmpty';
+import isEmpty from 'lodash/isEmpty';
 import { ViewBackupComponent } from 'src/app/modules/backup-restore/view-backup/view-backup.component';
 import { RoutesService } from 'src/app/services/routes.service';
 // -----------------------------------------------------------------------------
@@ -105,10 +105,6 @@ export class Application extends DataModelBase<IRawApplication> {
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplication> {
         return this.data.restClient.getApplication(this.id, messageHandler);
-    }
-
-    public removeAdvancedActions(): void {
-        this.actions.collection = this.actions.collection.filter(action => ['enableApplicationBackup', 'disableApplicationBackup', 'suspendApplicationBackup', 'suspendApplicationBackup'].indexOf(action.name) === -1);
     }
 
     private setUpActions(): void {
@@ -339,8 +335,8 @@ export class ApplicationBackupConfigurationInfo extends DataModelBase<IRawApplic
             },
             ViewBackupComponent,
             () => true,
-            () => this.data.restClient.getBackupPolicy(this.raw.PolicyName).pipe(map(data => {
-                this.action.data.backup = data;
+            () => this.data.restClient.getBackupPolicy(this.raw.PolicyName).pipe(map(resp => {
+                this.action.data.backup = resp;
             }))
             );
     }

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedApplication.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedApplication.ts
@@ -51,7 +51,7 @@ export class DeployedApplication extends DataModelBase<IRawDeployedApplication> 
     }
 
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IDeployedApplicationHealthStateFilter {
-        let appFilter = clusterHealthChunkQueryDescription.ApplicationFilters.find(appFilter => appFilter.ApplicationNameFilter === this.name);
+        let appFilter = clusterHealthChunkQueryDescription.ApplicationFilters.find(aFilter => aFilter.ApplicationNameFilter === this.name);
         if (!appFilter) {
             // Add one filter for current application and node
             appFilter = {

--- a/src/SfxWeb/src/app/Models/DataModels/ImageStore.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ImageStore.ts
@@ -81,7 +81,7 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
             return;
         }
 
-        return Observable.create(observer => {
+        return new Observable(observer => {
             this.isLoadingFolderContent = true;
             this.loadFolderContent(path).subscribe(raw => {
                 this.setCurrentFolder(path, raw, clearCache);
@@ -179,7 +179,7 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
 
         */
 
-        return Observable.create(observer => {
+        return new Observable(observer => {
             this.data.restClient.getImageStoreContent(path).subscribe(raw => {
                 if (refresh) {
                     this.setCurrentFolder(path, raw, false);

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -235,7 +235,8 @@ export class NodeLoadInformation extends DataModelBase<IRawNodeLoadInformation> 
     }
 
     protected updateInternal(): Observable<any> | void {
-        this.nodeLoadMetricInformation = CollectionUtils.updateDataModelCollection(this.nodeLoadMetricInformation, this.raw.NodeLoadMetricInformation.map(lmi => new NodeLoadMetricInformation(this.data, lmi, this)));
+        this.nodeLoadMetricInformation = CollectionUtils.updateDataModelCollection(this.nodeLoadMetricInformation,
+                                                                                   this.raw.NodeLoadMetricInformation.map(lmi => new NodeLoadMetricInformation(this.data, lmi, this)));
         this.metrics = this.nodeLoadMetricInformation.reduce(
             (obj: Record<string, number>, metricData) => {
                 obj[metricData.name] = +metricData.raw.NodeLoad;

--- a/src/SfxWeb/src/app/Models/DataModels/Partition.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Partition.ts
@@ -54,7 +54,7 @@ export class Partition extends DataModelBase<IRawPartition> {
         return RoutesService.getPartitionViewPath(this.parent.parent.raw.TypeName, this.parent.parent.id, this.parent.id, this.id);
     }
 
-    public get IsStatefulServiceAndSystemService(): Boolean {
+    public get IsStatefulServiceAndSystemService(): boolean {
         return this.isStatefulService && this.parent.parent.raw.TypeName !== 'System';
     }
 

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -1,5 +1,6 @@
 import { DataModelBase, IDecorators } from './Base';
-import { IRawService, IRawUpdateServiceDescription, IRawServiceHealth, IRawServiceDescription, IRawServiceType, IRawServiceManifest, IRawCreateServiceDescription, IRawServiceBackupConfigurationInfo, IRawCreateServiceFromTemplateDescription } from '../RawDataTypes';
+import { IRawService, IRawUpdateServiceDescription, IRawServiceHealth, IRawServiceDescription, IRawServiceType, IRawServiceManifest,
+         IRawCreateServiceDescription, IRawServiceBackupConfigurationInfo, IRawCreateServiceFromTemplateDescription } from '../RawDataTypes';
 import { PartitionCollection, ServiceBackupConfigurationInfoCollection } from './collections/Collections';
 import { DataService } from 'src/app/services/data.service';
 import { HealthStateFilterFlags, IClusterHealthChunkQueryDescription, IServiceHealthStateFilter } from '../HealthChunkRawDataTypes';
@@ -12,8 +13,8 @@ import { Observable, of } from 'rxjs';
 import { HealthBase } from './HealthEvent';
 import { ApplicationType } from './ApplicationType';
 import { mergeMap, map } from 'rxjs/operators';
-import  cloneDeep  from 'lodash/cloneDeep';
-import  escapeRegExp  from 'lodash/escapeRegExp';
+import cloneDeep from 'lodash/cloneDeep';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { ActionWithConfirmationDialog, IsolatedAction } from '../Action';
 import { ScaleServiceComponent } from 'src/app/views/service/scale-service/scale-service.component';
 import { ViewBackupComponent } from 'src/app/modules/backup-restore/view-backup/view-backup.component';
@@ -291,16 +292,19 @@ export class CreateServiceDescription {
         const descriptionCloned = cloneDeep(this.raw);
         let flags = 0;
         if (this.raw.ReplicaRestartWaitDurationSeconds !== null) {
+            // tslint:disable-next-line:no-bitwise
             flags ^= 0x01;
         } else {
             delete descriptionCloned.ReplicaRestartWaitDurationSeconds;
         }
         if (this.raw.QuorumLossWaitDurationSeconds !== null) {
+            // tslint:disable-next-line:no-bitwise
             flags ^= 0x02;
         } else {
             delete descriptionCloned.QuorumLossWaitDurationSeconds;
         }
         if (this.raw.StandByReplicaKeepDurationSeconds !== null) {
+            // tslint:disable-next-line:no-bitwise
             flags ^= 0x04;
         } else {
             delete descriptionCloned.StandByReplicaKeepDurationSeconds;
@@ -447,8 +451,8 @@ export class ServiceBackupConfigurationInfo extends DataModelBase<IRawServiceBac
             },
             ViewBackupComponent,
             () => true,
-            () => this.data.restClient.getBackupPolicy(this.raw.PolicyName).pipe(map(data => {
-                this.action.data.backup = data;
+            () => this.data.restClient.getBackupPolicy(this.raw.PolicyName).pipe(map(resp => {
+                this.action.data.backup = resp;
             }))
             );
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -439,10 +439,10 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
                 this.defaultDateWindowInDays);
         }
 
-        if (!this._startDate || this._startDate.getTime() !== startDate.getTime() ||
-            !this._endDate || this._endDate.getTime() !== endDate.getTime()) {
-            this._startDate = startDate;
-            this._endDate = endDate;
+        if (!this.iStartDate || this.iStartDate.getTime() !== startDate.getTime() ||
+            !this.iEndDate || this.iEndDate.getTime() !== endDate.getTime()) {
+            this.iStartDate = startDate;
+            this.iEndDate = endDate;
             return true;
         }
 

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -1,14 +1,12 @@
-import { IDataModel } from '../Base';
-import { IClusterHealthChunk, IHealthStateChunk, IHealthStateChunkList, IServiceHealthStateChunk, IDeployedApplicationHealthStateChunk, IDeployedServicePackageHealthStateChunk } from '../../HealthChunkRawDataTypes';
+import { IClusterHealthChunk, IDeployedServicePackageHealthStateChunk } from '../../HealthChunkRawDataTypes';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { Observable, Subject, of, throwError, forkJoin } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { ValueResolver, ITextAndBadge } from 'src/app/Utils/ValueResolver';
-import { INodesStatusDetails, NodeStatusDetails, IRawDeployedApplication, IRawDeployedServicePackage } from '../../RawDataTypes';
+import { IRawDeployedServicePackage } from '../../RawDataTypes';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
 import { DataService } from 'src/app/services/data.service';
-import { HealthStateConstants, NodeStatusConstants, StatusWarningLevel, BannerWarningID, Constants } from 'src/app/Common/Constants';
+import { HealthStateConstants } from 'src/app/Common/Constants';
 import { mergeMap, map } from 'rxjs/operators';
-import { Utils } from 'src/app/Utils/Utils';
 import { BackupPolicy } from '../Cluster';
 import { ApplicationBackupConfigurationInfo, Application } from '../Application';
 import { ApplicationTypeGroup, ApplicationType } from '../ApplicationType';
@@ -24,10 +22,8 @@ import { FabricEventBase, FabricEventInstanceModel, ClusterEvent, NodeEvent, App
 import { ListSettings, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingWithEventStoreFullDescription, ListColumnSettingWithEventStoreRowDisplay } from '../../ListSettings';
 import { TimeUtils } from 'src/app/Utils/TimeUtils';
 import { PartitionBackup, PartitionBackupInfo } from '../PartitionBackupInfo';
-
 import { DataModelCollectionBase, IDataModelCollection } from './CollectionBase';
-
-import   groupBy  from 'lodash/groupBy';
+import groupBy from 'lodash/groupBy';
 import { RoutesService } from 'src/app/services/routes.service';
 // -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -241,7 +237,7 @@ export class DeployedServicePackageCollection extends DataModelCollectionBase<De
         const appHealthChunk = clusterHealthChunk.ApplicationHealthStateChunks.Items.find(item => item.ApplicationName === this.parent.name);
         if (appHealthChunk) {
             const deployedAppHealthChunk = appHealthChunk.DeployedApplicationHealthStateChunks.Items.find(
-                deployedAppHealthChunk => deployedAppHealthChunk.NodeName === this.parent.parent.name);
+                deployedAppHealth => deployedAppHealth.NodeName === this.parent.parent.name);
             if (deployedAppHealthChunk) {
                 return this.updateCollectionFromHealthChunkList<IDeployedServicePackageHealthStateChunk>(
                     deployedAppHealthChunk.DeployedServicePackageHealthStateChunks,
@@ -330,14 +326,14 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
     protected readonly optionalColsStartIndex: number = 2;
 
     private lastRefreshTime?: Date;
-    private _startDate: Date;
-    private _endDate: Date;
+    private iStartDate: Date;
+    private iEndDate: Date;
 
     public get startDate() {
-        return new Date(this._startDate.valueOf());
+        return new Date(this.iStartDate.valueOf());
     }
     public get endDate() {
-        let endDate = new Date(this._endDate.valueOf());
+        let endDate = new Date(this.iEndDate.valueOf());
         const timeNow = new Date();
         if (endDate > timeNow) {
             endDate = timeNow;

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -10,7 +10,7 @@ export interface IRepairTaskHistoryPhase {
 
 export interface IDisplayStatus {
     badgeIcon: string;
-    status: String;
+    status: string;
     statusCss: string;
 }
 

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -18,40 +18,40 @@ export class ListSettings {
     public sortPropertyPaths: string[] = [];
     public sortReverse = false;
 
-    private _currentPage = 1;
-    private _itemCount = 0;
+    private iCurrentPage = 1;
+    private iItemCount = 0;
 
     public get count(): number {
-        return this._itemCount;
+        return this.iItemCount;
     }
 
     public set count(itemCount: number) {
-        this._itemCount = itemCount;
+        this.iItemCount = itemCount;
 
         if (this.currentPage > this.pageCount) {
             this.currentPage = this.pageCount;
         }
     }
 
-    public get currentPage(): number {
-        return this._currentPage;
-    }
-
     public get hasEnabledFilters(): boolean {
         return this.columnSettings.some(cs => cs.enableFilter);
     }
 
+    public get currentPage(): number {
+        return this.iCurrentPage;
+    }
+
     public set currentPage(page: number) {
         if (page < 1) {
-            this._currentPage = 1;
+            this.iCurrentPage = 1;
         } else if (page > this.pageCount) {
             if (this.pageCount > 0) {
-                this._currentPage = this.pageCount;
+                this.iCurrentPage = this.pageCount;
             } else {
-                this._currentPage = 1;
+                this.iCurrentPage = 1;
             }
         } else {
-            this._currentPage = page;
+            this.iCurrentPage = page;
         }
     }
 

--- a/src/SfxWeb/src/app/Models/eventstore/Events.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/Events.ts
@@ -19,21 +19,14 @@ export interface IEventPropertiesCollection {
 }
 
 export abstract class FabricEventBase implements IFabricEventMetadata, IEventPropertiesCollection {
-    private _kind: string;
-    private _category?: string;
-    private _eventInstanceId: string;
-    private _timeStamp: string;
-    private _hasCorrelatedEvents?: boolean;
-    private _eventProperties: { [key: string]: any; } = {};
-
+    public hasCorrelatedEvents: boolean;
+    public eventProperties: { [key: string]: any; } = {};
+    public kind: string;
+    public eventInstanceId: string;
+    public timeStamp: string;
+    public category: string;
     public raw: { [key: string]: any; } = {};
-    public get kind() { return this._kind; }
-    public get category() { return this._category; }
-    public get eventInstanceId() { return this._eventInstanceId; }
-    public get timeStamp() { return this._timeStamp; }
-    public get timeStampString() {  return TimeUtils.datetimeToString(this._timeStamp); }
-    public get hasCorrelatedEvents() { return this._hasCorrelatedEvents; }
-    public get eventProperties() { return this._eventProperties; }
+    public get timeStampString() {  return TimeUtils.datetimeToString(this.timeStamp); }
 
     public fillFromJSON(responseItem: any) {
         this.raw = responseItem;
@@ -47,19 +40,19 @@ export abstract class FabricEventBase implements IFabricEventMetadata, IEventPro
     protected extractField(name: string, value: any): boolean {
         switch (name) {
             case 'Kind':
-                this._kind = value;
+                this.kind = value;
                 return true;
             case 'Category':
-                this._category = value;
+                this.category = value;
                 return true;
             case 'EventInstanceId':
-                this._eventInstanceId = value;
+                this.eventInstanceId = value;
                 return true;
             case 'TimeStamp':
-                this._timeStamp = value;
+                this.timeStamp = value;
                 return true;
             case 'HasCorrelatedEvents':
-                this._hasCorrelatedEvents = value;
+                this.hasCorrelatedEvents = value;
                 return true;
             default:
                 break;
@@ -89,9 +82,7 @@ export class ClusterEvent extends FabricEventBase {
 }
 
 export class NodeEvent extends FabricEventBase {
-    private _nodeName: string;
-
-    public get nodeName() { return this._nodeName; }
+    public nodeName: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -100,7 +91,7 @@ export class NodeEvent extends FabricEventBase {
 
         switch (name) {
             case 'NodeName':
-                this._nodeName = value;
+                this.nodeName = value;
                 return true;
             default:
                 break;
@@ -111,9 +102,7 @@ export class NodeEvent extends FabricEventBase {
 }
 
 export class ApplicationEvent extends FabricEventBase {
-    private _applicationId: string;
-
-    public get applicationId() { return this._applicationId; }
+    public applicationId: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -122,7 +111,7 @@ export class ApplicationEvent extends FabricEventBase {
 
         switch (name) {
             case 'ApplicationId':
-                this._applicationId = value;
+                this.applicationId = value;
                 return true;
             default:
                 break;
@@ -133,9 +122,7 @@ export class ApplicationEvent extends FabricEventBase {
 }
 
 export class ServiceEvent extends FabricEventBase {
-    private _serviceId: string;
-
-    public get serviceId() { return this._serviceId; }
+    public serviceId: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -144,7 +131,7 @@ export class ServiceEvent extends FabricEventBase {
 
         switch (name) {
             case 'ServiceId':
-                this._serviceId = value;
+                this.serviceId = value;
                 return true;
             default:
                 break;
@@ -155,9 +142,7 @@ export class ServiceEvent extends FabricEventBase {
 }
 
 export class PartitionEvent extends FabricEventBase {
-    private _partitionId: string;
-
-    public get partitionId() { return this._partitionId; }
+    public partitionId: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -166,7 +151,7 @@ export class PartitionEvent extends FabricEventBase {
 
         switch (name) {
             case 'PartitionId':
-                this._partitionId = value;
+                this.partitionId = value;
                 return true;
             default:
                 break;
@@ -177,11 +162,8 @@ export class PartitionEvent extends FabricEventBase {
 }
 
 export class ReplicaEvent extends FabricEventBase {
-    private _partitionId: string;
-    private _replicaId: string;
-
-    public get partitionId() { return this._partitionId; }
-    public get replicaId() { return this._replicaId; }
+    public partitionId: string;
+    public replicaId: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -190,10 +172,10 @@ export class ReplicaEvent extends FabricEventBase {
 
         switch (name) {
             case 'PartitionId':
-                this._partitionId = value;
+                this.partitionId = value;
                 return true;
             case 'ReplicaId':
-                this._replicaId = value;
+                this.replicaId = value;
                 return true;
             default:
                 break;

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -2,8 +2,8 @@
 
 import { FabricEventBase, ClusterEvent, NodeEvent, ApplicationEvent, FabricEvent } from './Events';
 import { DataSet, DataGroup, DataItem } from 'vis-timeline';
-import  padStart  from 'lodash/padStart';
-import  findIndex  from 'lodash/findIndex';
+import padStart from 'lodash/padStart';
+import findIndex from 'lodash/findIndex';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
 
 /*
@@ -11,12 +11,17 @@ import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
     Reference for understanding the timeline rendering library https://visjs.github.io/vis-timeline/docs/timeline/
     high level concerns:
     Currently there are 2 "versions" of the timeline event generation.
-    1. Applies some level of parsing event/multiple events to create one entry on the timeline. This is currently only used on significant items
-    2. Generically applies all events to the timeline. Some level of customization is available to drive their appearance from information on the event. Currently by adding "Duration", "Status", "Description" properties.
-    Ideally enough flexibility is applied to the generic handling to have all logic driven from there and no needing to update SFX except for updating to look for more fields.
-    To handle the generic approach there is a distinction for what is allowed to "stack" on the graph. Point based events are intended to not be allowed to stack and only let range based events stack for visibility.
-    The current approach for handling this is by adding 2 subgroupStack groups of "stack" and "noStack", where only stack allows for that group to not overlap. This solution works because we dont currently have any
-    subgroups defined otherwise.
+    1. Applies some level of parsing event/multiple events to create one entry on the timeline.
+       This is currently only used on significant items
+    2. Generically applies all events to the timeline. Some level of customization is available to drive their
+        appearance from information on the event. Currently by adding "Duration", "Status", "Description" properties.
+        Ideally enough flexibility is applied to the generic handling to have all logic driven from there and no needing
+        to update SFX except for updating to look for more fields.
+
+        To handle the generic approach there is a distinction for what is allowed to "stack" on the graph.
+        Point based events are intended to not be allowed to stack and only let range based events stack for visibility.
+        The current approach for handling this is by adding 2 subgroupStack groups of "stack" and "noStack", where only stack
+        allows for that group to not overlap. This solution works because we dont currently have any subgroups defined otherwise.
     */
 
 export interface ITimelineData {
@@ -45,10 +50,12 @@ export class EventStoreUtils {
 
         const outline = `<table style="word-break: break-all;"><tbody>${rows}</tbody></table>`;
 
+        // tslint:disable-next-line:max-line-length
         return `<div class="tooltip-test">${title.length > 0 ? title + '<br>' : ''}Start: ${start} <br>${ end ? 'End: ' + end + '<br>' : ''}<b style="text-align: center;">Details</b><br>${outline}</div>`;
     }
 
-    public static parseUpgradeAndRollback(rollbackCompleteEvent: FabricEventBase, rollbackStartedEvent: ClusterEvent, items: DataSet<DataItem>, startOfRange: Date, group: string, targetVersionProperty: string) {
+    public static parseUpgradeAndRollback(rollbackCompleteEvent: FabricEventBase, rollbackStartedEvent: ClusterEvent, items: DataSet<DataItem>,
+                                          startOfRange: Date, group: string, targetVersionProperty: string) {
         const rollbackEnd = rollbackCompleteEvent.timeStamp;
 
         let rollbackStarted = startOfRange.toISOString();
@@ -485,9 +492,6 @@ export class PartitionTimelineGenerator extends TimeLineGeneratorBase<NodeEvent>
  *    Category2
  *       Category2 - kind 1
  *       category2 - kind 2
- * @param event
- * @param groupIds
- * @param query
  */
 function parseAndAddGroupIdByString(event: FabricEvent, groupIds: any, query: string): string {
     const properties = query.split(',');

--- a/src/SfxWeb/src/app/Utils/CollectionUtils.ts
+++ b/src/SfxWeb/src/app/Utils/CollectionUtils.ts
@@ -13,12 +13,6 @@ export class CollectionUtils {
      *  - deleting items which are not in new collection
      *  - update item using update delegate
      *  - add new items using create delegate
-     * @param collection
-     * @param newCollection
-     * @param keySelector
-     * @param newKeySelector
-     * @param create
-     * @param update
      */
     public static updateCollection<T, P>(collection: T[], newCollection: P[],
                                          keySelector: (item: T) => any, newKeySelector: (item: P) => any,
@@ -52,10 +46,6 @@ export class CollectionUtils {
     /**
      * Returns true if the two collections have the same set of keys.
      * Otherwise false.
-     * @param collection
-     * @param newCollection
-     * @param keySelector
-     * @param newKeySelector
      */
     public static compareCollectionsByKeys<T, P>(collection: T[], newCollection: P[],
                                                  keySelector: (item: T) => any, newKeySelector: (item: P) => any) {
@@ -73,11 +63,10 @@ export class CollectionUtils {
 
     /**
      * Update DataModelCollection
-     * @param collection
-     * @param newCollection
      */
     public static updateDataModelCollection<T>(collection: IDataModel<T>[], newCollection: IDataModel<T>[], appendOnly: boolean = false): any[] {
-        return CollectionUtils.updateCollection(collection, newCollection, item => item.uniqueId, item => item.uniqueId, (item, newItem) => newItem, (item, newItem) => item.update(newItem.raw), appendOnly);
+        return CollectionUtils.updateCollection(collection, newCollection, item => item.uniqueId, item => item.uniqueId,
+                                                (item, newItem) => newItem, (item, newItem) => item.update(newItem.raw), appendOnly);
     }
 }
 

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -9,8 +9,6 @@ export class Utils {
 
     /**
      * checks if two arrays have the same primitives;
-     * @param list
-     * @param list2
      */
     public static arraysAreEqual<T>(list: T[], list2: T[]): boolean{
         if (list === null || list === undefined || list2 === null || list2 === undefined){
@@ -21,7 +19,6 @@ export class Utils {
 
     /**
      * Filter all duplicates
-     * @param list
      */
     public static unique<T>(list: T[]): T[]{
         return Array.from(new Set(list));
@@ -33,8 +30,6 @@ export class Utils {
 
     /**
      * implements lodash groupBy in es6. returns a dictionary of lists
-     * @param list
-     * @param key key for value
      */
     public static groupByFunc<T>(list: T[], keyFunction: (T) => string): Record<string, T[]> {
         return list.reduce( (previous, current) => { const key = keyFunction(current);
@@ -49,25 +44,22 @@ export class Utils {
 
     /**
      * implements lodash groupBy in es6. returns a dictionary of lists
-     * @param list
      * @param key key for value
      */
     public static groupBy<T>(list: T[], key: string): Record<string, T[]> {
         return list.reduce( (previous, current) => { previous[key] = (previous[key] || []).push(current) ; return previous; }, {});
     }
 
-        /**
+    /**
      * implements lodash keyBy in es6. returns a dictionary of lists
-     * @param list
      * @param key key for value
      */
     public static keyBy<T>(list: T[], key: string): Record<string, T> {
         return list.reduce( (previous, current) => { previous[current[key]] = current; return previous; }, {});
     }
 
-        /**
+    /**
      * implements lodash keyBy in es6. returns a dictionary of lists
-     * @param list
      * @param keyFunction function to return a key based string for each entry.
      */
     public static keyByFromFunction<T>(list: T[], keyFunction: (T) => string): Record<string, T> {
@@ -77,7 +69,6 @@ export class Utils {
     /**
      * Check if the input value is numeric.
      * Solution comes from http://stackoverflow.com/questions/18082/validate-decimal-numbers-in-javascript-isnumeric
-     * @param value
      */
     public static isNumeric(value: any): boolean {
         return !isNaN(parseFloat(value)) && isFinite(value);
@@ -90,8 +81,6 @@ export class Utils {
      * Lodash version of result does not work here because b and c might
      * be function where _.result only call function when it is the last
      * element in the chain.
-     * @param item
-     * @param propertyPath
      */
     public static result(item: any, propertyPath: string) {
         let value = item;
@@ -107,7 +96,6 @@ export class Utils {
 
     /**
      * Check if a giving object represents a Badge object
-     * @param item
      */
     public static isBadge(item: any) {
         return item && item.hasOwnProperty('text') && item.hasOwnProperty('badgeId');

--- a/src/SfxWeb/src/app/Utils/healthUtils.spec.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.spec.ts
@@ -1,5 +1,6 @@
 import { HealthUtils, HealthStatisticsEntityKind } from './healthUtils';
-import { IRawHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawNodeHealthEvluation, IRawApplicationHealthEvluation, IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation, IRawReplicaHealthEvaluation } from '../Models/RawDataTypes';
+import { IRawHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawNodeHealthEvluation, IRawApplicationHealthEvluation,
+         IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation, IRawReplicaHealthEvaluation } from '../Models/RawDataTypes';
 import { DataService } from '../services/data.service';
 import { ApplicationCollection } from '../Models/DataModels/collections/Collections';
 

--- a/src/SfxWeb/src/app/Utils/healthUtils.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.ts
@@ -1,13 +1,9 @@
-import { IRawUnhealthyEvaluation, IRawHealthEvaluation, IRawNodeHealthEvluation,
-        IRawApplicationHealthEvluation, IRawServiceHealthEvaluation, IRawPartitionHealthEvaluation,
-        IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation, IRawHealthStateCount, IRawApplicationHealth, IRawClusterHealth, IRawServiceHealth } from '../Models/RawDataTypes';
+import { IRawUnhealthyEvaluation, IRawHealthEvaluation, IRawNodeHealthEvluation, IRawApplicationHealthEvluation, IRawServiceHealthEvaluation,
+         IRawPartitionHealthEvaluation, IRawReplicaHealthEvaluation, IRawDeployedServicePackageHealthEvaluation, IRawDeployedApplicationHealthEvaluation,
+         IRawHealthStateCount, IRawApplicationHealth, IRawClusterHealth, IRawServiceHealth } from '../Models/RawDataTypes';
 import { HealthEvaluation } from '../Models/DataModels/Shared';
 import { DataService } from '../services/data.service';
 import { RoutesService } from '../services/routes.service';
-import { ApplicationHealth } from '../Models/DataModels/Application';
-import { ClusterHealth } from '../Models/DataModels/Cluster';
-import { ServiceHealth } from '../Models/DataModels/Service';
-import { ReplicaHealth } from '../Models/DataModels/Replica';
 
 export enum HealthStatisticsEntityKind {
     Node,
@@ -60,9 +56,6 @@ export class HealthUtils {
     /**
      * Generates the url for a healthEvaluation to be able to route to the proper page. Urls are built up by taking the parentUrl and adding the minimum needed to route to this event.
      * Make sure that the application collection is initialized before calling this because for application kinds they make calls to the collection on the dataservice to get apptype.
-     * @param healthEval
-     * @param data
-     * @param parentUrl
      */
     public static getViewPathUrl(healthEval: IRawHealthEvaluation, data: DataService, parentUrl: string = ''): IViewPathData {
         let viewPathUrl = '';

--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -7,7 +7,7 @@ import { RefreshService } from '../services/refresh.service';
 import { MessageService } from '../services/message.service';
 
 @Directive()
-export abstract class BaseController implements  OnInit, OnDestroy {
+export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
     subscriptions: Subscription = new Subscription();
 

--- a/src/SfxWeb/src/app/ViewModels/MetricsViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/MetricsViewModel.ts
@@ -26,15 +26,15 @@ export interface IMetricsViewModel {
 }
 
 export class MetricsViewModel implements IMetricsViewModel {
-    public _showResourceGovernanceMetrics = true;
-    public _showLoadMetrics = true;
-    public _showSystemMetrics = false;
-    public _normalizeMetricsData = true;
+    public iShowResourceGovernanceMetrics = true;
+    public iShowLoadMetrics = true;
+    public iShowSystemMetrics = false;
+    public iNormalizeMetricsData = true;
     public refreshToken = 0;
     public isExpanderEnabled = false;
     public isFullScreen = false;
 
-    private _metrics: LoadMetricInformation[] = null;
+    private iMetrics: LoadMetricInformation[] = null;
 
     private static ensureResourceGovernanceMetrics(metrics: LoadMetricInformation[]): LoadMetricInformation[] {
         let cpuCapacityAvailable = false;
@@ -105,6 +105,7 @@ export class MetricsViewModel implements IMetricsViewModel {
             if (this.selectedMetrics[0].hasCapacity) {
                 // If selected metric has capacity defined only display nodes with non-zero capacity defined or non-zero load reported
                 return this.nodesLoadInformation.filter(nli => {
+                    // tslint:disable-next-line:max-line-length
                     return nli.isInitialized && nli.nodeLoadMetricInformation.some(lmi => this.selectedMetrics.some(m => m.name === lmi.name && (+lmi.raw.NodeCapacity !== -1 || +lmi.raw.NodeLoad > 0)));
                 });
             } else {
@@ -117,11 +118,11 @@ export class MetricsViewModel implements IMetricsViewModel {
     }
 
     public get metrics(): LoadMetricInformation[] {
-        if (this._metrics == null) {
+        if (this.iMetrics == null) {
             // Copy list of metrics and append zero CPU/Memory allocated capacities if info not available
-            this._metrics = MetricsViewModel.ensureResourceGovernanceMetrics(this.clusterLoadInformation.loadMetricInformation);
+            this.iMetrics = MetricsViewModel.ensureResourceGovernanceMetrics(this.clusterLoadInformation.loadMetricInformation);
         }
-        return this._metrics;
+        return this.iMetrics;
     }
 
     public get filteredMetrics(): LoadMetricInformation[] {
@@ -153,33 +154,33 @@ export class MetricsViewModel implements IMetricsViewModel {
     }
 
     public get showResourceGovernanceMetrics(): boolean {
-        return this._showResourceGovernanceMetrics;
+        return this.iShowResourceGovernanceMetrics;
     }
 
     public set showResourceGovernanceMetrics(value: boolean) {
-        this._showResourceGovernanceMetrics = value;
+        this.iShowResourceGovernanceMetrics = value;
         if (!value) {
             this.refresh();
         }
     }
 
     public get showLoadMetrics(): boolean {
-        return this._showLoadMetrics;
+        return this.iShowLoadMetrics;
     }
 
     public set showLoadMetrics(value: boolean) {
-        this._showLoadMetrics = value;
+        this.iShowLoadMetrics = value;
         if (!value) {
             this.refresh();
         }
     }
 
     public get showSystemMetrics(): boolean {
-        return this._showSystemMetrics;
+        return this.iShowSystemMetrics;
     }
 
     public set showSystemMetrics(value: boolean) {
-        this._showSystemMetrics = value;
+        this.iShowSystemMetrics = value;
         if (!value) {
             this.selectedMetrics.forEach(m => {
                 if (m.isSystemMetric) { m.selected = false; }
@@ -190,18 +191,18 @@ export class MetricsViewModel implements IMetricsViewModel {
     }
 
     public get normalizeMetricsData(): boolean {
-        return this._normalizeMetricsData;
+        return this.iNormalizeMetricsData;
     }
 
     public set normalizeMetricsData(value: boolean) {
-        this._normalizeMetricsData = value;
+        this.iNormalizeMetricsData = value;
         this.refresh();
     }
 
     public refresh(): void {
         this.refreshToken = (this.refreshToken + 1) % 10000;
         // Clear copied list of metrics
-        this._metrics = null;
+        this.iMetrics = null;
     }
 
     public toggleMetric(metric: LoadMetricInformation) {

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
@@ -13,7 +13,7 @@ describe('Tree Node', () => {
 
     let child: ITreeNode;
 
-    let parent: null;
+    const parent = null;
     let childQuery: ITreeNode[];
 
     beforeEach((() => {

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
@@ -60,10 +60,10 @@ describe('Tree Node', () => {
         beforeEach(() => {
             node.alwaysVisible = false;
 
-            testNode._tree = {} as TreeViewModel;
-            testNode._tree.showOkItems = false;
-            testNode._tree.showWarningItems = false;
-            testNode._tree.showErrorItems = false;
+            testNode.tree = {} as TreeViewModel;
+            testNode.tree.showOkItems = false;
+            testNode.tree.showWarningItems = false;
+            testNode.tree.showErrorItems = false;
 
             vr =  new ValueResolver();
         });
@@ -84,7 +84,7 @@ describe('Tree Node', () => {
             node.badge = () => vr.resolveHealthStatus('OK');
             testNode.update(node);
             expect(testNode.isVisibleByBadge).toBeFalsy();
-            testNode._tree.showOkItems = true;
+            testNode.tree.showOkItems = true;
             expect(testNode.isVisibleByBadge).toBeTruthy();
         });
 
@@ -94,7 +94,7 @@ describe('Tree Node', () => {
             testNode.update(node);
 
             expect(testNode.isVisibleByBadge).toBeFalsy();
-            testNode._tree.showWarningItems = true;
+            testNode.tree.showWarningItems = true;
             expect(testNode.isVisibleByBadge).toBeTruthy();
         });
 
@@ -104,7 +104,7 @@ describe('Tree Node', () => {
             testNode.update(node);
 
             expect(testNode.isVisibleByBadge).toBeFalsy();
-            testNode._tree.showErrorItems = true;
+            testNode.tree.showErrorItems = true;
             expect(testNode.isVisibleByBadge).toBeTruthy();
         });
 

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -32,16 +32,16 @@ export class TreeNodeGroupViewModel {
         }
     }
 
-    public _tree: TreeViewModel;
+    public tree: TreeViewModel;
     public node: ITreeNode;
-    private _keyboardSelectActionDelayInMilliseconds = 200;
+    private keyboardSelectActionDelayInMilliseconds = 200;
 
     public children: TreeNodeGroupViewModel[] = [];
     public loadingChildren = false;
     public childrenLoaded = false;
 
-    private _isExpanded = false;
-    private _currentGetChildrenPromise: Subject<any>;
+    private IisExpanded = false;
+    private currentGetChildrenPromise: Subject<any>;
 
     public get displayedChildren(): TreeNodeGroupViewModel[] {
         let result = this.children.filter(node => node.isVisibleByBadge);
@@ -58,11 +58,11 @@ export class TreeNodeGroupViewModel {
     }
 
     public get isExpanded(): boolean {
-        return  this._isExpanded && !!this.node.childrenQuery;
+        return  this.IisExpanded && !!this.node.childrenQuery;
     }
 
     public get isCollapsed(): boolean {
-        return !this._isExpanded && this.hasChildren;
+        return !this.IisExpanded && this.hasChildren;
     }
 
     public get paddingLeftPx(): string {
@@ -74,30 +74,34 @@ export class TreeNodeGroupViewModel {
     }
 
     constructor(tree: TreeViewModel, node: ITreeNode, parent: TreeNodeGroupViewModel) {
-        this._tree = tree;
+        this.tree = tree;
         this.node = node;
         this.parent = parent;
         this.listSettings = node.listSettings;
-        this.displayName = node.displayName || function(){ return ''; };
+        if (node.displayName) {
+            this.displayName = node.displayName;
+        }else {
+            this.displayName = () => '';
+        }
         this.update(node);
     }
 
     public toggle(): Observable<any> {
-        this._isExpanded = !this._isExpanded;
-        return this._isExpanded ? this.getChildren() : of(true);
+        this.IisExpanded = !this.IisExpanded;
+        return this.IisExpanded ? this.getChildren() : of(true);
     }
 
     public expand(): Observable<any> {
-        this._isExpanded = true;
+        this.IisExpanded = true;
         return this.getChildren();
     }
 
     public collapse() {
-        this._isExpanded = false;
+        this.IisExpanded = false;
     }
 
     public updateHealthChunkQueryRecursively(healthChunkQueryDescription: IClusterHealthChunkQueryDescription): void {
-        if (!this._isExpanded) {
+        if (!this.IisExpanded) {
             return;
         }
 
@@ -111,7 +115,7 @@ export class TreeNodeGroupViewModel {
     }
 
     public updateDataModelFromHealthChunkRecursively(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
-        if (!this._isExpanded) {
+        if (!this.IisExpanded) {
             return of(true);
         }
 
@@ -126,7 +130,7 @@ export class TreeNodeGroupViewModel {
     }
 
     public refreshExpandedChildrenRecursively(): Observable<any> {
-        if (!this.node.childrenQuery || !this._isExpanded) {
+        if (!this.node.childrenQuery || !this.IisExpanded) {
             return of(true);
         }
 
@@ -136,7 +140,7 @@ export class TreeNodeGroupViewModel {
                 if (response.some(newChild => newChild.nodeId === child.nodeId) ) {
                     filteredChildren.push(child);
                 }else {
-                    if (this._tree.selectedNode && (child === this._tree.selectedNode || child.isParentOf(this._tree.selectedNode))) {
+                    if (this.tree.selectedNode && (child === this.tree.selectedNode || child.isParentOf(this.tree.selectedNode))) {
                         // Select the parent node instead
                         child.parent.select();
                     }
@@ -148,7 +152,7 @@ export class TreeNodeGroupViewModel {
                 if (existingNode) {
                     existingNode.update(child);
                 }else{
-                    filteredChildren.push(new TreeNodeGroupViewModel(this._tree, child, this));
+                    filteredChildren.push(new TreeNodeGroupViewModel(this.tree, child, this));
                 }
             });
 
@@ -163,12 +167,12 @@ export class TreeNodeGroupViewModel {
             return of(true);
         }
 
-        if (!this._currentGetChildrenPromise) {
+        if (!this.currentGetChildrenPromise) {
             this.loadingChildren = true;
-            this._currentGetChildrenPromise = new Subject();
+            this.currentGetChildrenPromise = new Subject();
             this.node.childrenQuery().subscribe(response => {
 
-                this.children = response.map(node => new TreeNodeGroupViewModel(this._tree, node, this));
+                this.children = response.map(node => new TreeNodeGroupViewModel(this.tree, node, this));
                 // Sort the children
                 this.children = orderBy(this.children, item => item.sortBy ? item.sortBy() : []);
 
@@ -178,21 +182,21 @@ export class TreeNodeGroupViewModel {
                     this.node.listSettings.count = this.children.length;
                 }
 
-                this._currentGetChildrenPromise.next();
-                this._currentGetChildrenPromise.complete();
-                this._currentGetChildrenPromise = null;
+                this.currentGetChildrenPromise.next();
+                this.currentGetChildrenPromise.complete();
+                this.currentGetChildrenPromise = null;
                 this.loadingChildren = false;
 
             },
             () => {
-                this._currentGetChildrenPromise.next();
-                this._currentGetChildrenPromise.complete();
-                this._currentGetChildrenPromise = null;
+                this.currentGetChildrenPromise.next();
+                this.currentGetChildrenPromise.complete();
+                this.currentGetChildrenPromise = null;
                 this.loadingChildren = false;
             });
         }
 
-        return this._currentGetChildrenPromise ? this._currentGetChildrenPromise.asObservable() : of(null);
+        return this.currentGetChildrenPromise ? this.currentGetChildrenPromise.asObservable() : of(null);
     }
 
     public get nonRootpaddingLeftPx(): string {
@@ -210,13 +214,13 @@ export class TreeNodeGroupViewModel {
            switch (badgeState.badgeClass) {
                case BadgeConstants.BadgeUnknown:
                case BadgeConstants.BadgeOK:
-                   isVisible = this._tree.showOkItems;
+                   isVisible = this..showOkItems;
                    break;
                case BadgeConstants.BadgeWarning:
-                   isVisible = this._tree.showWarningItems;
+                   isVisible = this.tree.showWarningItems;
                    break;
                case BadgeConstants.BadgeError:
-                   isVisible = this._tree.showErrorItems;
+                   isVisible = this.tree.showErrorItems;
                    break;
                default:
                    break;
@@ -224,7 +228,7 @@ export class TreeNodeGroupViewModel {
        }
 
        if (this.selected && !isVisible) {
-            this._tree.selectTreeNode([IdGenerator.cluster()]);
+            this.tree.selectTreeNode([IdGenerator.cluster()]);
         }
 
        return isVisible;
@@ -240,8 +244,8 @@ export class TreeNodeGroupViewModel {
 
     public get displayHtml(): string {
         const name = this.node.displayName();
-        if (this._tree && this._tree.searchTerm && this._tree.searchTerm.trim()) {
-            const searchTerm = this._tree.searchTerm;
+        if (this.tree && this.tree.searchTerm && this.tree.searchTerm.trim()) {
+            const searchTerm = this.tree.searchTerm;
             const matchIndex = name.toLowerCase().indexOf(searchTerm.toLowerCase());
 
             if (matchIndex !== -1) {
@@ -276,13 +280,13 @@ export class TreeNodeGroupViewModel {
     }
 
     public select(actionDelay?: number, skipSelectAction?: boolean) {
-        if (this._tree.selectNode(this)) {
+        if (this.tree.selectNode(this)) {
             if (this.node.selectAction && !skipSelectAction) {
                 setTimeout(() => {
                     if (this.selected) {
                         this.node.selectAction();
                     }
-                }, actionDelay | 0);
+                }, actionDelay || 0);
             }
         }
     }
@@ -293,7 +297,7 @@ export class TreeNodeGroupViewModel {
 
     public selectNext(actionDelay?: number) {
         if (this.hasExpandedAndLoadedChildren) {
-            this.displayedChildren[0].select(this._keyboardSelectActionDelayInMilliseconds);
+            this.displayedChildren[0].select(this.keyboardSelectActionDelayInMilliseconds);
         } else {
             this.selectNextSibling();
         }
@@ -304,7 +308,7 @@ export class TreeNodeGroupViewModel {
         const myIndex = parentsChildren.indexOf(this);
 
         if (myIndex === 0 && this.parent) {
-            this.parent.select(this._keyboardSelectActionDelayInMilliseconds);
+            this.parent.select(this.keyboardSelectActionDelayInMilliseconds);
         } else if (myIndex !== 0) {
             parentsChildren[myIndex - 1].selectLast();
         }
@@ -324,7 +328,7 @@ export class TreeNodeGroupViewModel {
         if (this.hasChildren && this.isExpanded) {
             this.toggle();
         } else if (this.parent) {
-            this.parent.select(this._keyboardSelectActionDelayInMilliseconds);
+            this.parent.select(this.keyboardSelectActionDelayInMilliseconds);
         }
     }
 
@@ -337,7 +341,7 @@ export class TreeNodeGroupViewModel {
     }
 
     private getParentsChildren(): TreeNodeGroupViewModel[] {
-        return this.parent ? this.parent.displayedChildren : this._tree.childGroupViewModel.displayedChildren;
+        return this.parent ? this.parent.displayedChildren : this.tree.childGroupViewModel.displayedChildren;
     }
 
     private selectLast() {
@@ -345,7 +349,7 @@ export class TreeNodeGroupViewModel {
             const lastChild: TreeNodeGroupViewModel = this.displayedChildren[this.displayedChildren.length - 1];
             lastChild.selectLast();
         } else {
-            this.select(this._keyboardSelectActionDelayInMilliseconds);
+            this.select(this.keyboardSelectActionDelayInMilliseconds);
         }
     }
 
@@ -409,17 +413,17 @@ export class TreeNodeGroupViewModel {
         if (myIndex === parentsChildren.length - 1 && this.parent) {
             this.parent.selectNextSibling();
         } else if (myIndex !== parentsChildren.length - 1) {
-            parentsChildren[myIndex + 1].select(this._keyboardSelectActionDelayInMilliseconds);
+            parentsChildren[myIndex + 1].select(this.keyboardSelectActionDelayInMilliseconds);
         }
         return myIndex;
     }
 
     public get filtered(): number {
-        if (this._tree.searchTerm.length === 0) {
+        if (this.tree.searchTerm.length === 0) {
             return 0;
         }else {
             let count = 0;
-            if (this.displayName().toLowerCase().indexOf(this._tree.searchTerm.toLowerCase()) > -1) {
+            if (this.displayName().toLowerCase().indexOf(this.tree.searchTerm.toLowerCase()) > -1) {
                 count ++;
             }
             this.children.forEach(child => count += child.filtered );

--- a/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
@@ -30,16 +30,16 @@ export class TreeViewModel {
             !this.childGroupViewModel.children.length;
     }
 
-    private _childrenQuery: () => Observable<ITreeNode[]>;
-    private _selectTreeNodeOpId = 1;
+    private childrenQuery: () => Observable<ITreeNode[]>;
+    private selectTreeNodeOpId = 1;
 
     constructor(childrenQuery: () => Observable<ITreeNode[]>) {
-        this._childrenQuery = childrenQuery;
+        this.childrenQuery = childrenQuery;
         this.refreshChildren();
     }
 
     public refreshChildren() {
-        const baseNode: ITreeNode = {childrenQuery: this._childrenQuery,
+        const baseNode: ITreeNode = {childrenQuery: this.childrenQuery,
                                      displayName: () => '',
                                     nodeId: 'base'};
         this.childGroupViewModel = new TreeNodeGroupViewModel(this, baseNode, null);
@@ -71,17 +71,17 @@ export class TreeViewModel {
 
     public onKeyDown(event: KeyboardEvent) {
         const selectedNode = this.selectedNode;
-        switch (event.which) {
-            case 40: // Down
+        switch (event.key) {
+            case '40': // Down
                 this.selectedNode.selectNext();
                 break;
-            case 38: // Up
+            case '38': // Up
                 this.selectedNode.selectPrevious();
                 break;
-            case 39: // Right
+            case '39': // Right
                 this.selectedNode.expandOrMoveToChild();
                 break;
-            case 37: // Left
+            case '37': // Left
                 this.selectedNode.collapseOrMoveToParent();
                 break;
         }
@@ -97,8 +97,8 @@ export class TreeViewModel {
     }
 
     public selectTreeNode(path: string[], skipSelectAction?: boolean): Observable<void> {
-        this._selectTreeNodeOpId++;
-        const opId = this._selectTreeNodeOpId;
+        this.selectTreeNodeOpId++;
+        const opId = this.selectTreeNodeOpId;
         return this.selectTreeNodeInternal(path, 0, this.childGroupViewModel, opId, skipSelectAction);
     }
 
@@ -114,15 +114,15 @@ export class TreeViewModel {
     private selectTreeNodeInternal(path: string[], currIndex: number, group: TreeNodeGroupViewModel, opId: number, skipSelectAction?: boolean): Observable<void> {
         const observ = group.expand();
         observ.subscribe(() => {
-            if (opId !== this._selectTreeNodeOpId) {
+            if (opId !== this.selectTreeNodeOpId) {
                 return;
             }
 
             let node: TreeNodeGroupViewModel = null;
             const nodes = group.children;
-            for (let i = 0; i < nodes.length; i++) {
-                if (nodes[i].nodeId === path[currIndex]) {
-                    node = nodes[i];
+            for (const n of nodes) {
+                if (n.nodeId === path[currIndex]) {
+                    node = n;
                     break;
                 }
             }

--- a/src/SfxWeb/src/app/app-routing.module.ts
+++ b/src/SfxWeb/src/app/app-routing.module.ts
@@ -13,19 +13,29 @@ const routes: Routes = [
 
 
   // node section
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/activationid/:activationId/partition/:partitionId/replica/:replicaId', loadChildren: () => import(`./views/deployed-replica/deployed-replica.module`).then(m => m.DeployedReplicaModule) },
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/partition/:partitionId/replica/:replicaId', loadChildren: () => import(`./views/deployed-replica/deployed-replica.module`).then(m => m.DeployedReplicaModule) },
 
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/activationid/:activationId/replicas', loadChildren: () => import(`./views/deployed-replicas/deployed-replicas.module`).then(m => m.DeployedReplicasModule) },
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/replicas', loadChildren: () => import(`./views/deployed-replicas/deployed-replicas.module`).then(m => m.DeployedReplicasModule) },
 
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/activationid/:activationId/codepackage/:codePackageName', loadChildren: () => import(`./views/deployed-code-package/deployed-code-package.module`).then(m => m.DeployedCodePackageModule) },
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/codepackage/:codePackageName', loadChildren: () => import(`./views/deployed-code-package/deployed-code-package.module`).then(m => m.DeployedCodePackageModule) },
 
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/activationid/:activationId/codepackages', loadChildren: () => import(`./views/deployed-code-packages/deployed-code-packages.module`).then(m => m.DeployedCodePackagesModule) },
+  // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/codepackages', loadChildren: () => import(`./views/deployed-code-packages/deployed-code-packages.module`).then(m => m.DeployedCodePackagesModule) },
 
+    // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId/activationid/:activationId', loadChildren: () => import(`./views/deployed-service-package/deployed-service-package.module`).then(m => m.DeployedServicePackageModule) },
+    // tslint:disable-next-line:max-line-length
   { path: 'node/:nodeName/deployedapp/:appId/deployedservice/:serviceId', loadChildren: () => import(`./views/deployed-service-package/deployed-service-package.module`).then(m => m.DeployedServicePackageModule) },
 
   { path: 'node/:nodeName/deployedapp/:appId', loadChildren: () => import(`./views/deployed-application/deployed-application.module`).then(m => m.DeployedApplicationModule) },

--- a/src/SfxWeb/src/app/app.component.html
+++ b/src/SfxWeb/src/app/app.component.html
@@ -24,8 +24,8 @@
     <!-- push stuff to align right -->
     <div style="margin-left: auto;"></div>
     <div>
-      <app-refresh-rate [value]="refreshService.refreshRate" (onChange)="refreshService.updateRefreshInterval($event)"
-                        [refresh]="refreshService.isRefreshing" (onForceRefresh)="attemptForceRefresh()"></app-refresh-rate>
+      <app-refresh-rate [value]="refreshService.refreshRate" (rateChange)="refreshService.updateRefreshInterval($event)"
+                        [refresh]="refreshService.isRefreshing" (forceRefreshed)="attemptForceRefresh()"></app-refresh-rate>
     </div>
     <app-advanced-option></app-advanced-option>
 
@@ -67,9 +67,9 @@
     </button>
       <div class="left-panel left-bar"  [ngStyle]="{'width': smallScreenSize ? smallScreenLeftPanelWidth : treeWidth }">
           <nav class="tree-container" [attr.aria-hidden]="smallScreenSize ? smallScreenLeftPanelWidth === '0px' : false" role="navigation">
-            <app-tree-view (onTreeSize)="resize($event)" [smallWindowSize]="smallScreenSize"  ></app-tree-view>
+            <app-tree-view (treeResize)="resize($event)" [smallWindowSize]="smallScreenSize"  ></app-tree-view>
           </nav>
-        <div class="slider-bar" appDrag (onDrag)="resize($event)" *ngIf="!smallScreenSize"></div>
+        <div class="slider-bar" appDrag (dragFinish)="resize($event)" *ngIf="!smallScreenSize"></div>
         <div class="slider-bar" style="cursor: initial;" *ngIf="smallScreenSize"></div>
     </div>
     <div [ngStyle]="{'left': smallScreenSize ? '0px' : rightOffset }" class="right-panel main-content" (click)="smallScreenSize ? resize(0): null" (focusin)="smallScreenSize ? resize(0): null">

--- a/src/SfxWeb/src/app/http-interceptor.spec.ts
+++ b/src/SfxWeb/src/app/http-interceptor.spec.ts
@@ -35,8 +35,8 @@ describe('Http interceptors', () => {
                 { provide: AdalService, useValue: adalService }]
         });
 
-        httpMock = TestBed.get(HttpTestingController);
-        httpClient = TestBed.get(HttpClient);
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
     });
 
 

--- a/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, Input, AfterViewInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, Input, AfterViewInit, OnChanges } from '@angular/core';
 import { IDashboardViewModel } from 'src/app/ViewModels/DashboardViewModels';
 import { Chart, Options, chart, PointOptionsObject, SeriesPieOptions } from 'highcharts';
 
@@ -7,7 +7,7 @@ import { Chart, Options, chart, PointOptionsObject, SeriesPieOptions } from 'hig
   templateUrl: './dashboard-tile.component.html',
   styleUrls: ['./dashboard-tile.component.scss']
 })
-export class DashboardTileComponent implements OnInit, AfterViewInit {
+export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges {
 
   @Input() data: IDashboardViewModel;
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -1,10 +1,10 @@
-<div class="app-detail-list-container flex-child" style="margin-top: 15px;">
+<div class="detail-list-container flex-child" style="margin-top: 15px;">
         <app-input [placeholder]="searchText" [model]="listSettings.search" (changed)="listSettings.search = $event; updateList()"></app-input>
         <button class="simple-button"  (click)="resetAll()">Reset All</button>
 
         <label aria-live="off" aria-atomic="true" class="sr-only">There are {{sortedFilteredList.length}} items in the search result    </label>
         <div class="table-responsive">
-            <table class="table app-detail-list">
+            <table class="table detail-list">
                 <thead aria-live="polite">
                     <tr>
                     <th class="sort-filter-th" *ngFor="let columnSetting of listSettings.columnSettings; let i = index"

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -1,10 +1,10 @@
-<div class="detail-list-container flex-child" style="margin-top: 15px;">
-        <app-input [placeholder]="searchText" [model]="listSettings.search" (onChange)="listSettings.search = $event; updateList()"></app-input>
+<div class="app-detail-list-container flex-child" style="margin-top: 15px;">
+        <app-input [placeholder]="searchText" [model]="listSettings.search" (changed)="listSettings.search = $event; updateList()"></app-input>
         <button class="simple-button"  (click)="resetAll()">Reset All</button>
 
         <label aria-live="off" aria-atomic="true" class="sr-only">There are {{sortedFilteredList.length}} items in the search result    </label>
         <div class="table-responsive">
-            <table class="table detail-list">
+            <table class="table app-detail-list">
                 <thead aria-live="polite">
                     <tr>
                     <th class="sort-filter-th" *ngFor="let columnSetting of listSettings.columnSettings; let i = index"

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -1,15 +1,15 @@
 import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ViewChildren, QueryList} from '@angular/core';
 import { ListSettings, ListColumnSetting, FilterValue } from 'src/app/Models/ListSettings';
 import { DataModelCollectionBase } from 'src/app/Models/DataModels/collections/CollectionBase';
-import  fill  from 'lodash/fill';
-import  isEmpty  from 'lodash/isEmpty';
-import  sortBy  from 'lodash/sortBy';
-import  union  from 'lodash/union';
-import  map from 'lodash/map';
-import  filter from 'lodash/filter';
-import  uniq from 'lodash/uniq';
-import  includes from 'lodash/includes';
-import  every from 'lodash/every';
+import fill from 'lodash/fill';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import union from 'lodash/union';
+import map from 'lodash/map';
+import filter from 'lodash/filter';
+import uniq from 'lodash/uniq';
+import includes from 'lodash/includes';
+import every from 'lodash/every';
 
 import { Utils } from 'src/app/Utils/Utils';
 import { Subject, Subscription } from 'rxjs';
@@ -17,7 +17,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 @Component({
-  selector: 'detail-list',
+  selector: 'app-detail-list',
   templateUrl: './detail-list.component.html',
   styleUrls: ['./detail-list.component.scss']
 })
@@ -26,7 +26,9 @@ export class DetailListComponent implements OnInit, OnDestroy {
   @Input() listSettings: ListSettings;
   @Input() searchText = 'Search list';
   @Input() isLoading = false;
-  private _list: any[];
+  @Output() sorted = new EventEmitter<any[]>();
+
+  private iList: any[];
   public sortedFilteredList: any[] = []; // actual list displayed in html.
 
   page = 1;
@@ -41,19 +43,17 @@ export class DetailListComponent implements OnInit, OnDestroy {
   @Input()
   set list(data: any[] | DataModelCollectionBase<any>) {
     if (data instanceof DataModelCollectionBase){
-      data.ensureInitialized().subscribe(data => {
-        this._list = [].concat(data.collection);
+      data.ensureInitialized().subscribe(resp => {
+        this.iList = [].concat(resp.collection);
         this.updateList();
       });
     }else{
-      this._list = data;
+      this.iList = data;
     }
 
-    this._list = this._list || [];
+    this.iList = this.iList || [];
     this.updateList();
   }
-
-  @Output() onSort = new EventEmitter<any[]>();
 
   ngOnInit() {
     this.debouncerHandlerSubscription = this.debounceHandler
@@ -98,7 +98,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   }
 
   private getSortedFilteredList(): any[] {
-    let list = this._list;
+    let list = this.iList;
 
     if (this.listSettings && (this.listSettings.hasEnabledFilters || this.listSettings.search)) {
 
@@ -227,11 +227,11 @@ const sortByProperty = (items: any[], propertyPath: string[], sortReverse: boole
   });
 };
 
-const filterByProperty = (obj: any, filter: string): boolean => {
+const filterByProperty = (obj: any, propFilter: string): boolean => {
   return Object.keys(obj).some(property => {
     if (!property.startsWith('$')){
       const val = obj[property];
-      return (val as string|number|boolean).toString().toLowerCase().includes(filter);
+      return (val as string|number|boolean).toString().toLowerCase().includes(propFilter);
     }
   });
 };

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -59,7 +59,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
     this.debouncerHandlerSubscription = this.debounceHandler
    .pipe(debounceTime(1000), distinctUntilChanged())
    .subscribe(val => {
-      this.onSort.emit(val);
+      this.sorted.emit(val);
    });
   }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-table-resolver/detail-table-resolver.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-table-resolver/detail-table-resolver.component.ts
@@ -24,10 +24,6 @@ export class DetailTableResolverComponent implements OnInit {
     this.loadComponent();
   }
 
-  ngOnDestroy() {
-
-  }
-
   loadComponent() {
 
     const componentFactory = this.componentFactoryResolver.resolveComponentFactory(this.template);

--- a/src/SfxWeb/src/app/modules/event-store/double-slider/double-slider.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/double-slider/double-slider.component.ts
@@ -17,7 +17,7 @@ export class DoubleSliderComponent implements OnChanges, AfterViewInit {
   @Input() startDate: any;
   @Input() endDate: any;
 
-  @Output() onDateChange = new EventEmitter<IOnDateChange>();
+  @Output() dateChanged = new EventEmitter<IOnDateChange>();
 
   slider: noUiSlider;
 

--- a/src/SfxWeb/src/app/modules/event-store/double-slider/double-slider.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/double-slider/double-slider.component.ts
@@ -64,7 +64,7 @@ export class DoubleSliderComponent implements OnChanges, AfterViewInit {
         }
 
         if (changed){
-          this.onDateChange.emit({
+          this.dateChanged.emit({
             endDate: this.endDate,
             startDate: this.startDate
           });

--- a/src/SfxWeb/src/app/modules/event-store/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store-timeline/event-store-timeline.component.ts
@@ -19,12 +19,12 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
 
   public isUTC = false;
 
-  private _timeline: Timeline;
-  private _start: Date;
-  private _end: Date;
-  private _oldestEvent: DataItem;
-  private _mostRecentEvent: DataItem;
-  private _firstEventsSet = true;
+  private timeline: Timeline;
+  private start: Date;
+  private end: Date;
+  private oldestEvent: DataItem;
+  private mostRecentEvent: DataItem;
+  private firstEventsSet = true;
 
   @ViewChild('visualization') container: ElementRef;
 
@@ -32,9 +32,9 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
   constructor() { }
 
   ngOnChanges() {
-    if (this._timeline) {
+    if (this.timeline) {
         this.updateList(this.events);
-        this._firstEventsSet = false;
+        this.firstEventsSet = false;
     }
   }
 
@@ -44,14 +44,14 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
     const items = new DataSet<DataItem>();
 
     // create visualization
-    this._timeline = new Timeline(this.container.nativeElement, items, groups, {
+    this.timeline = new Timeline(this.container.nativeElement, items, groups, {
         locale: 'en_US'
     });
     this.updateList(this.events);
   }
 
   public flipTimeZone() {
-    this._timeline.setOptions({
+    this.timeline.setOptions({
         moment: this.isUTC ? moment : moment.utc
     });
 
@@ -59,54 +59,54 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
   }
 
   public fitData() {
-    this._timeline.fit();
+    this.timeline.fit();
   }
 
   public fitWindow() {
-      this._timeline.setWindow(this._start, this._end);
+      this.timeline.setWindow(this.start, this.end);
   }
 
   public moveStart() {
-      this._timeline.moveTo(this._start);
+      this.timeline.moveTo(this.start);
   }
 
   public moveEnd() {
-      this._timeline.moveTo(this._end);
+      this.timeline.moveTo(this.end);
   }
 
   public moveToOldestEvent() {
-      if (this._oldestEvent) {
-          this._timeline.setWindow(this._oldestEvent.start, this._oldestEvent.end);
+      if (this.oldestEvent) {
+          this.timeline.setWindow(this.oldestEvent.start, this.oldestEvent.end);
       }
   }
 
   public moveToNewestEvent() {
-      if (this._mostRecentEvent) {
-          this._timeline.setWindow(this._mostRecentEvent.start, this._mostRecentEvent.end);
+      if (this.mostRecentEvent) {
+          this.timeline.setWindow(this.mostRecentEvent.start, this.mostRecentEvent.end);
       }
   }
 
     public updateList(events: ITimelineData) {
         if (events.start) {
-            this._timeline.setOptions({
+            this.timeline.setOptions({
                 min: events.start,
             });
-            this._start = events.start;
+            this.start = events.start;
         }
         if (events.end) {
-            this._end = events.end;
-            this._timeline.setOptions({
+            this.end = events.end;
+            this.timeline.setOptions({
                 max: events.end,
             });
         }
 
         if (events) {
-            this._timeline.setData({
+            this.timeline.setData({
                 groups: events.groups,
                 items: events.items
             });
 
-            this._timeline.setOptions({
+            this.timeline.setOptions({
                 selectable: false,
                 margin: {
                     item: {
@@ -120,11 +120,11 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
                 maxHeight: '700px',
                 verticalScroll: true,
                 width: '95%',
-                zoomMin: this._firstEventsSet ? 10800000 : 10
+                zoomMin: this.firstEventsSet ? 10800000 : 10
             });
 
             if (this.fitOnDataChange) {
-                this._timeline.fit();
+                this.timeline.fit();
             }
 
             if (events.items.length > 0) {
@@ -144,13 +144,13 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges {
                         newest = item;
                     }
                 });
-                this._mostRecentEvent = newest;
-                this._oldestEvent = oldest;
+                this.mostRecentEvent = newest;
+                this.oldestEvent = oldest;
             }
         } else {
-            this._mostRecentEvent = null;
-            this._oldestEvent = null;
-            this._timeline.zoomOut(1);
+            this.mostRecentEvent = null;
+            this.oldestEvent = null;
+            this.timeline.zoomOut(1);
         }
     }
 

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -10,12 +10,12 @@
                     </div>
                 </div>
 
-                <app-dual-date-picker [minDate]="startDateMin" [maxDate]="startDateMax" (onDateChange)="setNewDates($event)"
+                <app-dual-date-picker [minDate]="startDateMin" [maxDate]="startDateMax" (dateChanged)="setNewDates($event)"
                 [currentStartDate]="startDate" [currentEndDate]="endDate" ></app-dual-date-picker>    
             </div>
             <div style="min-width: 400px; flex: 1; padding-left: 15px;" >
                 <div style="width: 90%; margin-top: 15px; margin-bottom: 15px;">
-                    <app-double-slider [startDate]="startDate" [endDate]="endDate" (onDateChange)="setNewDates($event)"></app-double-slider>
+                    <app-double-slider [startDate]="startDate" [endDate]="endDate" (dateChanged)="setNewDates($event)"></app-double-slider>
                 </div>
             </div>
         </div>
@@ -30,7 +30,7 @@
             </div>
             <span class="mif-info mif-lg" style="vertical-align: middle; margin-left: 10px;" title="Correlated: Only certain high value scenarios are plotted, created from multiple events.&#010;All: Every event listed is plotted."></span>
             <span *ngIf="dataService.isAdvancedModeEnabled() && showAllEvents">
-                <app-input placeholder="query string" [model]="transformText" (onChange)="transformText = $event;"></app-input>
+                <app-input placeholder="query string" [model]="transformText" (changed)="transformText = $event;"></app-input>
                 <button class="simple-button" (click)="setTimelineData()">filter</button>
             </span>
             <p *ngIf="timeLineEventsData?.potentiallyMissingEvents" style="display: inline-block; margin-left: 10px;">
@@ -43,7 +43,7 @@
             <app-event-store-timeline [events]="timeLineEventsData" ></app-event-store-timeline>
         </div>
 
-        <detail-list [list]="eventsList.collection" [listSettings]="eventsList.settings" [isLoading]="!eventsList.isInitialized"></detail-list>
+        <app-detail-listlist [list]="eventsList.collection" [listSettings]="eventsList.settings" [isLoading]="!eventsList.isInitializedapp-detail-listail-list>
     
         <div>
             <div style="float: right; padding: 15px 0 0 0; margin: 0px;">

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -43,7 +43,7 @@
             <app-event-store-timeline [events]="timeLineEventsData" ></app-event-store-timeline>
         </div>
 
-        <app-detail-listlist [list]="eventsList.collection" [listSettings]="eventsList.settings" [isLoading]="!eventsList.isInitializedapp-detail-listail-list>
+        <app-detail-list [list]="eventsList.collection" [listSettings]="eventsList.settings" [isLoading]="!eventsList.isInitialized"></app-detail-list>
     
         <div>
             <div style="float: right; padding: 15px 0 0 0; margin: 0px;">

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -21,9 +21,9 @@ export class EventStoreComponent implements OnInit, OnDestroy {
 
   constructor(public dataService: DataService) { }
 
-  public get showAllEvents() { return this._showAllEvents; }
+  public get showAllEvents() { return this.pshowAllEvents; }
   public set showAllEvents(state: boolean) {
-      this._showAllEvents = state;
+      this.pshowAllEvents = state;
       this.setTimelineData();
   }
 
@@ -52,13 +52,13 @@ export class EventStoreComponent implements OnInit, OnDestroy {
 
   public transformText = 'Category,Kind';
 
-  private _showAllEvents = false;
+  private pshowAllEvents = false;
 
   public startDate: Date;
   public endDate: Date;
 
   ngOnInit() {
-    this._showAllEvents = !this.timelineGenerator;
+    this.pshowAllEvents = !this.timelineGenerator;
     this.resetSelectionProperties();
     this.setTimelineData();
     this.debouncerHandlerSubscription = this.debounceHandler
@@ -115,7 +115,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   public setTimelineData(): void {
     this.eventsList.ensureInitialized().subscribe( () => {
         try {
-            if (this._showAllEvents) {
+            if (this.pshowAllEvents) {
                 const d = parseEventsGenerically(this.eventsList.collection.map(event => event.raw), this.transformText);
 
                 this.timeLineEventsData = {

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
@@ -37,7 +37,7 @@
                 </span>
             </div>
             <!-- search-text="'Search confined to current directory'" TODO add this input -->
-            <detail-list [list]="imagestoreRoot.currentFolder.allChildren" [listSettings]="fileListSettings"></detail-list>
+            <app-detail-listlistlistlistlistlistlistlist [list]="imagestoreRoot.currentFolder.allChildren" [listSetapp-detail-listail-listail-listail-listail-listail-listail-listail-list>
             <div>
                 <div style="float: right; padding: 15px 0 0 0; margin: 0px;">
                     <span class="mif-info" 

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
@@ -37,7 +37,7 @@
                 </span>
             </div>
             <!-- search-text="'Search confined to current directory'" TODO add this input -->
-            <app-detail-listlistlistlistlistlistlistlist [list]="imagestoreRoot.currentFolder.allChildren" [listSetapp-detail-listail-listail-listail-listail-listail-listail-listail-list>
+            <app-detail-list [list]="imagestoreRoot.currentFolder.allChildren" [listSettings]="fileListSettings"></app-detail-list>	
             <div>
                 <div style="float: right; padding: 15px 0 0 0; margin: 0px;">
                     <span class="mif-info" 

--- a/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.html
@@ -15,7 +15,7 @@
         </div>
     </li>
     <li *ngFor="let child of node.displayedChildren; trackBy: trackById" class="node" [ngClass]="{ 'selected': child.selected }" >
-        <button class="self hide-nested" (click)="child.select()" style="width: 100%; display: flex; align-items: center;" tabindex="0"  (keyup)="node._tree.onKeyDown($event)" role="treeitem" [attr.aria-level]="child.depth" 
+        <button class="self hide-nested" (click)="child.select()" style="width: 100%; display: flex; align-items: center;" tabindex="0"  (keyup)="node.tree.onKeyDown($event)" role="treeitem" [attr.aria-level]="child.depth" 
              [attr.aria-label]="child.displayName()">
             <span  [ngStyle]="{ 'paddingLeft': child.paddingLeftPx }"></span>
             <div class="expander" *ngIf="!child.hasExpander"></div>

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
@@ -18,7 +18,7 @@
             <app-health-badge [badgeClass]="'badge-error'" [text]="'Error'"></app-health-badge>
         </app-check-box>
         <div style="padding: 10px 10px 0px 0px; margin-left: -15px;">
-            <app-input (onChange)="setSearchText($event)"></app-input>
+            <app-input (changed)="setSearchText($event)"></app-input>
         </div>
     </div>
     <div class="tree-list">

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, OnChanges, AfterViewInit, Output, EventEmitter, DoCheck, Input } from '@angular/core';
+import { Component, ViewChild, ElementRef, Output, EventEmitter, DoCheck, Input } from '@angular/core';
 import { TreeService } from 'src/app/services/tree.service';
 import { environment } from 'src/environments/environment';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
@@ -11,7 +11,7 @@ import { LiveAnnouncer } from '@angular/cdk/a11y';
 export class TreeViewComponent implements DoCheck {
 
   @Input() smallWindowSize = false;
-  @Output() onTreeSize = new EventEmitter<number>();
+  @Output() treeResize = new EventEmitter<number>();
 
   public showBeta = environment.showBeta;
   public canExpand = false;
@@ -30,7 +30,7 @@ export class TreeViewComponent implements DoCheck {
   }
 
   setWidth() {
-    this.onTreeSize.emit(this.tree.nativeElement.scrollWidth + 20);
+    this.treeResize.emit(this.tree.nativeElement.scrollWidth + 20);
   }
 
   setSearchText(text: string) {

--- a/src/SfxWeb/src/app/modules/upgrade-progress/partition-info/partition-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/partition-info/partition-info.component.ts
@@ -18,7 +18,8 @@ export class PartitionInfoComponent {
 
   view() {
     this.dataService.getApp(this.partitionInfo.applicationName.Id).subscribe(app => {
-      const routeLocation = () => RoutesService.getPartitionViewPath(app.raw.TypeName, this.partitionInfo.applicationName.Id, this.partitionInfo.serviceName.Id, this.partitionInfo.partition.PartitionInformation.Id);
+      const routeLocation = () => RoutesService.getPartitionViewPath(app.raw.TypeName, this.partitionInfo.applicationName.Id,
+                                                                     this.partitionInfo.serviceName.Id, this.partitionInfo.partition.PartitionInformation.Id);
       this.routeService.navigate(routeLocation);
     });
   }

--- a/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.html
@@ -1,4 +1,4 @@
-<table class="table app-detail-listlistlistlistlistlistlistlistlist" style="width: 100%">
+<table class="table detail-list" style="width: 100%">
     <thead>
     <tr>
         <th>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.html
@@ -1,4 +1,4 @@
-<table class="table detail-list" style="width: 100%">
+<table class="table app-detail-listlistlistlistlistlistlistlistlist" style="width: 100%">
     <thead>
     <tr>
         <th>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core
 import { UpgradeDomain } from 'src/app/Models/DataModels/Shared';
 
 @Component({
-  selector: 'upgrade-progress',
+  selector: 'app-upgrade-progress',
   templateUrl: './upgrade-progress.component.html',
   styleUrls: ['./upgrade-progress.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/SfxWeb/src/app/services/adal.service.spec.ts
+++ b/src/SfxWeb/src/app/services/adal.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-
 import { AdalService } from './adal.service';
 import { RestClientService } from './rest-client.service';
 import { IResponseMessageHandler } from '../Common/ResponseMessageHandlers';
@@ -13,12 +12,12 @@ describe('AdalService', () => {
   }));
 
   fit('should be created', () => {
-    const service: AdalService = TestBed.get(AdalService);
+    const service: AdalService = TestBed.inject(AdalService);
     expect(service).toBeTruthy();
   });
 
   fit('load', async () => {
-    const service: AdalService = TestBed.get(AdalService);
+    const service: AdalService = TestBed.inject(AdalService);
 
     restClientMock.getAADmetadata = (messageHandler: IResponseMessageHandler): Observable<AadMetadata> => {
       return of(new AadMetadata({
@@ -41,7 +40,7 @@ describe('AdalService', () => {
   });
 
   fit('load non aad authed', async () => {
-    const service: AdalService = TestBed.get(AdalService);
+    const service: AdalService = TestBed.inject(AdalService);
 
     restClientMock.getAADmetadata = (messageHandler: IResponseMessageHandler): Observable<AadMetadata> => {
       return of(new AadMetadata({

--- a/src/SfxWeb/src/app/services/adal.service.ts
+++ b/src/SfxWeb/src/app/services/adal.service.ts
@@ -1,13 +1,11 @@
 import { Injectable } from '@angular/core';
-import { DataService } from './data.service';
 import { RestClientService } from './rest-client.service';
 import { Observable, Subscriber, of } from 'rxjs';
 import { retry, map } from 'rxjs/operators';
 import { AadMetadata } from '../Models/DataModels/Aad';
-import * as AuthenticationContext from  'adal-angular';
+import * as AuthenticationContext from 'adal-angular';
 import { adal } from 'adal-angular';
 
-// declare var AuthenticationContext: adal.AuthenticationContextStatic;
 const createAuthContextFn: adal.AuthenticationContextStatic = AuthenticationContext;
 
 export class AdalConfig {

--- a/src/SfxWeb/src/app/services/data.service.spec.ts
+++ b/src/SfxWeb/src/app/services/data.service.spec.ts
@@ -6,7 +6,7 @@ describe('DataService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: DataService = TestBed.get(DataService);
+    const service: DataService = TestBed.inject(DataService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { SystemApplication, Application } from '../Models/DataModels/Application';
-import { ApplicationTypeGroupCollection, ApplicationCollection, BackupPolicyCollection, ServiceTypeCollection, DeployedReplicaCollection, DeployedCodePackageCollection, DeployedServicePackageCollection, ReplicaOnPartitionCollection, PartitionCollection, ClusterEventList, NodeEventList, ApplicationEventList, ServiceEventList, PartitionEventList, ReplicaEventList, CorrelatedEventList } from '../Models/DataModels/collections/Collections';
+import { ApplicationTypeGroupCollection, ApplicationCollection, BackupPolicyCollection, ServiceTypeCollection,
+         DeployedReplicaCollection, DeployedCodePackageCollection, DeployedServicePackageCollection, ReplicaOnPartitionCollection,
+         PartitionCollection, ClusterEventList, NodeEventList, ApplicationEventList, ServiceEventList, PartitionEventList, ReplicaEventList, CorrelatedEventList } from '../Models/DataModels/collections/Collections';
 import { RoutesService } from './routes.service';
 import { MessageService } from './message.service';
 import { TelemetryService } from './telemetry.service';
@@ -214,6 +216,7 @@ export class DataService {
       }));
   }
 
+  // tslint:disable-next-line:max-line-length
   public getReplicaOnPartition(appId: string, serviceId: string, partitionId: string, replicaId: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<ReplicaOnPartition> {
       return this.getReplicasOnPartition(appId, serviceId, partitionId, false, messageHandler).pipe(mergeMap(collection => {
           return this.tryGetValidItem(collection, IdGenerator.replica(replicaId), forceRefresh, messageHandler);
@@ -238,30 +241,35 @@ export class DataService {
       }));
   }
 
+  // tslint:disable-next-line:max-line-length
   public getDeployedServicePackage(nodeName: string, appId: string, servicePackageName: string, servicePackageActivationId: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<DeployedServicePackage> {
       return this.getDeployedServicePackages(nodeName, appId, false, messageHandler).pipe(mergeMap(collection => {
           return this.tryGetValidItem(collection, IdGenerator.deployedServicePackage(servicePackageName, servicePackageActivationId), forceRefresh, messageHandler);
       }));
   }
 
+  // tslint:disable-next-line:max-line-length
   public getDeployedCodePackages(nodeName: string, appId: string, servicePackageName: string, servicePackageActivationId: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<DeployedCodePackageCollection> {
       return this.getDeployedServicePackage(nodeName, appId, servicePackageName, servicePackageActivationId, false, messageHandler).pipe(mergeMap(deployedServicePackage => {
           return deployedServicePackage.deployedCodePackages.ensureInitialized(forceRefresh, messageHandler).pipe(map( () => deployedServicePackage.deployedCodePackages));
       }));
   }
 
+  // tslint:disable-next-line:max-line-length
   public getDeployedCodePackage(nodeName: string, appId: string, servicePackageName: string, servicePackageActivationId: string, codePackageName: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<DeployedCodePackage> {
       return this.getDeployedCodePackages(nodeName, appId, servicePackageName, servicePackageActivationId, false, messageHandler).pipe(mergeMap(collection => {
           return this.tryGetValidItem(collection, IdGenerator.deployedCodePackage(codePackageName), forceRefresh, messageHandler);
       }));
   }
 
+// tslint:disable-next-line:max-line-length
   public getDeployedReplicas(nodeName: string, appId: string, servicePackageName: string, servicePackageActivationId: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<DeployedReplicaCollection> {
       return this.getDeployedServicePackage(nodeName, appId, servicePackageName, servicePackageActivationId, false, messageHandler).pipe(mergeMap(deployedServicePackage => {
           return deployedServicePackage.deployedReplicas.ensureInitialized(forceRefresh, messageHandler).pipe(map( () => deployedServicePackage.deployedReplicas));
       }));
   }
 
+    // tslint:disable-next-line:max-line-length
   public getDeployedReplica(nodeName: string, appId: string, servicePackageName: string, servicePackageActivationId: string, partitionId: string, forceRefresh?: boolean, messageHandler?: IResponseMessageHandler): Observable<DeployedReplica> {
     return this.getDeployedReplicas(nodeName, appId, servicePackageName, servicePackageActivationId, false, messageHandler).pipe(mergeMap(collection => {
         return this.tryGetValidItem(collection, IdGenerator.deployedReplica(partitionId), forceRefresh, messageHandler);

--- a/src/SfxWeb/src/app/services/message.service.spec.ts
+++ b/src/SfxWeb/src/app/services/message.service.spec.ts
@@ -6,7 +6,7 @@ describe('MessageService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: MessageService = TestBed.get(MessageService);
+    const service: MessageService = TestBed.inject(MessageService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/message.service.ts
+++ b/src/SfxWeb/src/app/services/message.service.ts
@@ -23,13 +23,13 @@ export class MessageService {
   static readonly LOCALSTORAGE_KEY_SUPPRES = 'SFX-supress-message';
 
   toasts: IToast[] = [];
-  _suppressMessages = false;
+  private suppressMessagesState = false;
   constructor(private storageService: StorageService) {
     this.suppressMessage = this.storageService.getValueBoolean(MessageService.LOCALSTORAGE_KEY_SUPPRES, false);
   }
 
   remove(toast: IToast) {
-    this.toasts = this.toasts.filter(t => t != toast);
+    this.toasts = this.toasts.filter(t => t !== toast);
   }
 
   getClass(severity: MessageSeverity): string {
@@ -42,12 +42,12 @@ export class MessageService {
   }
 
   public get suppressMessage() {
-    return this._suppressMessages;
+    return this.suppressMessagesState;
   }
 
   public set suppressMessage(b: boolean) {
     this.storageService.setValue(MessageService.LOCALSTORAGE_KEY_SUPPRES, b);
-    this._suppressMessages = b;
+    this.suppressMessagesState = b;
   }
 
   public showMessage(message: string, severity: MessageSeverity, header: string = '', duration: number = 5000) {

--- a/src/SfxWeb/src/app/services/refresh.service.spec.ts
+++ b/src/SfxWeb/src/app/services/refresh.service.spec.ts
@@ -16,13 +16,13 @@ describe('RefreshService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   fit('should be created', () => {
-    const service: RefreshService = TestBed.get(RefreshService);
+    const service: RefreshService = TestBed.inject(RefreshService);
     expect(service).toBeTruthy();
   });
 
 
   fit('add and remove refresh subject', () => {
-    const service: RefreshService = TestBed.get(RefreshService);
+    const service: RefreshService = TestBed.inject(RefreshService);
 
     const keyName = 'test';
     const func = () => of(null);
@@ -38,7 +38,7 @@ describe('RefreshService', () => {
   });
 
   fit('refresh all', async () => {
-    const service: RefreshService = TestBed.get(RefreshService);
+    const service: RefreshService = TestBed.inject(RefreshService);
     let done = false;
     const keyName = 'test';
     const func = () => of(null).pipe(map( () => done = true));
@@ -56,7 +56,7 @@ describe('RefreshService', () => {
   });
 
   fit('refresh withError', async () => {
-    const service: RefreshService = TestBed.get(RefreshService);
+    const service: RefreshService = TestBed.inject(RefreshService);
     const keyName = 'test';
     const func = () =>  throwError('error');
     let done = false;
@@ -76,7 +76,7 @@ describe('RefreshService', () => {
   });
 
   fit('update refresh interval', async () => {
-    const service: RefreshService = TestBed.get(RefreshService);
+    const service: RefreshService = TestBed.inject(RefreshService);
     service.init();
 
     expect(service.refreshRate).toBe('15');

--- a/src/SfxWeb/src/app/services/refresh.service.ts
+++ b/src/SfxWeb/src/app/services/refresh.service.ts
@@ -15,7 +15,7 @@ export class RefreshService {
   private previousRefreshSetting = 0;
 
   private refreshSubjects: (() => Observable<any>)[] = [];
-  private _refreshSubjectsMap: Record<string, () => Observable<any>> = {};
+  private refreshSubjectsMap: Record<string, () => Observable<any>> = {};
 
   constructor(private storage: StorageService) { }
 
@@ -27,23 +27,23 @@ export class RefreshService {
   }
 
   public insertRefreshSubject(key: string, func: () => Observable<any> ) {
-    if (key in this._refreshSubjectsMap) {
+    if (key in this.refreshSubjectsMap) {
       return;
     }
 
-    this._refreshSubjectsMap[key] = func;
+    this.refreshSubjectsMap[key] = func;
     this.refreshSubjects.push(func);
   }
 
   public removeRefreshSubject(key: string) {
-    if (key in this._refreshSubjectsMap) {
-      this.refreshSubjects = this.refreshSubjects.filter( subject => subject !== this._refreshSubjectsMap[key]);
-      delete this._refreshSubjectsMap[key];
+    if (key in this.refreshSubjectsMap) {
+      this.refreshSubjects = this.refreshSubjects.filter( subject => subject !== this.refreshSubjectsMap[key]);
+      delete this.refreshSubjectsMap[key];
     }
   }
 
   public hasRefreshSubject(key: string): boolean {
-    return key in this._refreshSubjectsMap;
+    return key in this.refreshSubjectsMap;
   }
 
   public refreshSubjectCount(): number{

--- a/src/SfxWeb/src/app/services/rest-client.service.spec.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.spec.ts
@@ -6,7 +6,7 @@ describe('RestClientService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: RestClientService = TestBed.get(RestClientService);
+    const service: RestClientService = TestBed.inject(RestClientService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/rest-client.service.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.ts
@@ -1,22 +1,24 @@
 import { Injectable } from '@angular/core';
 import { MessageService, MessageSeverity } from './message.service';
-import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { HealthStateFilterFlags, IClusterHealthChunkQueryDescription } from '../Models/HealthChunkRawDataTypes';
 import { IResponseMessageHandler, ResponseMessageHandlers } from '../Common/ResponseMessageHandlers';
-import { Observable, of, Observer, throwError } from 'rxjs';
-import { IRawCollection, IRawClusterManifest, IRawClusterHealth, IRawClusterUpgradeProgress, IRawClusterLoadInformation, IRawNetwork, IRawNetworkOnApp,
-         IRawNetworkOnNode, IRawAppOnNetwork, IRawNodeOnNetwork, IRawDeployedContainerOnNetwork, IRawNode, IRawBackupPolicy, IRawApplicationBackupConfigurationInfo,
+import { Observable, of, throwError } from 'rxjs';
+import { IRawCollection, IRawClusterManifest, IRawClusterHealth, IRawClusterUpgradeProgress, IRawClusterLoadInformation,
+        IRawDeployedContainerOnNetwork, IRawNode, IRawBackupPolicy, IRawApplicationBackupConfigurationInfo,
          IRawServiceBackupConfigurationInfo, IRawBackupProgressInfo, IRawRestoreProgressInfo, IRawPartitionBackupConfigurationInfo, IRawPartitionBackup, IRawNodeHealth,
          IRawNodeLoadInformation, IRawDeployedApplication, IRawApplicationHealth, IRawDeployedServicePackage, IRawDeployedServicePackageHealth, IRawServiceManifest,
          IRawDeployedReplica, IRawServiceType, IRawDeployedCodePackage, IRawContainerLogs, IRawDeployedReplicaDetail, IRawApplicationType, IRawApplicationManifest,
          IRawApplication, IRawService, IRawCreateServiceDescription, IRawCreateServiceFromTemplateDescription, IRawUpdateServiceDescription, IRawServiceDescription,
          IRawServiceHealth, IRawApplicationUpgradeProgress, IRawCreateComposeDeploymentDescription, IRawPartition, IRawPartitionHealth, IRawPartitionLoadInformation,
-         IRawReplicaOnPartition, IRawReplicaHealth, IRawImageStoreContent, IRawStoreFolderSize, IRawClusterVersion, IRawList, IRawAadMetadataMetadata, IRawAadMetadata, IRawStorage, IRawRepairTask, IRawServiceNameInfo, IRawApplicationNameInfo } from '../Models/RawDataTypes';
+         IRawReplicaOnPartition, IRawReplicaHealth, IRawImageStoreContent, IRawStoreFolderSize, IRawClusterVersion, IRawList, IRawAadMetadata, IRawStorage, IRawRepairTask,
+         IRawServiceNameInfo, IRawApplicationNameInfo } from '../Models/RawDataTypes';
 import { mergeMap, map, catchError } from 'rxjs/operators';
 import { Application } from '../Models/DataModels/Application';
 import { Service } from '../Models/DataModels/Service';
 import { Partition } from '../Models/DataModels/Partition';
-import { ClusterEvent, NodeEvent, ApplicationEvent, ServiceEvent, PartitionEvent, ReplicaEvent, FabricEvent, EventsResponseAdapter, FabricEventBase } from '../Models/eventstore/Events';
+import { ClusterEvent, NodeEvent, ApplicationEvent, ServiceEvent, PartitionEvent, ReplicaEvent,
+         FabricEvent, EventsResponseAdapter, FabricEventBase } from '../Models/eventstore/Events';
 import { StandaloneIntegration } from '../Common/StandaloneIntegration';
 import { AadMetadata } from '../Models/DataModels/Aad';
 import { environment } from 'src/environments/environment';
@@ -121,11 +123,13 @@ export class RestClientService {
   }
 
   public getLatestPartitionBackup(partitionId: string, messageHandler?: IResponseMessageHandler): Observable<IRawPartitionBackup[]> {
-      return this.getFullCollection2<IRawPartitionBackup>('Partitions/' + encodeURIComponent(partitionId) + '/$/GetBackups', 'Gets the latest partition backup', RestClientService.apiVersion64, messageHandler, undefined, undefined, undefined, undefined, true);
+      return this.getFullCollection2<IRawPartitionBackup>('Partitions/' + encodeURIComponent(partitionId) + '/$/GetBackups', 'Gets the latest partition backup',
+                                                          RestClientService.apiVersion64, messageHandler, undefined, undefined, undefined, undefined, true);
   }
 
   public getPartitionBackupList(partitionId: string, messageHandler?: IResponseMessageHandler, startDate?: Date, endDate?: Date, maxResults?: number): Observable<IRawPartitionBackup[]> {
-      return this.getFullCollection2<IRawPartitionBackup>('Partitions/' + encodeURIComponent(partitionId) + '/$/GetBackups', 'Gets the partition backup list', RestClientService.apiVersion64, messageHandler, undefined, startDate, endDate, maxResults);
+      return this.getFullCollection2<IRawPartitionBackup>('Partitions/' + encodeURIComponent(partitionId) + '/$/GetBackups', 'Gets the partition backup list', RestClientService.apiVersion64,
+                                                          messageHandler, undefined, startDate, endDate, maxResults);
   }
 
   public getBackupPolicy(backupName: string, messageHandler?: IResponseMessageHandler): Observable<IRawBackupPolicy> {
@@ -252,6 +256,8 @@ export class RestClientService {
       return this.get(formedUrl, 'Get deployed code packages', messageHandler);
   }
 
+
+// tslint:disable-next-line:max-line-length
   public getDeployedCodePackage(nodeName: string, applicationId: string, servicePackageName: string, codePackageName: string, messageHandler?: IResponseMessageHandler): Observable<IRawDeployedCodePackage[]> {
       const url = 'Nodes/' + encodeURIComponent(nodeName)
           + '/$/GetApplications/' + encodeURIComponent(applicationId)
@@ -264,6 +270,7 @@ export class RestClientService {
       return this.get(formedUrl, 'Get deployed code package', messageHandler);
   }
 
+// tslint:disable-next-line:max-line-length
   public getDeployedContainerLogs(nodeName: string, applicationId: string, servicePackageName: string, codePackageName: string, servicePackageActivationId: string, tail: string, messageHandler?: IResponseMessageHandler): Observable<IRawContainerLogs> {
       const url = 'Nodes/' + encodeURIComponent(nodeName)
           + '/$/GetApplications/' + encodeURIComponent(applicationId)
@@ -279,6 +286,7 @@ export class RestClientService {
       return this.get(formedUrl, 'Get deployed container logs', messageHandler);
   }
 
+    // tslint:disable-next-line:max-line-length
   public restartCodePackage(nodeName: string, applicationId: string, serviceManifestName: string, codePackageName: string, codePackageInstanceId: string, servicePackageActivationId?: string, messageHandler?: IResponseMessageHandler): Observable<{}> {
       const url = 'Nodes/' + encodeURIComponent(nodeName)
           + '/$/GetApplications/' + encodeURIComponent(applicationId)
@@ -736,7 +744,7 @@ export class RestClientService {
   }
 
   public getRepairTasks(messageHandler?: IResponseMessageHandler): Observable<IRawRepairTask[]> {
-        const url = `$/GetRepairTaskList`; // additional filters available but not in use. keeping here incase they are needed ?StateFilter=${stateFilter}&TaskIdFilter=${taskIdFilter}&ExecutorFilter=${ExecutorFilter}
+        const url = `$/GetRepairTaskList`;
 
         return this.get(this.getApiUrl(url, RestClientService.apiVersion60), 'Get repair tasks', messageHandler);
     }
@@ -778,11 +786,12 @@ export class RestClientService {
           `/${path}${path.indexOf('?') === -1 ? '?' : '&'}api-version=${apiVersion ? apiVersion : RestClientService.defaultApiVersion}${skipCacheToken === true ? '' : `&_cacheToken=${this.cacheAllowanceToken}`}${continuationToken ? `&ContinuationToken=${continuationToken}` : ''}`;
   }
 
+  // tslint:disable-next-line:max-line-length
   private getApiUrl2(path: string, apiVersion = RestClientService.defaultApiVersion, continuationToken?: string, skipCacheToken?: boolean, startDate?: Date, endDate?: Date, maxResults?: number, latest?: boolean): string {
       // token to allow for invalidation of browser api call cache
       const appUrl =  this.getApiUrl(path, apiVersion, continuationToken, false);
-      return appUrl +
-          `${maxResults === undefined || maxResults === null ? '' : `&MaxResults=${maxResults}`}${(startDate === undefined || startDate === null || endDate === undefined || endDate === null) ? '' : `&StartDateTimeFilter=${startDate.toISOString().substr(0, 19)}Z&EndDateTimeFilter=${endDate.toISOString().substr(0, 19)}Z`}${latest === true ? `&Latest=True` : ''}`;
+          // tslint:disable-next-line:max-line-length
+      return appUrl + `${maxResults === undefined || maxResults === null ? '' : `&MaxResults=${maxResults}`}${(startDate === undefined || startDate === null || endDate === undefined || endDate === null) ? '' : `&StartDateTimeFilter=${startDate.toISOString().substr(0, 19)}Z&EndDateTimeFilter=${endDate.toISOString().substr(0, 19)}Z`}${latest === true ? `&Latest=True` : ''}`;
   }
 
   private getFullCollection<T>(url: string, apiDesc: string, apiVersion?: string, messageHandler?: IResponseMessageHandler, continuationToken?: string): Observable<T[]> {
@@ -801,18 +810,18 @@ export class RestClientService {
 
   }
 
+    // tslint:disable-next-line:max-line-length
   private getFullCollection2<T>(url: string, apiDesc: string, apiVersion?: string, messageHandler?: IResponseMessageHandler, continuationToken?: string, startDate?: Date, endDate?: Date, maxResults?: number, latest?: boolean): Observable<T[]> {
       const appUrl = this.getApiUrl2(url, apiVersion, continuationToken, false, startDate, endDate, maxResults, latest);
       return this.get<IRawCollection<T>>(appUrl, apiDesc, messageHandler).pipe(mergeMap(response => {
           if (response.ContinuationToken) {
               return this.getFullCollection<T>(url, apiDesc, apiVersion, messageHandler, response.ContinuationToken).pipe(map(items => {
-                  return of(response.Items.concat(items));
+                  return response.Items.concat(items);
               }));
+          }else{
+            return of(response.Items);
           }
-          return of(response.Items);
-        }, err => {
-          return [];
-      }));
+        }));
   }
 
   private get<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler): Observable<T> {

--- a/src/SfxWeb/src/app/services/routes.service.spec.ts
+++ b/src/SfxWeb/src/app/services/routes.service.spec.ts
@@ -27,8 +27,8 @@ describe('RoutesService', () => {
       declarations: [AppComponent]
     });
 
-    router = TestBed.get(Router);
-    location = TestBed.get(Location);
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
 
     fixture = TestBed.createComponent(AppComponent);
     router.initialNavigation();
@@ -36,12 +36,12 @@ describe('RoutesService', () => {
 
 
   fit('should be created', () => {
-    const service: RoutesService = TestBed.get(RoutesService);
+    const service: RoutesService = TestBed.inject(RoutesService);
     expect(service).toBeTruthy();
   });
 
   fit('start on nondefault route of entity and view different entity of same type (redirect)', async () => {
-    const service: RoutesService = TestBed.get(RoutesService);
+    const service: RoutesService = TestBed.inject(RoutesService);
 
     await router.navigate(['/node/node1/details']);
     expect(location.path()).toBe('/node/node1/details');
@@ -56,7 +56,7 @@ describe('RoutesService', () => {
   });
 
   fit('route to different view and back (no redirect)', async () => {
-    const service: RoutesService = TestBed.get(RoutesService);
+    const service: RoutesService = TestBed.inject(RoutesService);
 
     await router.navigate(['/node/node1/details']);
     expect(location.path()).toBe('/node/node1/details');
@@ -72,7 +72,7 @@ describe('RoutesService', () => {
 
 
   fit('route to different subpage. (no redirect)', async () => {
-    const service: RoutesService = TestBed.get(RoutesService);
+    const service: RoutesService = TestBed.inject(RoutesService);
 
     await router.navigate(['/node/node1/details']);
     expect(location.path()).toBe('/node/node1/details');
@@ -87,7 +87,7 @@ describe('RoutesService', () => {
   });
 
   fit('route to default page of same entity type (no redirect)', async () => {
-    const service: RoutesService = TestBed.get(RoutesService);
+    const service: RoutesService = TestBed.inject(RoutesService);
 
     await router.navigate(['/node/node1']);
     expect(location.path()).toBe('/node/node1');

--- a/src/SfxWeb/src/app/services/routes.service.testData.ts
+++ b/src/SfxWeb/src/app/services/routes.service.testData.ts
@@ -32,27 +32,27 @@ export class ApplicationModule { }
 @Component({
     template: `Search`
 })
-export class SearchComponent2 {}
+export class Search2Component {}
 
 @Component({
     template: `Home`
 })
-export class HomeComponent2 {}
+export class Home2Component {}
 
 @Component({
     template: `<router-outlet></router-outlet>`
   })
-export class NestedComponent2 {}
+export class Nested2Component {}
 
 const routes2: Routes = [{
-    path: '', component: NestedComponent2, children: [
-        { path: '', component: HomeComponent2 },
-        { path: 'details', component: SearchComponent2 }
+    path: '', component: Nested2Component, children: [
+        { path: '', component: Home2Component },
+        { path: 'details', component: Search2Component }
       ]
     }];
 
 @NgModule({
-    declarations: [SearchComponent2, HomeComponent2, NestedComponent2],
+    declarations: [Search2Component, Home2Component, Nested2Component],
     imports: [RouterModule.forChild(routes2)]
 })
 export class ApplicationModule2 { }

--- a/src/SfxWeb/src/app/services/routes.service.ts
+++ b/src/SfxWeb/src/app/services/routes.service.ts
@@ -61,7 +61,7 @@ export class RoutesService {
     });
    }
 
-  private static _forceSingleEncode = true;
+  private static singleEncode = true;
 
 // keep track of previous states to know when we changed
   private previouslastPaths = [];
@@ -125,7 +125,8 @@ export class RoutesService {
   }
 
   public static getDeployedReplicaViewPath(nodeName: string, appId: string, serviceId: string, activationId: string, partitionId: string, replicaId: string): string {
-      // A partition with a node/app/service is enough to uniquely identify a Replica.  A replicaId is NOT enough to identify a replica.  However, the replicaId is still used in displaying information.
+      // A partition with a node/app/service is enough to uniquely identify a Replica.
+      // A replicaId is NOT enough to identify a replica.  However, the replicaId is still used in displaying information.
       return '/node/' + this.doubleEncode(nodeName) + '/deployedapp/' + this.doubleEncode(appId) +
           '/deployedservice/' + this.doubleEncode(serviceId) +
           (activationId ? '/activationid/' + this.doubleEncode(activationId) : '') +
@@ -164,11 +165,11 @@ export class RoutesService {
 
   // Double encode may be necessary because the browser automatically decodes the token before we have access to it
   public static doubleEncode(str: string): string {
-      return RoutesService._forceSingleEncode ? encodeURIComponent(str) : encodeURIComponent(encodeURIComponent(str));
+      return RoutesService.singleEncode ? encodeURIComponent(str) : encodeURIComponent(encodeURIComponent(str));
   }
 
   private static forceSingleEncode(force: boolean) {
-    RoutesService._forceSingleEncode = force;
+    RoutesService.singleEncode = force;
   }
 
    getPathData(snapshot: ActivatedRouteSnapshot): { params: {}, pathPostFix: string, lastPaths: Component[] } {

--- a/src/SfxWeb/src/app/services/settings.service.spec.ts
+++ b/src/SfxWeb/src/app/services/settings.service.spec.ts
@@ -6,7 +6,7 @@ describe('SettingsService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: SettingsService = TestBed.get(SettingsService);
+    const service: SettingsService = TestBed.inject(SettingsService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { ListColumnSetting, ListSettings, ListColumnSettingForBadge, ListColumnSettingForLink, ListColumnSettingWithCopyText, ListColumnSettingWithUtcTime } from '../Models/ListSettings';
-import { HtmlUtils } from '../Utils/HtmlUtils';
 import { NodeStatusConstants, Constants } from '../Common/Constants';
 import { ClusterLoadInformation } from '../Models/DataModels/Cluster';
 import { NodeLoadInformation } from '../Models/DataModels/Node';
-import { IMetricsViewModel, MetricsViewModel } from '../ViewModels/MetricsViewModel';
+import { MetricsViewModel } from '../ViewModels/MetricsViewModel';
 import { StorageService } from './storage.service';
 
 @Injectable({
@@ -12,11 +11,11 @@ import { StorageService } from './storage.service';
 })
 export class SettingsService {
   private listSettings: Record<string, ListSettings>;
-  private _paginationLimit: number;
-  private _metricsViewModel: MetricsViewModel;
+  private iPaginationLimit: number;
+  private iMetricsViewModel: MetricsViewModel;
 
   public get paginationLimit(): number {
-      return this._paginationLimit;
+      return this.iPaginationLimit;
   }
 
   public set paginationLimit(limit: number) {
@@ -28,21 +27,21 @@ export class SettingsService {
       } else if (limit > Constants.PaginationLimitMax) {
           limit = Constants.PaginationLimitMax;
       }
-      this._paginationLimit = limit;
+      this.iPaginationLimit = limit;
       this.storage.setValue(Constants.PaginationLimitStorageKey, limit);
       this.updatePaginationLimit(limit);
   }
 
   public constructor(private storage: StorageService) {
       this.listSettings = {};
-      this._paginationLimit = storage.getValueNumber(Constants.PaginationLimitStorageKey, Constants.DefaultPaginationLimit);
+      this.iPaginationLimit = storage.getValueNumber(Constants.PaginationLimitStorageKey, Constants.DefaultPaginationLimit);
   }
 
   public getNewOrExistingMetricsViewModel(clusterLoadInformation: ClusterLoadInformation, nodesLoadInformation: NodeLoadInformation[]): MetricsViewModel {
-      if (!this._metricsViewModel) {
-          this._metricsViewModel = new MetricsViewModel(clusterLoadInformation, nodesLoadInformation);
+      if (!this.iMetricsViewModel) {
+          this.iMetricsViewModel = new MetricsViewModel(clusterLoadInformation, nodesLoadInformation);
       }
-      return this._metricsViewModel;
+      return this.iMetricsViewModel;
   }
 
   public getNewOrExistingListSettings(

--- a/src/SfxWeb/src/app/services/status-warning.service.spec.ts
+++ b/src/SfxWeb/src/app/services/status-warning.service.spec.ts
@@ -6,7 +6,7 @@ describe('StatusWarningService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: StatusWarningService = TestBed.get(StatusWarningService);
+    const service: StatusWarningService = TestBed.inject(StatusWarningService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/storage.service.spec.ts
+++ b/src/SfxWeb/src/app/services/storage.service.spec.ts
@@ -6,7 +6,7 @@ describe('StorageService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: StorageService = TestBed.get(StorageService);
+    const service: StorageService = TestBed.inject(StorageService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/telemetry.service.spec.ts
+++ b/src/SfxWeb/src/app/services/telemetry.service.spec.ts
@@ -6,7 +6,7 @@ describe('TelemetryService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: TelemetryService = TestBed.get(TelemetryService);
+    const service: TelemetryService = TestBed.inject(TelemetryService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/tree.service.spec.ts
+++ b/src/SfxWeb/src/app/services/tree.service.spec.ts
@@ -6,7 +6,7 @@ describe('TreeService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: TreeService = TestBed.get(TreeService);
+    const service: TreeService = TestBed.inject(TreeService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -302,7 +302,8 @@ export class TreeService {
             }));
         }
 
-        private getDeployedCodePackages(deployedCodePackages: DeployedCodePackageCollection, nodeName: string, applicationId: string, servicePackageName: string, servicePackageActivationId: string): Observable<ITreeNode[]> {
+        private getDeployedCodePackages(deployedCodePackages: DeployedCodePackageCollection, nodeName: string, applicationId: string,
+                                        servicePackageName: string, servicePackageActivationId: string): Observable<ITreeNode[]> {
             return of(deployedCodePackages.collection.map(codePackage => {
                 return {
                     nodeId: IdGenerator.deployedCodePackage(codePackage.name),
@@ -314,7 +315,8 @@ export class TreeService {
             }));
         }
 
-        private getDeployedReplicas(deployedReplicas: DeployedReplicaCollection, nodeName: string, applicationId: string, servicePackageName: string, servicePackageActivationId: string): Observable<ITreeNode[]> {
+        private getDeployedReplicas(deployedReplicas: DeployedReplicaCollection, nodeName: string, applicationId: string,
+                                    servicePackageName: string, servicePackageActivationId: string): Observable<ITreeNode[]> {
             return of(deployedReplicas.collection.map(replica => {
                 return {
                     nodeId: IdGenerator.deployedReplica(replica.raw.PartitionId),

--- a/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
+++ b/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, HostListener, Injector } from '@angular/core';
 import { ClusterUpgradeProgress } from 'src/app/Models/DataModels/Cluster';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
   templateUrl: './cluster-upgrade-banner.component.html',
   styleUrls: ['./cluster-upgrade-banner.component.scss']
 })
-export class ClusterUpgradeBannerComponent extends BaseController {
+export class ClusterUpgradeBannerComponent extends BaseControllerDirective implements OnInit {
 
   displayMiddleText = true;
   displayAllText = true;

--- a/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.html
+++ b/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.html
@@ -1,6 +1,6 @@
 <div class="table-responsive">
     <div *ngIf="resolvedData">
-        <table class="table detail-table detail-list" [ngClass]="{ 'table-layout-fixed': !noFixedLayout }">
+        <table class="table detail-table app-detail-listlistlistlistlistlistlistlist" [ngClass]="{ 'table-layout-fixed': !noFixedLayout }">
             <tbody *ngFor="let item of resolvedData | keyvalue : asIsOrder"
                 [ngSwitch]="getResolvedPropertyType(item.value)" style="border-top: 0px solid;">
                 <!-- Render simple property (one row) -->

--- a/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.html
+++ b/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.html
@@ -1,6 +1,6 @@
 <div class="table-responsive">
     <div *ngIf="resolvedData">
-        <table class="table detail-table app-detail-listlistlistlistlistlistlistlist" [ngClass]="{ 'table-layout-fixed': !noFixedLayout }">
+        <table class="table detail-table detail-list" [ngClass]="{ 'table-layout-fixed': !noFixedLayout }">
             <tbody *ngFor="let item of resolvedData | keyvalue : asIsOrder"
                 [ngSwitch]="getResolvedPropertyType(item.value)" style="border-top: 0px solid;">
                 <!-- Render simple property (one row) -->

--- a/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
+++ b/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
@@ -3,17 +3,17 @@ import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
 import { Constants } from 'src/app/Common/Constants';
 import { Utils } from 'src/app/Utils/Utils';
 import { ITextAndBadge } from 'src/app/Utils/ValueResolver';
-import  size from 'lodash/size';
-import  forOwn  from 'lodash/forOwn';
-import  startCase  from 'lodash/startCase';
-import  camelCase  from 'lodash/camelCase';
-import  isNumber  from 'lodash/isNumber';
-import  isBoolean  from 'lodash/isBoolean';
-import  isUndefined  from 'lodash/isUndefined';
-import  isNull  from 'lodash/isNull';
-import  isEmpty  from 'lodash/isEmpty';
-import  isObject  from 'lodash/isObject';
-import  first  from 'lodash/first';
+import size from 'lodash/size';
+import forOwn from 'lodash/forOwn';
+import startCase from 'lodash/startCase';
+import camelCase from 'lodash/camelCase';
+import isNumber from 'lodash/isNumber';
+import isBoolean from 'lodash/isBoolean';
+import isUndefined from 'lodash/isUndefined';
+import isNull from 'lodash/isNull';
+import isEmpty from 'lodash/isEmpty';
+import isObject from 'lodash/isObject';
+import first from 'lodash/first';
 
 export class ResolvedObject {
   [index: string]: any;

--- a/src/SfxWeb/src/app/shared/component/dual-date-picker/dual-date-picker.component.ts
+++ b/src/SfxWeb/src/app/shared/component/dual-date-picker/dual-date-picker.component.ts
@@ -14,10 +14,10 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
   @Input() currentStartDate: Date;
   @Input() currentEndDate: Date;
 
-  @Output() onDateChange = new EventEmitter<{endDate: Date, startDate: Date}>();
+  @Output() dateChanged = new EventEmitter<{endDate: Date, startDate: Date}>();
 
-  _minDate: NgbDateStruct;
-  _maxDate: NgbDateStruct;
+  private internalMinDate: NgbDateStruct;
+  private internalMaxDate: NgbDateStruct;
 
   hoveredDate: NgbDate;
 
@@ -34,8 +34,8 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
   }
 
   ngOnInit(){
-    this._maxDate = this.dateToNgbDate(this.maxDate);
-    this._minDate = this.dateToNgbDate(this.minDate);
+    this.internalMaxDate = this.dateToNgbDate(this.maxDate);
+    this.internalMinDate = this.dateToNgbDate(this.minDate);
   }
 
   dateToNgbDate(date: Date): NgbDate {
@@ -59,7 +59,7 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
     if (this.fromDate && this.toDate){
       this.currentStartDate.setFullYear(this.fromDate.year, this.fromDate.month - 1, this.fromDate.day);
       this.currentEndDate.setFullYear(this.toDate.year, this.toDate.month - 1, this.toDate.day);
-      this.onDateChange.emit({
+      this.dateChanged.emit({
         endDate: this.currentEndDate,
         startDate: this.currentStartDate
       });
@@ -84,6 +84,6 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
   }
 
   isDisabled = (date: NgbDate, current: {month: number}) => {
-    return date.before(this._minDate) || date.after(this._maxDate);
+    return date.before(this.internalMinDate) || date.after(this.internalMaxDate);
   }
 }

--- a/src/SfxWeb/src/app/shared/component/input/input.component.ts
+++ b/src/SfxWeb/src/app/shared/component/input/input.component.ts
@@ -26,7 +26,7 @@ export class InputComponent implements OnInit, OnDestroy {
   }
 
 
-  @Output() onChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() changed: EventEmitter<string> = new EventEmitter<string>();
 
   constructor() { }
 
@@ -34,7 +34,7 @@ export class InputComponent implements OnInit, OnDestroy {
     this.debouncerHandlerSubscription = this.debounceHandler
    .pipe(debounceTime(200), distinctUntilChanged())
    .subscribe(val => {
-      this.onChange.emit(val);
+      this.changed.emit(val);
    });
   }
 

--- a/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
+++ b/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
@@ -9,16 +9,16 @@ export class RefreshRateComponent {
   @Input() refresh = false;
   @Input()
   set value( val: number) {
-    this.change( +(Object.keys(this._mapping).find(key => this._mapping[key] === val) || 4), false );
+    this.change( +(Object.keys(this.mapping).find(key => this.mapping[key] === val) || 4), false );
   }
 
-  @Output() onChange = new EventEmitter<string>();
-  @Output() onForceRefresh = new EventEmitter<any>();
+  @Output() rateChange = new EventEmitter<string>();
+  @Output() forceRefreshed = new EventEmitter<any>();
   refreshRate = 0;
 
   displayRate: string | number;
 
-  _mapping: Record<number, string> = {
+  private mapping: Record<number, string> = {
     0: '0',
     1: '300',
     2: '60',
@@ -32,16 +32,16 @@ export class RefreshRateComponent {
   }
 
   change(updatedValue: number, emitValue = true) {
-    this.displayRate = this._mapping[updatedValue];
+    this.displayRate = this.mapping[updatedValue];
     this.refreshRate = updatedValue;
 
     if (emitValue){
-      this.onChange.emit(this.displayRate);
+      this.rateChange.emit(this.displayRate);
     }
   }
 
   forceRefresh() {
-    this.onForceRefresh.emit();
+    this.forceRefreshed.emit();
   }
 
 

--- a/src/SfxWeb/src/app/shared/directive/drag.directive.ts
+++ b/src/SfxWeb/src/app/shared/directive/drag.directive.ts
@@ -7,12 +7,12 @@ export class DragDirective {
 
   down = false;
 
-  @Output() onDrag = new EventEmitter();
+  @Output() dragFinish = new EventEmitter();
 
   @HostListener('document:mousemove', ['$event'])
   handleDrag($event: MouseEvent){
     if (this.down){
-      this.onDrag.emit($event.clientX);
+      this.dragFinish.emit($event.clientX);
     }
   }
 
@@ -25,7 +25,7 @@ export class DragDirective {
   @HostListener('document:mouseup', ['$event'])
   endDrag($event: any){
     if (this.down){
-      this.onDrag.emit($event.clientX);
+      this.dragFinish.emit($event.clientX);
     }
     this.down = false;
   }

--- a/src/SfxWeb/src/app/shared/shared.module.ts
+++ b/src/SfxWeb/src/app/shared/shared.module.ts
@@ -25,7 +25,11 @@ import { FormatDatePipe } from './pipes/format-date.pipe';
 import { LocalTimeComponent } from './component/local-time/local-time.component';
 import { DisplayTimeComponent } from './component/display-time/display-time.component';
 @NgModule({
-  declarations: [NavbarComponent, ClipBoardComponent, HealthBadgeComponent, CandyBarCompactComponent, DetailViewPartComponent, CollapseContainerComponent, RefreshRateComponent, DragDirective, ActionDialogComponent, ManifestComponent, ActionCollectionDropDownComponent, InputComponent, ToastContainerComponent, CheckBoxComponent, ClusterUpgradeBannerComponent, DualDatePickerComponent, AdvancedOptionComponent, ReplicaAddressComponent, FormatDatePipe, LocalTimeComponent, DisplayTimeComponent],
+  declarations: [NavbarComponent, ClipBoardComponent, HealthBadgeComponent, CandyBarCompactComponent, DetailViewPartComponent,
+                 CollapseContainerComponent, RefreshRateComponent, DragDirective, ActionDialogComponent, ManifestComponent,
+                 ActionCollectionDropDownComponent, InputComponent, ToastContainerComponent, CheckBoxComponent,
+                 ClusterUpgradeBannerComponent, DualDatePickerComponent, AdvancedOptionComponent, ReplicaAddressComponent,
+                 FormatDatePipe, LocalTimeComponent, DisplayTimeComponent],
   imports: [
     CommonModule,
     RouterModule,
@@ -35,6 +39,10 @@ import { DisplayTimeComponent } from './component/display-time/display-time.comp
     NgbDatepickerModule,
     NgbTooltipModule
   ],
-  exports: [NavbarComponent, ClipBoardComponent, HealthBadgeComponent, CandyBarCompactComponent, DetailViewPartComponent, CollapseContainerComponent, RefreshRateComponent, DragDirective, ActionDialogComponent, ManifestComponent, ActionCollectionDropDownComponent, InputComponent, ToastContainerComponent, CheckBoxComponent, ClusterUpgradeBannerComponent, DualDatePickerComponent, AdvancedOptionComponent, ReplicaAddressComponent, FormatDatePipe, LocalTimeComponent, DisplayTimeComponent]
+  exports: [NavbarComponent, ClipBoardComponent, HealthBadgeComponent, CandyBarCompactComponent, DetailViewPartComponent,
+            CollapseContainerComponent, RefreshRateComponent, DragDirective, ActionDialogComponent, ManifestComponent,
+            ActionCollectionDropDownComponent, InputComponent, ToastContainerComponent, CheckBoxComponent,
+            ClusterUpgradeBannerComponent, DualDatePickerComponent, AdvancedOptionComponent, ReplicaAddressComponent,
+            FormatDatePipe, LocalTimeComponent, DisplayTimeComponent]
 })
 export class SharedModule { }

--- a/src/SfxWeb/src/app/views/application-type/ApplicationTypeBase.ts
+++ b/src/SfxWeb/src/app/views/application-type/ApplicationTypeBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType';
 
 @Directive()
-export class ApplicationTypeBaseController extends BaseController {
+export class ApplicationTypeBaseControllerDirective extends BaseControllerDirective {
     appTypeName: string;
     appTypeGroup: ApplicationTypeGroup;
 

--- a/src/SfxWeb/src/app/views/application-type/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/base/base.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, Injector } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
-import { ApplicationTypeBaseController } from '../ApplicationTypeBase';
+import { ApplicationTypeBaseControllerDirective } from '../ApplicationTypeBase';
 import { DataService } from 'src/app/services/data.service';
 
 @Component({
@@ -10,7 +10,7 @@ import { DataService } from 'src/app/services/data.service';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends ApplicationTypeBaseController {
+export class BaseComponent extends ApplicationTypeBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/application-type/create-application/create-application.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/create-application/create-application.component.ts
@@ -24,8 +24,6 @@ export class CreateApplicationComponent implements OnInit {
    this.form = this.formBuilder.group({
     userInput: [Constants.FabricPrefix + this.app.name, [Validators.required, Validators.pattern(/^fabric:\/.+/)]]
     });
-
-   this.form.invalid;
   }
 
   ok(){

--- a/src/SfxWeb/src/app/views/application-type/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/details/details.component.ts
@@ -1,20 +1,17 @@
-import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { Component, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { ActivatedRouteSnapshot } from '@angular/router';
-import { IdUtils } from 'src/app/Utils/IdUtils';
 import { ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType';
 import { mergeMap } from 'rxjs/operators';
 import { forkJoin, Observable } from 'rxjs';
-import { ApplicationTypeBaseController } from '../ApplicationTypeBase';
+import { ApplicationTypeBaseControllerDirective } from '../ApplicationTypeBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends ApplicationTypeBaseController {
+export class DetailsComponent extends ApplicationTypeBaseControllerDirective {
   appTypeName: string;
   appTypeGroup: ApplicationTypeGroup;
 

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
@@ -3,7 +3,7 @@
         <h4 collapse-header>
             Application Type versions
         </h4>    
-        <app-app-detail-listlist [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings" collapse-bodapp-app-detail-listail-list>
+        <app-detail-list [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings" collapse-body></app-detail-list>	
     </app-collapse-container>
 </div>
 
@@ -12,6 +12,6 @@
         <h4 collapse-header>
             Applications
         </h4>    
-        <app-app-detail-listlist [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-bodapp-app-detail-listail-list>
+        <app-detail-list [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-body></app-detail-list>	
     </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
@@ -3,7 +3,7 @@
         <h4 collapse-header>
             Application Type versions
         </h4>    
-        <detail-list [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings" collapse-body></detail-list>
+        <app-app-detail-listlist [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings" collapse-bodapp-app-detail-listail-list>
     </app-collapse-container>
 </div>
 
@@ -12,6 +12,6 @@
         <h4 collapse-header>
             Applications
         </h4>    
-        <detail-list [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-body></detail-list>
+        <app-app-detail-listlist [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-bodapp-app-detail-listail-list>
     </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -1,13 +1,12 @@
-import { Component, OnInit, Injector } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { Observable } from 'rxjs';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType';
 import { ListSettings, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingForBadge, ListColumnSettingForLink } from 'src/app/Models/ListSettings';
-import { Constants } from 'src/app/Common/Constants';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
-import { ApplicationTypeBaseController } from '../ApplicationTypeBase';
+import { ApplicationTypeBaseControllerDirective } from '../ApplicationTypeBase';
 import { ListColumnSettingForApplicationType } from '../action-row/action-row.component';
 
 @Component({
@@ -15,7 +14,7 @@ import { ListColumnSettingForApplicationType } from '../action-row/action-row.co
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends ApplicationTypeBaseController {
+export class EssentialsComponent extends ApplicationTypeBaseControllerDirective {
   appTypeGroup: ApplicationTypeGroup;
   appsListSettings: ListSettings;
   appTypesListSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/application/applicationBase.ts
+++ b/src/SfxWeb/src/app/views/application/applicationBase.ts
@@ -2,14 +2,14 @@ import { Application } from 'src/app/Models/DataModels/Application';
 import { DataService } from 'src/app/services/data.service';
 import { Injector, Directive } from '@angular/core';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { Observable, of } from 'rxjs';
-import { map, mergeMap, catchError } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 
 @Directive()
-export class ApplicationBaseController extends BaseController {
+export class ApplicationBaseControllerDirective extends BaseControllerDirective {
     appTypeName: string;
     appId: string;
 

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.html
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.html
@@ -5,5 +5,5 @@
 
 <div class="detail-pane essen-pane" *ngIf="app">
     <h4>Application Backup Configuration</h4>
-    <detail-list [list]="app.applicationBackupConfigurationInfoCollection.collection" [listSettings]="applicationBackupConfigurationInfoListSettings"></detail-list>
+    <app-detail-list [list]="app.applicationBackupConfigurationInfoCollection.collection" [listSettings]="applicationBackupConfigurationInfoListSettings"></app-detail-list>
 </div>

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { ListSettings, ListColumnSetting } from 'src/app/Models/ListSettings';
@@ -17,7 +17,7 @@ import { PartitionEnableBackUpComponent } from 'src/app/modules/backup-restore/p
   templateUrl: './backup.component.html',
   styleUrls: ['./backup.component.scss']
 })
-export class BackupComponent extends ApplicationBaseController  {
+export class BackupComponent extends ApplicationBaseControllerDirective  {
 
   applicationBackupConfigurationInfoListSettings: ListSettings;
   actions: ActionCollection;

--- a/src/SfxWeb/src/app/views/application/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/application/base/base.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -10,7 +10,7 @@ import { IdGenerator } from 'src/app/Utils/IdGenerator';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends ApplicationBaseController {
+export class BaseComponent extends ApplicationBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/application/deployments/deployments.component.html
+++ b/src/SfxWeb/src/app/views/application/deployments/deployments.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane">
-    <detail-list [list]="deployedApplicationsHealthStates" [listSettings]="deployedApplicationsHealthStatesListSettings"></detail-list>
+    <app-app-detail-listlistlist [list]="deployedApplicationsHealthStates" [listSettings]="deployedApplicationsHealthStatesListSettapp-app-detail-listail-listail-list>
 </div>

--- a/src/SfxWeb/src/app/views/application/deployments/deployments.component.html
+++ b/src/SfxWeb/src/app/views/application/deployments/deployments.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane">
-    <app-app-detail-listlistlist [list]="deployedApplicationsHealthStates" [listSettings]="deployedApplicationsHealthStatesListSettapp-app-detail-listail-listail-list>
+    <app-detail-list [list]="deployedApplicationsHealthStates" [listSettings]="deployedApplicationsHealthStatesListSettings"></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/application/deployments/deployments.component.ts
+++ b/src/SfxWeb/src/app/views/application/deployments/deployments.component.ts
@@ -6,14 +6,14 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { DeployedApplicationHealthState } from 'src/app/Models/DataModels/Application';
 import { ListSettings, ListColumnSettingForBadge, ListColumnSettingForLink } from 'src/app/Models/ListSettings';
 import { map } from 'rxjs/operators';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 
 @Component({
   selector: 'app-deployments',
   templateUrl: './deployments.component.html',
   styleUrls: ['./deployments.component.scss']
 })
-export class DeploymentsComponent extends ApplicationBaseController {
+export class DeploymentsComponent extends ApplicationBaseControllerDirective {
 
   deployedApplicationsHealthStatesListSettings: ListSettings;
   deployedApplicationsHealthStates: DeployedApplicationHealthState[] = [];

--- a/src/SfxWeb/src/app/views/application/details/details.component.html
+++ b/src/SfxWeb/src/app/views/application/details/details.component.html
@@ -4,5 +4,5 @@
 
 <div class="detail-pane essen-pane">
     <h4>Health Events</h4>
-    <detail-list [list]="app?.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+    <app-app-detail-listlist [list]="app?.health.healthEvents" [listSettings]="healthEventsListSettingsapp-app-detail-listail-list>
 </div>

--- a/src/SfxWeb/src/app/views/application/details/details.component.html
+++ b/src/SfxWeb/src/app/views/application/details/details.component.html
@@ -4,5 +4,5 @@
 
 <div class="detail-pane essen-pane">
     <h4>Health Events</h4>
-    <app-app-detail-listlist [list]="app?.health.healthEvents" [listSettings]="healthEventsListSettingsapp-app-detail-listail-list>
+    <app-detail-list [list]="app?.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/application/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/application/details/details.component.ts
@@ -4,14 +4,14 @@ import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends ApplicationBaseController {
+export class DetailsComponent extends ApplicationBaseControllerDirective {
 
   healthEventsListSettings: ListSettings;
 

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
@@ -71,7 +71,7 @@
         </div>
         <div collapse-body>
             <div class="table-responsive">
-                <table class="table app-detail-list">
+                <table class="table detail-list">
                     <thead>
                         <tr>
                             <th>Target Version</th>

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.html
@@ -71,7 +71,7 @@
         </div>
         <div collapse-body>
             <div class="table-responsive">
-                <table class="table detail-list">
+                <table class="table app-detail-list">
                     <thead>
                         <tr>
                             <th>Target Version</th>
@@ -99,7 +99,7 @@
 
             <div class="detail-pane essen-pane" *ngIf="upgradeProgress.upgradeDomains.length > 0">
                 <h4>Progress by Upgrade Domain</h4>
-                <upgrade-progress [upgradeDomains]="upgradeProgress.upgradeDomains"></upgrade-progress>
+                <app-upgrade-progress [upgradeDomains]="upgradeProgress.upgradeDomains"></app-upgrade-progress>
             </div>
 
             <div class="detail-pane essen-pane" *ngIf="upgradeProgress.raw.FailureReason !== 'None'">
@@ -123,7 +123,7 @@
             </div>
             <div class="detail-pane essen-pane" *ngIf="upgradeProgress.unhealthyEvaluations.length > 0">
                 <h4>Unhealthy Evaluations (Upgrade)</h4>
-                <detail-list [list]="upgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></detail-list>
+                <app-detail-list [list]="upgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></app-detail-list>
             </div>
 
             <div class="detail-pane essen-pane" *ngIf="upgradeProgress.upgradeDescription">
@@ -140,7 +140,7 @@
             <h4>Unhealthy Evaluations</h4>
         </div>
         <div collapse-body>
-            <detail-list [list]="app.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></detail-list>
+            <app-detail-list [list]="app.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>
         </div>
     </app-collapse-container>
 </div>
@@ -151,7 +151,7 @@
             <h4>Services</h4>
         </div>
         <div collapse-body>
-            <detail-list [list]="app.services.collection" [listSettings]="listSettings"></detail-list>
+            <app-detail-list [list]="app.services.collection" [listSettings]="listSettings"></app-detail-list>
         </div>
     </app-collapse-container>
 </div>
@@ -162,12 +162,12 @@
             <h4>Service Types</h4>
         </div>
         <div collapse-body>
-            <detail-list [list]="app.serviceTypes.collection" [listSettings]="serviceTypesListSettings"></detail-list>
+            <app-detail-list [list]="app.serviceTypes.collection" [listSettings]="serviceTypesListSettings"></app-detail-list>
         </div>
     </app-collapse-container>
 </div>
 
 <!-- <div class="detail-pane essen-pane" *ngIf="clusterManifest && clusterManifest.isNetworkInventoryManagerEnabled">
     <h4>Networks</h4>
-    <detail-list [list]="networks" [listSettings]="networkListSettings"></detail-list>
+    <app-detail-list [list]="networks" [listSettings]="networkListSettings"></app-detail-list>
 </div> -->

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -7,7 +7,7 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { forkJoin, of, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ClusterManifest } from 'src/app/Models/DataModels/Cluster';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { ListColumnSettingForApplicationServiceRow } from '../action-row/action-row.component';
 import { IDashboardViewModel, DashboardViewModel } from 'src/app/ViewModels/DashboardViewModels';
 import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUtils';
@@ -16,7 +16,7 @@ import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUti
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends ApplicationBaseController {
+export class EssentialsComponent extends ApplicationBaseControllerDirective {
 
   upgradeProgress: ApplicationUpgradeProgress;
   listSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/application/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/application/events/events.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { ApplicationEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { ApplicationTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
@@ -9,7 +9,7 @@ import { ApplicationTimelineGenerator } from 'src/app/Models/eventstore/timeline
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends ApplicationBaseController {
+export class EventsComponent extends ApplicationBaseControllerDirective {
 
   timelineGenerator: ApplicationTimelineGenerator;
   appEvents: ApplicationEventList;

--- a/src/SfxWeb/src/app/views/application/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/application/manifest/manifest.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ApplicationBaseController } from '../applicationBase';
+import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
   templateUrl: './manifest.component.html',
   styleUrls: ['./manifest.component.scss']
 })
-export class ManifestComponent extends ApplicationBaseController {
+export class ManifestComponent extends ApplicationBaseControllerDirective {
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);

--- a/src/SfxWeb/src/app/views/applications/all/all.component.html
+++ b/src/SfxWeb/src/app/views/applications/all/all.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane" *ngIf="apps">
-    <app-app-app-detail-listlist [list]="apps.collection" [listSettings]="listSettings" collapse-bodapp-app-app-detail-listail-list>
+    <app-detail-list [list]="apps.collection" [listSettings]="listSettings" collapse-body></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/applications/all/all.component.html
+++ b/src/SfxWeb/src/app/views/applications/all/all.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane" *ngIf="apps">
-    <detail-list [list]="apps.collection" [listSettings]="listSettings" collapse-body></detail-list>
+    <app-app-app-detail-listlist [list]="apps.collection" [listSettings]="listSettings" collapse-bodapp-app-app-detail-listail-list>
 </div>

--- a/src/SfxWeb/src/app/views/applications/all/all.component.ts
+++ b/src/SfxWeb/src/app/views/applications/all/all.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
@@ -13,7 +13,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './all.component.html',
   styleUrls: ['./all.component.scss']
 })
-export class AllComponent extends BaseController {
+export class AllComponent extends BaseControllerDirective {
 
   apps: ApplicationCollection;
   listSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/applications/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ApplicationEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { DataService } from 'src/app/services/data.service';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { IResponseMessageHandler, EventsStoreResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 
@@ -10,7 +10,7 @@ import { Observable } from 'rxjs';
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends BaseController {
+export class EventsComponent extends BaseControllerDirective {
 
   appEvents: ApplicationEventList;
 

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.html
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane" *ngIf="upgradeProgresses">
-    <app-detail-listlist [list]="upgradeProgresses" [listSettings]="upgradeAppsListSettingsapp-detail-listail-list>
+    <app-detail-list [list]="upgradeProgresses" [listSettings]="upgradeAppsListSettings"></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.html
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane" *ngIf="upgradeProgresses">
-    <detail-list [list]="upgradeProgresses" [listSettings]="upgradeAppsListSettings"></detail-list>
+    <app-detail-listlist [list]="upgradeProgresses" [listSettings]="upgradeAppsListSettingsapp-detail-listail-list>
 </div>

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
@@ -1,5 +1,5 @@
 import { Component, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { ApplicationCollection } from 'src/app/Models/DataModels/collections/Collections';
 import { ListSettings, ListColumnSettingForLink, ListColumnSetting, ListColumnSettingWithFilter } from 'src/app/Models/ListSettings';
 import { ApplicationUpgradeProgress } from 'src/app/Models/DataModels/Application';
@@ -15,7 +15,7 @@ import { Observable, forkJoin, of } from 'rxjs';
   templateUrl: './upgrading.component.html',
   styleUrls: ['./upgrading.component.scss']
 })
-export class UpgradingComponent extends BaseController {
+export class UpgradingComponent extends BaseControllerDirective {
 
   apps: ApplicationCollection;
   upgradeAppsListSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
+++ b/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
@@ -3,5 +3,5 @@
 </div>
 <div class="detail-pane essen-pane">
     <h2>Backup Policies</h2>
-    <app-detail-listlistlistlist [list]="backupPolicies.collection" [listSettings]="backupPolicyListapp-detail-listail-listail-listail-list>
+    <app-detail-list [list]="partition.partitionBackupInfo.partitionBackupList.collection" [listSettings]="partitionBackupListSettings" ></app-detail-list>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
+++ b/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
@@ -3,5 +3,5 @@
 </div>
 <div class="detail-pane essen-pane">
     <h2>Backup Policies</h2>
-    <detail-list [list]="backupPolicies.collection" [listSettings]="backupPolicyListSettings"></detail-list>
+    <app-detail-listlistlistlist [list]="backupPolicies.collection" [listSettings]="backupPolicyListapp-detail-listail-listail-listail-list>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
+++ b/src/SfxWeb/src/app/views/cluster/backups/backups.component.html
@@ -3,5 +3,5 @@
 </div>
 <div class="detail-pane essen-pane">
     <h2>Backup Policies</h2>
-    <app-detail-list [list]="partition.partitionBackupInfo.partitionBackupList.collection" [listSettings]="partitionBackupListSettings" ></app-detail-list>
+    <app-detail-list [list]="backupPolicies.collection" [listSettings]="backupPolicyListSettings"></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/cluster/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/backups/backups.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -15,7 +15,7 @@ import { ActionCreateBackupPolicyComponent } from '../action-create-backup-polic
   templateUrl: './backups.component.html',
   styleUrls: ['./backups.component.scss']
 })
-export class BackupsComponent extends BaseController {
+export class BackupsComponent extends BaseControllerDirective {
 
   backupPolicyListSettings: ListSettings;
   backupPolicies: BackupPolicyCollection;

--- a/src/SfxWeb/src/app/views/cluster/cluster.module.ts
+++ b/src/SfxWeb/src/app/views/cluster/cluster.module.ts
@@ -20,13 +20,15 @@ import { UpgradeProgressModule } from 'src/app/modules/upgrade-progress/upgrade-
 import { ChartsModule } from 'src/app/modules/charts/charts.module';
 import { StatusWarningsComponent } from './status-warnings/status-warnings.component';
 import { BackupsComponent } from './backups/backups.component';
-import { NgbDropdownModule, NgbTabsetModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { BackupRestoreModule } from 'src/app/modules/backup-restore/backup-restore.module';
 import { RepairTasksComponent } from './repair-tasks/repair-tasks.component';
 import { RepairTaskViewComponent } from './repair-task-view/repair-task-view.component';
 
 @NgModule({
-  declarations: [EssentialsComponent, DetailsComponent, BaseComponent, MetricsComponent, ClustermapComponent, ImagestoreComponent, ManifestComponent, EventsComponent, ActionCreateBackupPolicyComponent, StatusWarningsComponent, BackupsComponent, RepairTasksComponent, RepairTaskViewComponent],
+  declarations: [EssentialsComponent, DetailsComponent, BaseComponent, MetricsComponent, ClustermapComponent,
+                 ImagestoreComponent, ManifestComponent, EventsComponent, ActionCreateBackupPolicyComponent,
+                 StatusWarningsComponent, BackupsComponent, RepairTasksComponent, RepairTaskViewComponent],
   imports: [
     CommonModule,
     ClusterRoutingModule,
@@ -39,7 +41,7 @@ import { RepairTaskViewComponent } from './repair-task-view/repair-task-view.com
     ChartsModule,
     NgbDropdownModule,
     BackupRestoreModule,
-    NgbTabsetModule,
+    NgbNavModule,
     UpgradeProgressModule
   ]
 })

--- a/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.html
+++ b/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.html
@@ -1,6 +1,6 @@
 <div class="detail-pane">
     <div>
-        <app-input placeholder="Filter nodes" [model]="filter" (onChange)="filter = $event;" ></app-input>
+        <app-input placeholder="Filter nodes" [model]="filter" (changed)="filter = $event;" ></app-input>
 
         <div style="margin: 15px; display: block;">
             <app-check-box [(state)]="healthFilter.OK">

--- a/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.ts
@@ -3,7 +3,7 @@ import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { forkJoin, Observable } from 'rxjs';
 import { Node } from 'src/app/Models/DataModels/Node';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollection';
 import { HealthStateConstants } from 'src/app/Common/Constants';
 
@@ -12,7 +12,7 @@ import { HealthStateConstants } from 'src/app/Common/Constants';
   templateUrl: './clustermap.component.html',
   styleUrls: ['./clustermap.component.scss']
 })
-export class ClustermapComponent extends BaseController {
+export class ClustermapComponent extends BaseControllerDirective {
 
   nodes: NodeCollection;
   filter = '';

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.html
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.html
@@ -3,7 +3,7 @@
         <h4 collapse-header>
             Health Events
         </h4>
-        <detail-list [list]="clusterHealth.healthEvents" [listSettings]="healthEventsListSettings"  collapse-body></detail-list>
+        <app-detail-listlist [list]="clusterHealth.healthEvents" [listSettings]="healthEventsListSettings"  collapse-bodapp-detail-listail-list>
     </app-collapse-container>
 </div>
 
@@ -42,7 +42,7 @@
                 </div>
                 <div *ngIf="clusterUpgradeProgress.upgradeDomains.length > 0" style="margin-top: 20px;">
                     <h5 style="font-size: 16px;">Upgrade Domain Progress</h5>
-                    <upgrade-progress [upgradeDomains]="clusterUpgradeProgress.upgradeDomains"></upgrade-progress>
+                    <app-upgrade-progress [upgradeDomains]="clusterUpgradeProgress.upgradeDomains"></app-upgrade-progress>
                 </div>
 
             <div style="margin-top:20px" *ngIf="clusterUpgradeProgress.isUpgrading">
@@ -70,7 +70,7 @@
             </div>
             <div class="detail-pane" *ngIf="clusterUpgradeProgress.unhealthyEvaluations.length > 0">
                 <h4>Unhealthy Evaluations (Upgrade)</h4>
-                <detail-list [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></detail-list>
+                <app-detail-listlist [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettingsapp-detail-listail-list>
             </div>
         </div>
     </app-collapse-container>
@@ -88,7 +88,7 @@
 <div *ngIf="nodesStatuses" class="detail-pane essen-pane">
     <app-collapse-container sectionName="Node States">
         <h4 collapse-header>Node States</h4>        
-        <detail-list [list]="nodesStatuses" [listSettings]="nodeStatusListSettings" collapse-body></detail-list>
+        <app-detail-listlist [list]="nodesStatuses" [listSettings]="nodeStatusListSettings" collapse-bodapp-detail-listail-list>
     </app-collapse-container>
 </div>
 

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.html
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.html
@@ -3,7 +3,7 @@
         <h4 collapse-header>
             Health Events
         </h4>
-        <app-detail-listlist [list]="clusterHealth.healthEvents" [listSettings]="healthEventsListSettings"  collapse-bodapp-detail-listail-list>
+        <app-detail-list [list]="clusterHealth.healthEvents" [listSettings]="healthEventsListSettings"  collapse-body></app-detail-list>
     </app-collapse-container>
 </div>
 
@@ -70,7 +70,7 @@
             </div>
             <div class="detail-pane" *ngIf="clusterUpgradeProgress.unhealthyEvaluations.length > 0">
                 <h4>Unhealthy Evaluations (Upgrade)</h4>
-                <app-detail-listlist [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettingsapp-detail-listail-list>
+                <app-detail-list [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></app-detail-list>
             </div>
         </div>
     </app-collapse-container>
@@ -88,7 +88,7 @@
 <div *ngIf="nodesStatuses" class="detail-pane essen-pane">
     <app-collapse-container sectionName="Node States">
         <h4 collapse-header>Node States</h4>        
-        <app-detail-listlist [list]="nodesStatuses" [listSettings]="nodeStatusListSettings" collapse-bodapp-detail-listail-list>
+        <app-detail-list [list]="nodesStatuses" [listSettings]="nodeStatusListSettings" collapse-body></app-detail-list>
     </app-collapse-container>
 </div>
 

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.ts
@@ -8,7 +8,7 @@ import { HealthStateFilterFlags } from 'src/app/Models/HealthChunkRawDataTypes';
 import { INodesStatusDetails } from 'src/app/Models/RawDataTypes';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { SettingsService } from 'src/app/services/settings.service';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollection';
 
 
@@ -17,7 +17,7 @@ import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollec
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends BaseController {
+export class DetailsComponent extends BaseControllerDirective {
 
   clusterUpgradeProgress: ClusterUpgradeProgress;
   clusterLoadInformation: ClusterLoadInformation;

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
@@ -90,6 +90,6 @@
 
 <div class="detail-pane essen-pane">
     <h4>Unhealthy Evaluations</h4>
-    <app-detail-list [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluations"></app-detail-list>
+    <app-detail-list [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>	
 </div>
 

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
@@ -90,6 +90,6 @@
 
 <div class="detail-pane essen-pane">
     <h4>Unhealthy Evaluations</h4>
-    <app-app-app-detail-listlistlistlist [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettapp-app-detail-listail-listail-listail-list>
+    <app-detail-list [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluations"></app-detail-list>
 </div>
 

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
@@ -90,6 +90,6 @@
 
 <div class="detail-pane essen-pane">
     <h4>Unhealthy Evaluations</h4>
-    <detail-list [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></detail-list>
+    <app-app-app-detail-listlistlistlist [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettapp-app-detail-listail-listail-listail-list>
 </div>
 

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
@@ -5,7 +5,7 @@ import { HealthStateFilterFlags } from 'src/app/Models/HealthChunkRawDataTypes';
 import { SystemApplication } from 'src/app/Models/DataModels/Application';
 import { Observable, forkJoin, of } from 'rxjs';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollection';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -20,7 +20,7 @@ import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUti
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends BaseController {
+export class EssentialsComponent extends BaseControllerDirective {
 
   clusterUpgradeProgress: ClusterUpgradeProgress;
   nodes: NodeCollection;

--- a/src/SfxWeb/src/app/views/cluster/imagestore/imagestore.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/imagestore/imagestore.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { ImageStore } from 'src/app/Models/DataModels/ImageStore';
 import { SettingsService } from 'src/app/services/settings.service';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
   templateUrl: './imagestore.component.html',
   styleUrls: ['./imagestore.component.scss']
 })
-export class ImagestoreComponent extends BaseController {
+export class ImagestoreComponent extends BaseControllerDirective {
 
   imageStore: ImageStore;
 

--- a/src/SfxWeb/src/app/views/cluster/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/manifest/manifest.component.ts
@@ -3,14 +3,14 @@ import { DataService } from 'src/app/services/data.service';
 import { ClusterManifest } from 'src/app/Models/DataModels/Cluster';
 import { Observable } from 'rxjs';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 
 @Component({
   selector: 'app-manifest',
   templateUrl: './manifest.component.html',
   styleUrls: ['./manifest.component.scss']
 })
-export class ManifestComponent extends BaseController {
+export class ManifestComponent extends BaseControllerDirective {
 
   clusterManifest: ClusterManifest;
 

--- a/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, forkJoin } from 'rxjs';
@@ -22,7 +22,7 @@ interface IChartData {
   templateUrl: './metrics.component.html',
   styleUrls: ['./metrics.component.scss']
 })
-export class MetricsComponent extends BaseController {
+export class MetricsComponent extends BaseControllerDirective {
 
   clusterLoadInformation: ClusterLoadInformation;
   nodes: NodeCollection;

--- a/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.html
@@ -2,14 +2,12 @@
     Copy raw repair Job <app-clip-board [text]="copyText"></app-clip-board>
 </div>
 
-<ngb-tabset>
-    <ngb-tab>
-        <ng-template ngbTabTitle>
-            <div style="font-size: 12pt;">
-                Condensed
-            </div>
-        </ng-template>
-        <ng-template ngbTabContent>
+<div ngbNav #nav="ngbNav">
+    <div ngbNavItem>
+        <a ngbNavLink style="font-size: 12pt;">
+            Condensed
+        </a>
+        <ng-template ngbNavContent>
             <div style="display: flex;flex-direction: row;">
                 <div *ngIf="item.raw.History" style="min-width: 400px;">
                     <h5 style="border-bottom: 1px solid gray; padding-bottom: 5px">
@@ -69,17 +67,16 @@
             </div>
 
         </ng-template>
-    </ngb-tab>
-    <ngb-tab>
-        <ng-template ngbTabTitle>
-            <div style="font-size: 12pt;">
-                Full Description
-            </div>
-        </ng-template>
-        <ng-template ngbTabContent>
+    </div>
+    <div ngbNavItem>
+        <a ngbNavLink style="font-size: 12pt;">
+            Full Description
+        </a>
+        <ng-template ngbNavContent>
             <div style="width: 80%">
                 <app-detail-view-part [data]="item.raw"></app-detail-view-part>
             </div>
         </ng-template>
-    </ngb-tab>
-</ngb-tabset>
+    </div>
+</div>
+<div [ngbNavOutlet]="nav"></div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -8,7 +8,7 @@
         <h4 collapse-header>
             Pending Repair Tasks
         </h4>
-        <detail-list [list]="repairTasks" [listSettings]="repairTaskListSettings" collapse-body (onSort)="sorted($event, false)"></detail-list>
+        <app-detail-listlistlistlist [list]="repairTasks" [listSettings]="repairTaskListSettings" collapse-body (sorted)="sorted($eventapp-detail-listail-listail-listail-list>
     </app-collapse-container>
 </div>
 
@@ -17,6 +17,6 @@
         <h4 collapse-header>
             Completed Repair Tasks
         </h4>
-        <detail-list [list]="completedRepairTasks" [listSettings]="completedRepairTaskListSettings" collapse-body (onSort)="sorted($event)"></detail-list>
+        <app-detail-listlistlistlist [list]="completedRepairTasks" [listSettings]="completedRepairTaskListSettings" collapse-body (sorted)="sortedapp-detail-listail-listail-listail-list>
     </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -8,7 +8,7 @@
         <h4 collapse-header>
             Pending Repair Tasks
         </h4>
-        <app-detail-listlistlistlist [list]="repairTasks" [listSettings]="repairTaskListSettings" collapse-body (sorted)="sorted($eventapp-detail-listail-listail-listail-list>
+        <app-detail-list [list]="repairTasks" [listSettings]="repairTaskListSettings" collapse-body (onSort)="sorted($event, false)"></app-detail-list>
     </app-collapse-container>
 </div>
 
@@ -17,6 +17,6 @@
         <h4 collapse-header>
             Completed Repair Tasks
         </h4>
-        <app-detail-listlistlistlist [list]="completedRepairTasks" [listSettings]="completedRepairTaskListSettings" collapse-body (sorted)="sortedapp-detail-listail-listail-listail-list>
+        <app-detail-list [list]="completedRepairTasks" [listSettings]="completedRepairTaskListSettings" collapse-body (onSort)="sorted($event)"></app-detail-list>
     </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
@@ -16,7 +16,7 @@ import { DataSet, DataGroup, DataItem } from 'vis-timeline';
   templateUrl: './repair-tasks.component.html',
   styleUrls: ['./repair-tasks.component.scss']
 })
-export class RepairTasksComponent extends BaseController {
+export class RepairTasksComponent extends BaseControllerDirective {
 
   repairTasks: RepairTask[] = [];
   completedRepairTasks: RepairTask[] = [];

--- a/src/SfxWeb/src/app/views/deployed-application/DeployedApplicationBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/DeployedApplicationBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DeployedApplication } from 'src/app/Models/DataModels/DeployedApplication';
 
 @Directive()
-export class DeployedAppBaseController extends BaseController {
+export class DeployedAppBaseControllerDirective extends BaseControllerDirective {
     nodeName: string;
     appId: string;
 

--- a/src/SfxWeb/src/app/views/deployed-application/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/base/base.component.ts
@@ -1,6 +1,6 @@
 import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
-import { DeployedAppBaseController } from '../DeployedApplicationBase';
+import { DeployedAppBaseControllerDirective } from '../DeployedApplicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -10,7 +10,7 @@ import { IdGenerator } from 'src/app/Utils/IdGenerator';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends DeployedAppBaseController {
+export class BaseComponent extends DeployedAppBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/deployed-application/details/details.component.html
+++ b/src/SfxWeb/src/app/views/deployed-application/details/details.component.html
@@ -20,7 +20,7 @@
                 </h4>
             </div>
             <div collapse-body>
-                <app-detail-listlistlistlist [list]="deployedApp.health.healthEvents" [listSettings]="healthEventsListapp-detail-listail-listail-listail-list>
+                <app-detail-list [list]="deployedApp.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>
             </div>
         </app-collapse-container>
     </div>

--- a/src/SfxWeb/src/app/views/deployed-application/details/details.component.html
+++ b/src/SfxWeb/src/app/views/deployed-application/details/details.component.html
@@ -20,7 +20,7 @@
                 </h4>
             </div>
             <div collapse-body>
-                <detail-list [list]="deployedApp.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+                <app-detail-listlistlistlist [list]="deployedApp.health.healthEvents" [listSettings]="healthEventsListapp-detail-listail-listail-listail-list>
             </div>
         </app-collapse-container>
     </div>

--- a/src/SfxWeb/src/app/views/deployed-application/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/details/details.component.ts
@@ -2,14 +2,14 @@ import { Component, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { ListSettings} from 'src/app/Models/ListSettings';
-import { DeployedAppBaseController } from '../DeployedApplicationBase';
+import { DeployedAppBaseControllerDirective } from '../DeployedApplicationBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends DeployedAppBaseController {
+export class DetailsComponent extends DeployedAppBaseControllerDirective {
   healthEventsListSettings: ListSettings;
 
 

--- a/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.html
@@ -55,8 +55,8 @@
       <h4>Unhealthy Evaluations</h4>
     </div>
     <div collapse-body>
-      <detail-list [list]="deployedApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
-        *ngIf="deployedApp && deployedApp.health"></detail-list>
+      <app-detail-listlistlist [list]="deployedApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
+        *ngIf="deployedApp && deployedApp.health"></app-detail-listlistlist>
     </div>
   </app-collapse-container>
 </div>
@@ -67,8 +67,8 @@
       <h4>Deployed Service Packages</h4>
     </div>
     <div collapse-body>
-      <detail-list [list]="deployedServicePackages.collection" [listSettings]="listSettings"
-        *ngIf="deployedServicePackages"></detail-list>
+      <app-detail-listlistlist [list]="deployedServicePackages.collection" [listSettings]="listSettings"
+        *ngIf="deployedServicePackages"></app-detail-listlistlist>
     </div>
   </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.html
@@ -55,8 +55,8 @@
       <h4>Unhealthy Evaluations</h4>
     </div>
     <div collapse-body>
-      <app-detail-listlistlist [list]="deployedApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
-        *ngIf="deployedApp && deployedApp.health"></app-detail-listlistlist>
+      <app-detail-list [list]="deployedApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
+        *ngIf="deployedApp && deployedApp.health"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>
@@ -67,8 +67,8 @@
       <h4>Deployed Service Packages</h4>
     </div>
     <div collapse-body>
-      <app-detail-listlistlist [list]="deployedServicePackages.collection" [listSettings]="listSettings"
-        *ngIf="deployedServicePackages"></app-detail-listlistlist>
+      <app-detail-list [list]="deployedServicePackages.collection" [listSettings]="listSettings"
+        *ngIf="deployedServicePackages"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.ts
@@ -7,14 +7,14 @@ import { map } from 'rxjs/operators';
 import { ListSettings, ListColumnSettingForLink, ListColumnSettingForBadge, ListColumnSettingWithFilter, ListColumnSetting } from 'src/app/Models/ListSettings';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { DeployedServicePackageCollection } from 'src/app/Models/DataModels/collections/Collections';
-import { DeployedAppBaseController } from '../DeployedApplicationBase';
+import { DeployedAppBaseControllerDirective } from '../DeployedApplicationBase';
 
 @Component({
   selector: 'app-essentials',
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends DeployedAppBaseController {
+export class EssentialsComponent extends DeployedAppBaseControllerDirective {
   deployedServicePackages: DeployedServicePackageCollection;
 
   unhealthyEvaluationsListSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/deployed-code-package/DeployedCodePackageBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/DeployedCodePackageBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DeployedCodePackage } from 'src/app/Models/DataModels/DeployedCodePackage';
 
 @Directive()
-export class DeployedCodePackageBaseController extends BaseController {
+export class DeployedCodePackageBaseControllerDirective extends BaseControllerDirective {
     serviceId: string;
     activationId: string;
     appId: string;

--- a/src/SfxWeb/src/app/views/deployed-code-package/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/base/base.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { DeployedCodePackageBaseController } from '../DeployedCodePackageBase';
+import { DeployedCodePackageBaseControllerDirective } from '../DeployedCodePackageBase';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
@@ -13,7 +13,7 @@ import { Observable, of } from 'rxjs';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends DeployedCodePackageBaseController {
+export class BaseComponent extends DeployedCodePackageBaseControllerDirective {
 
   containerLogTabName = 'container logs';
 

--- a/src/SfxWeb/src/app/views/deployed-code-package/container-logs/container-logs.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/container-logs/container-logs.component.ts
@@ -2,7 +2,7 @@ import { Component, Injector } from '@angular/core';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
-import { DeployedCodePackageBaseController } from '../DeployedCodePackageBase';
+import { DeployedCodePackageBaseControllerDirective } from '../DeployedCodePackageBase';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -10,7 +10,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './container-logs.component.html',
   styleUrls: ['./container-logs.component.scss']
 })
-export class ContainerLogsComponent extends DeployedCodePackageBaseController {
+export class ContainerLogsComponent extends DeployedCodePackageBaseControllerDirective {
   containerLogs: string;
 
   constructor(protected data: DataService, injector: Injector) {

--- a/src/SfxWeb/src/app/views/deployed-code-package/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/details/details.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnInit, Injector } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { DeployedCodePackageBaseController } from '../DeployedCodePackageBase';
+import { DeployedCodePackageBaseControllerDirective } from '../DeployedCodePackageBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends DeployedCodePackageBaseController {
+export class DetailsComponent extends DeployedCodePackageBaseControllerDirective {
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);

--- a/src/SfxWeb/src/app/views/deployed-code-package/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/essentials/essentials.component.ts
@@ -1,13 +1,13 @@
 import { Component, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { DeployedCodePackageBaseController } from '../DeployedCodePackageBase';
+import { DeployedCodePackageBaseControllerDirective } from '../DeployedCodePackageBase';
 
 @Component({
   selector: 'app-essentials',
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends DeployedCodePackageBaseController {
+export class EssentialsComponent extends DeployedCodePackageBaseControllerDirective {
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);

--- a/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.html
+++ b/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.html
@@ -2,6 +2,6 @@
 
 <div class="main-view" *ngIf="codePackages">
     <div class="detail-pane essen-pane">
-        <app-detail-listlist [list]="codePackages" [listSettings]="listSettingsapp-detail-listail-list>
+        <app-detail-list [list]="codePackages" [listSettings]="listSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.html
+++ b/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.html
@@ -2,6 +2,6 @@
 
 <div class="main-view" *ngIf="codePackages">
     <div class="detail-pane essen-pane">
-        <detail-list [list]="codePackages" [listSettings]="listSettings"></detail-list>
+        <app-detail-listlist [list]="codePackages" [listSettings]="listSettingsapp-detail-listail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
@@ -17,7 +17,7 @@ import { SettingsService } from 'src/app/services/settings.service';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends BaseController {
+export class BaseComponent extends BaseControllerDirective {
   public nodeName: string;
   public appId: string;
   public serviceId: string;

--- a/src/SfxWeb/src/app/views/deployed-replica/DeployedReplicaBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/DeployedReplicaBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DeployedReplica } from 'src/app/Models/DataModels/DeployedReplica';
 
 @Directive()
-export class DeployedReplicaBaseController extends BaseController {
+export class DeployedReplicaBaseControllerDirective extends BaseControllerDirective {
     replicaStatus: number;
 
     nodeName: string;

--- a/src/SfxWeb/src/app/views/deployed-replica/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/base/base.component.ts
@@ -1,5 +1,5 @@
 import { Component, Injector } from '@angular/core';
-import { DeployedReplicaBaseController } from '../DeployedReplicaBase';
+import { DeployedReplicaBaseControllerDirective } from '../DeployedReplicaBase';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -12,7 +12,7 @@ import { ITab } from 'src/app/shared/component/navbar/navbar.component';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends DeployedReplicaBaseController {
+export class BaseComponent extends DeployedReplicaBaseControllerDirective {
 
   type = '';
 

--- a/src/SfxWeb/src/app/views/deployed-replica/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/details/details.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { DeployedReplicaBaseController } from '../DeployedReplicaBase';
+import { DeployedReplicaBaseControllerDirective } from '../DeployedReplicaBase';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends DeployedReplicaBaseController {
+export class DetailsComponent extends DeployedReplicaBaseControllerDirective {
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);

--- a/src/SfxWeb/src/app/views/deployed-replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/essentials/essentials.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { DeployedReplicaBaseController } from '../DeployedReplicaBase';
+import { DeployedReplicaBaseControllerDirective } from '../DeployedReplicaBase';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, of } from 'rxjs';
 import { RoutesService } from 'src/app/services/routes.service';
@@ -10,7 +10,7 @@ import { RoutesService } from 'src/app/services/routes.service';
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends DeployedReplicaBaseController {
+export class EssentialsComponent extends DeployedReplicaBaseControllerDirective {
   appView: string;
 
   constructor(protected data: DataService, injector: Injector) {

--- a/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.html
+++ b/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.html
@@ -2,7 +2,7 @@
     <app-navbar [type]="type" ></app-navbar>
     <div class="main-view">
         <div class="detail-pane essen-pane" *ngIf="listSettings">
-            <detail-list [list]="replicas" [listSettings]="listSettings"></detail-list>
+            <app-detail-list [list]="replicas" [listSettings]="listSettings"></app-detail-list>
         </div>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DeployedReplicaCollection } from 'src/app/Models/DataModels/collections/Collections';
 import { ListSettings, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingForLink } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
@@ -17,7 +17,7 @@ import { ActivatedRouteSnapshot } from '@angular/router';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends BaseController {
+export class BaseComponent extends BaseControllerDirective {
   nodeName: string;
   appId: string;
   serviceId: string;

--- a/src/SfxWeb/src/app/views/deployed-service-package/DeployedServicePackage.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/DeployedServicePackage.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { DeployedServicePackage } from 'src/app/Models/DataModels/DeployedServicePackage';
 
 @Directive()
-export class DeployedServicePackageBaseController extends BaseController {
+export class DeployedServicePackageBaseControllerDirective extends BaseControllerDirective {
     public serviceId: string;
     public activationId: string;
     public appId: string;

--- a/src/SfxWeb/src/app/views/deployed-service-package/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/base/base.component.ts
@@ -1,16 +1,16 @@
-import { Component, OnInit, Injector } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
-import { DeployedServicePackageBaseController } from '../DeployedServicePackage';
+import { DeployedServicePackageBaseControllerDirective } from '../DeployedServicePackage';
 
 @Component({
   selector: 'app-base',
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends DeployedServicePackageBaseController {
+export class BaseComponent extends DeployedServicePackageBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/deployed-service-package/details/details.component.html
+++ b/src/SfxWeb/src/app/views/deployed-service-package/details/details.component.html
@@ -7,6 +7,6 @@
         <h4>
             Health Events
         </h4>
-        <detail-list [list]="servicePackage.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+        <app-detail-list [list]="servicePackage.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-service-package/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/details/details.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Injector } from '@angular/core';
-import { DeployedServicePackageBaseController } from '../DeployedServicePackage';
+import { Component, Injector } from '@angular/core';
+import { DeployedServicePackageBaseControllerDirective } from '../DeployedServicePackage';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -9,7 +9,7 @@ import { SettingsService } from 'src/app/services/settings.service';
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends DeployedServicePackageBaseController {
+export class DetailsComponent extends DeployedServicePackageBaseControllerDirective {
   healthEventsListSettings: ListSettings;
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {

--- a/src/SfxWeb/src/app/views/deployed-service-package/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/deployed-service-package/essentials/essentials.component.html
@@ -50,6 +50,6 @@
 
     <div class="detail-pane essen-pane" *ngIf="servicePackage.health">
         <h4>Unhealthy Evaluations</h4>
-        <detail-list [list]="servicePackage.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></detail-list>
+        <app-detail-list [list]="servicePackage.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/deployed-service-package/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/essentials/essentials.component.ts
@@ -1,5 +1,5 @@
 import { Component, Injector } from '@angular/core';
-import { DeployedServicePackageBaseController } from '../DeployedServicePackage';
+import { DeployedServicePackageBaseControllerDirective } from '../DeployedServicePackage';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { ListSettings } from 'src/app/Models/ListSettings';
@@ -9,7 +9,7 @@ import { ListSettings } from 'src/app/Models/ListSettings';
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends DeployedServicePackageBaseController {
+export class EssentialsComponent extends DeployedServicePackageBaseControllerDirective {
   unhealthyEvaluationsListSettings: ListSettings;
 
 

--- a/src/SfxWeb/src/app/views/deployed-service-package/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/manifest/manifest.component.ts
@@ -1,5 +1,5 @@
 import { Component, Injector } from '@angular/core';
-import { DeployedServicePackageBaseController } from '../DeployedServicePackage';
+import { DeployedServicePackageBaseControllerDirective } from '../DeployedServicePackage';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
@@ -10,7 +10,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './manifest.component.html',
   styleUrls: ['./manifest.component.scss']
 })
-export class ManifestComponent extends DeployedServicePackageBaseController {
+export class ManifestComponent extends DeployedServicePackageBaseControllerDirective {
   serviceManifest: string;
 
   constructor(protected data: DataService, injector: Injector) {

--- a/src/SfxWeb/src/app/views/node/NodeBase.ts
+++ b/src/SfxWeb/src/app/views/node/NodeBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { Node } from 'src/app/Models/DataModels/Node';
 
 @Directive()
-export class NodeBaseController extends BaseController {
+export class NodeBaseControllerDirective extends BaseControllerDirective {
     nodeName: string;
     node: Node;
 

--- a/src/SfxWeb/src/app/views/node/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/node/base/base.component.ts
@@ -2,7 +2,7 @@ import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
-import { NodeBaseController } from '../NodeBase';
+import { NodeBaseControllerDirective } from '../NodeBase';
 import { DataService } from 'src/app/services/data.service';
 
 @Component({
@@ -10,7 +10,7 @@ import { DataService } from 'src/app/services/data.service';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends NodeBaseController {
+export class BaseComponent extends NodeBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/node/details/details.component.html
+++ b/src/SfxWeb/src/app/views/node/details/details.component.html
@@ -12,7 +12,7 @@
         <h4 collapse-header>
             Health Events
         </h4>    
-        <detail-list [list]="node.health.healthEvents" [listSettings]="healthEventsListSettings" collapse-body></detail-list>
+        <app-detail-list [list]="node.health.healthEvents" [listSettings]="healthEventsListSettings" collapse-body></app-detail-list>
     </app-collapse-container>
 </div>
 

--- a/src/SfxWeb/src/app/views/node/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/node/details/details.component.ts
@@ -4,7 +4,7 @@ import { DataService } from 'src/app/services/data.service';
 import { Observable, forkJoin } from 'rxjs';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { SettingsService } from 'src/app/services/settings.service';
-import { NodeBaseController } from '../NodeBase';
+import { NodeBaseControllerDirective } from '../NodeBase';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -12,7 +12,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends NodeBaseController {
+export class DetailsComponent extends NodeBaseControllerDirective {
   healthEventsListSettings: ListSettings;
 
 

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -90,7 +90,7 @@
       </div>
       <div *ngIf="node.raw.NodeDeactivationInfo.NodeDeactivationTask.length > 0">
         <label style="font-size: 16px;">Deactivation Tasks</label>
-        <table class="table app-detail-list" style="width: 100%">
+        <table class="table detail-list" style="width: 100%">
           <thead>
             <tr>
               <th>

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -90,7 +90,7 @@
       </div>
       <div *ngIf="node.raw.NodeDeactivationInfo.NodeDeactivationTask.length > 0">
         <label style="font-size: 16px;">Deactivation Tasks</label>
-        <table class="table detail-list" style="width: 100%">
+        <table class="table app-detail-list" style="width: 100%">
           <thead>
             <tr>
               <th>
@@ -134,8 +134,8 @@
       <h4>Unhealthy Evaluations</h4>
     </div>
     <div collapse-body>
-      <detail-list *ngIf="node" [list]="node.health.unhealthyEvaluations"
-        [listSettings]="unhealthyEvaluationsListSettings"></detail-list>
+      <app-detail-list *ngIf="node" [list]="node.health.unhealthyEvaluations"
+        [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>
@@ -146,7 +146,7 @@
       <h4>Deployed Applications</h4>
     </div>
     <div collapse-body>
-      <detail-list [list]="deployedApps.collection" [listSettings]="listSettings"></detail-list>
+      <app-detail-list [list]="deployedApps.collection" [listSettings]="listSettings"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
@@ -6,14 +6,14 @@ import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers'
 import { ListSettings, ListColumnSetting, ListColumnSettingForLink, ListColumnSettingForBadge, ListColumnSettingWithFilter } from 'src/app/Models/ListSettings';
 import { SettingsService } from 'src/app/services/settings.service';
 import { DeployedApplicationCollection } from 'src/app/Models/DataModels/collections/DeployedApplicationCollection';
-import { NodeBaseController } from '../NodeBase';
+import { NodeBaseControllerDirective } from '../NodeBase';
 
 @Component({
   selector: 'app-essentials',
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends NodeBaseController {
+export class EssentialsComponent extends NodeBaseControllerDirective {
 
   deployedApps: DeployedApplicationCollection;
   listSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/node/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/node/events/events.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
-import { NodeBaseController } from '../NodeBase';
+import { NodeBaseControllerDirective } from '../NodeBase';
 import { NodeTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
 import { NodeEventList } from 'src/app/Models/DataModels/collections/Collections';
 
@@ -9,7 +9,7 @@ import { NodeEventList } from 'src/app/Models/DataModels/collections/Collections
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends NodeBaseController {
+export class EventsComponent extends NodeBaseControllerDirective {
   nodeEvents: NodeEventList;
   nodeEventTimelineGenerator: NodeTimelineGenerator;
 

--- a/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.html
+++ b/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.html
@@ -1,3 +1,3 @@
 <div class="detail-pane essen-pane">
-    <detail-list [listSettings]="listSettings" [list]="nodes.collection"></detail-list>
+    <app-detail-list [listSettings]="listSettings" [list]="nodes.collection"></app-detail-list>
 </div>

--- a/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.ts
@@ -4,7 +4,7 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { ListSettings, ListColumnSettingForLink, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingForBadge } from 'src/app/Models/ListSettings';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollection';
 
 @Component({
@@ -12,7 +12,7 @@ import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollec
   templateUrl: './all-nodes.component.html',
   styleUrls: ['./all-nodes.component.scss']
 })
-export class AllNodesComponent extends BaseController {
+export class AllNodesComponent extends BaseControllerDirective {
 
   nodes: NodeCollection;
   listSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/partition/PartitionBase.ts
+++ b/src/SfxWeb/src/app/views/partition/PartitionBase.ts
@@ -5,11 +5,11 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { Partition } from 'src/app/Models/DataModels/Partition';
 
 @Directive()
-export class PartitionBaseController extends BaseController {
+export class PartitionBaseControllerDirective extends BaseControllerDirective {
     public appId: string;
     public serviceId: string;
     public partitionId: string;

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.html
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.html
@@ -27,7 +27,7 @@
     </div>
     
     <div *ngIf="partition && partition.replicas.isInitialized" class="detail-pane essen-pane">
-        <detail-list [list]="partition.partitionBackupInfo.partitionBackupList.collection" [listSettings]="partitionBackupListSettings" ></detail-list>
+        <app-detail-list [list]="partition.partitionBackupInfo.partitionBackupList.collection" [listSettings]="partitionBackupListSettings" ></app-detail-list>
     </div>
     
 </div>

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Injector } from '@angular/core';
 import { ListSettings, ListColumnSetting } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
-import { PartitionBaseController } from '../PartitionBase';
+import { PartitionBaseControllerDirective } from '../PartitionBase';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, of } from 'rxjs';
 import { ActionCollection } from 'src/app/Models/ActionCollection';
@@ -19,7 +19,7 @@ import { PartitionRestoreBackUpComponent } from '../partition-restore-back-up/pa
   templateUrl: './backups.component.html',
   styleUrls: ['./backups.component.scss']
 })
-export class BackupsComponent extends PartitionBaseController {
+export class BackupsComponent extends PartitionBaseControllerDirective {
 
   partitionBackupListSettings: ListSettings;
   actions: ActionCollection;

--- a/src/SfxWeb/src/app/views/partition/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/partition/base/base.component.ts
@@ -1,6 +1,6 @@
 import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
-import { PartitionBaseController } from '../PartitionBase';
+import { PartitionBaseControllerDirective } from '../PartitionBase';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -13,7 +13,7 @@ import { Constants } from 'src/app/Common/Constants';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends PartitionBaseController {
+export class BaseComponent extends PartitionBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/partition/details/details.component.html
+++ b/src/SfxWeb/src/app/views/partition/details/details.component.html
@@ -8,7 +8,7 @@
         <h4>
             Health Events
         </h4>
-        <detail-list [list]="partition.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+        <app-detail-list [list]="partition.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>
     </div>
     
     <div class="detail-pane essen-pane" *ngIf="partition.loadInformation && partition.loadInformation.isValid">

--- a/src/SfxWeb/src/app/views/partition/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/partition/details/details.component.ts
@@ -7,16 +7,16 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Partition } from 'src/app/Models/DataModels/Partition';
 import { ListSettings } from 'src/app/Models/ListSettings';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { map } from 'rxjs/operators';
-import { PartitionBaseController } from '../PartitionBase';
+import { PartitionBaseControllerDirective } from '../PartitionBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends PartitionBaseController {
+export class DetailsComponent extends PartitionBaseControllerDirective {
 
   healthEventsListSettings: ListSettings;
 

--- a/src/SfxWeb/src/app/views/partition/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/partition/essentials/essentials.component.html
@@ -106,8 +106,8 @@
         <h4>Unhealthy Evaluations</h4>
       </div>
       <div collapse-body>
-        <detail-list [list]="partition.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings">
-        </detail-list>
+        <app-detail-list [list]="partition.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings">
+        </app-detail-list>
       </div>
     </app-collapse-container>
   </div>
@@ -118,8 +118,8 @@
         <h4>{{partition.isStatelessService ? "Instances" : "Replicas"}}</h4>
       </div>
       <div collapse-body>
-        <detail-list [list]="partition.replicas.collection" [listSettings]="listSettings"
-          *ngIf="partition.replicas.isInitialized"></detail-list>
+        <app-detail-list [list]="partition.replicas.collection" [listSettings]="listSettings"
+          *ngIf="partition.replicas.isInitialized"></app-detail-list>
       </div>
     </app-collapse-container>
   </div>

--- a/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
@@ -4,14 +4,14 @@ import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, forkJoin, of } from 'rxjs';
-import { PartitionBaseController } from '../PartitionBase';
+import { PartitionBaseControllerDirective } from '../PartitionBase';
 
 @Component({
   selector: 'app-essentials',
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends PartitionBaseController {
+export class EssentialsComponent extends PartitionBaseControllerDirective {
 
   public hideReplicator = true;
 

--- a/src/SfxWeb/src/app/views/partition/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { PartitionBaseController } from '../PartitionBase';
+import { PartitionBaseControllerDirective } from '../PartitionBase';
 import { DataService } from 'src/app/services/data.service';
 import { PartitionEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { PartitionTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
@@ -9,7 +9,7 @@ import { PartitionTimelineGenerator } from 'src/app/Models/eventstore/timelineGe
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends PartitionBaseController {
+export class EventsComponent extends PartitionBaseControllerDirective {
   partitionEvents: PartitionEventList;
   partitionTimeLineGenerator: PartitionTimelineGenerator;
 

--- a/src/SfxWeb/src/app/views/replica/ReplicaBase.ts
+++ b/src/SfxWeb/src/app/views/replica/ReplicaBase.ts
@@ -5,12 +5,12 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { ReplicaOnPartition } from 'src/app/Models/DataModels/Replica';
 import { Constants } from 'src/app/Common/Constants';
 
 @Directive()
-export class ReplicaBaseController extends BaseController {
+export class ReplicaBaseControllerDirective extends BaseControllerDirective {
     public appId: string;
     public serviceId: string;
     public partitionId: string;

--- a/src/SfxWeb/src/app/views/replica/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/replica/base/base.component.ts
@@ -1,6 +1,6 @@
 import { Component, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
-import { ReplicaBaseController } from '../ReplicaBase';
+import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -11,7 +11,7 @@ import { Constants } from 'src/app/Common/Constants';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends ReplicaBaseController {
+export class BaseComponent extends ReplicaBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/replica/details/details.component.html
+++ b/src/SfxWeb/src/app/views/replica/details/details.component.html
@@ -32,7 +32,7 @@
                 </h4>
             </div>
             <div collapse-body>
-                <detail-list [list]="replica.health.healthEvents" [listSettings]="healthEventsListSettings" *ngIf="replica.health"></detail-list>
+                <app-detail-list [list]="replica.health.healthEvents" [listSettings]="healthEventsListSettings" *ngIf="replica.health"></app-detail-list>
             </div>
         </app-collapse-container>
     </div>

--- a/src/SfxWeb/src/app/views/replica/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/replica/details/details.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ReplicaBaseController } from '../ReplicaBase';
+import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
@@ -11,7 +11,7 @@ import { SettingsService } from 'src/app/services/settings.service';
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends ReplicaBaseController {
+export class DetailsComponent extends ReplicaBaseControllerDirective {
 
   healthEventsListSettings: ListSettings;
 

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
@@ -56,7 +56,7 @@
 
   <div class="detail-pane essen-pane" *ngIf="replica.health.isInitialized">
     <h4>Unhealthy Evaluations</h4>
-    <detail-list [list]="replica.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings">
-    </detail-list>
+    <app-detail-list [list]="replica.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings">
+    </app-detail-list>
   </div>
 </div>

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -5,7 +5,7 @@ import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
-import { ReplicaBaseController } from '../ReplicaBase';
+import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { RoutesService } from 'src/app/services/routes.service';
 
 @Component({
@@ -13,7 +13,7 @@ import { RoutesService } from 'src/app/services/routes.service';
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends ReplicaBaseController {
+export class EssentialsComponent extends ReplicaBaseControllerDirective {
   unhealthyEvaluationsListSettings: ListSettings;
   nodeView: string;
 

--- a/src/SfxWeb/src/app/views/replica/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ReplicaBaseController } from '../ReplicaBase';
+import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { DataService } from 'src/app/services/data.service';
 import { ReplicaEventList } from 'src/app/Models/DataModels/collections/Collections';
 
@@ -8,7 +8,7 @@ import { ReplicaEventList } from 'src/app/Models/DataModels/collections/Collecti
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends ReplicaBaseController {
+export class EventsComponent extends ReplicaBaseControllerDirective {
 
   replicaEvents: ReplicaEventList;
 

--- a/src/SfxWeb/src/app/views/service/ServiceBase.ts
+++ b/src/SfxWeb/src/app/views/service/ServiceBase.ts
@@ -5,11 +5,11 @@ import { Observable, forkJoin } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { IdUtils } from 'src/app/Utils/IdUtils';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { Service } from 'src/app/Models/DataModels/Service';
 
 @Directive()
-export class ServiceBaseController extends BaseController {
+export class ServiceBaseControllerDirective extends BaseControllerDirective {
     appId: string;
     serviceId: string;
     appTypeName: string;

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.html
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.html
@@ -5,6 +5,6 @@
     </div>
     <div class="detail-pane" *ngIf="service">
         <h4>Service Backup Configuration</h4>
-        <detail-list [list]="service.serviceBackupConfigurationInfoCollection" [listSettings]="serviceBackupConfigurationInfoListSettings"></detail-list>
+        <app-detail-list [list]="service.serviceBackupConfigurationInfoCollection" [listSettings]="serviceBackupConfigurationInfoListSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { ListSettings, ListColumnSetting } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -17,7 +17,7 @@ import { TelemetryService } from 'src/app/services/telemetry.service';
   templateUrl: './backup.component.html',
   styleUrls: ['./backup.component.scss']
 })
-export class BackupComponent extends ServiceBaseController {
+export class BackupComponent extends ServiceBaseControllerDirective {
   serviceBackupConfigurationInfoListSettings: ListSettings;
   actions: ActionCollection;
 

--- a/src/SfxWeb/src/app/views/service/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/service/base/base.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
 import { TreeService } from 'src/app/services/tree.service';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { DataService } from 'src/app/services/data.service';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
 import { Constants } from 'src/app/Common/Constants';
@@ -14,7 +14,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends ServiceBaseController {
+export class BaseComponent extends ServiceBaseControllerDirective {
 
   tabs: ITab[] = [{
     name: 'essentials',

--- a/src/SfxWeb/src/app/views/service/details/details.component.html
+++ b/src/SfxWeb/src/app/views/service/details/details.component.html
@@ -14,6 +14,6 @@
         <h4>
             Health Events
         </h4>
-        <detail-list [list]="service.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+        <app-detail-list [list]="service.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/service/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/service/details/details.component.ts
@@ -4,30 +4,21 @@ import { Observable, forkJoin } from 'rxjs';
 import { ListColumnSetting, ListSettings } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 
 @Component({
   selector: 'app-details',
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends ServiceBaseController {
+export class DetailsComponent extends ServiceBaseControllerDirective {
   healthEventsListSettings: ListSettings;
-  serviceBackupConfigurationInfoListSettings: ListSettings;
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {
     super(data, injector);
   }
 
   setup() {
-    this.serviceBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('serviceBackupConfigurationInfoListSettings', ['raw.PolicyName'], [
-      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], false, (item, property) => `<a href='${item.parent.viewPath}/tab/details'>${property}</a>`, 1, item => item.action.runWithCallbacks.apply(item.action)),
-      new ListColumnSetting('raw.Kind', 'Kind'),
-      new ListColumnSetting('raw.PolicyInheritedFrom', 'Policy Inherited From'),
-      new ListColumnSetting('raw.PartitionId', 'Partition Id'),
-      new ListColumnSetting('raw.SuspensionInfo.IsSuspended', 'Is Suspended'),
-      new ListColumnSetting('raw.SuspensionInfo.SuspensionInheritedFrom', 'Suspension Inherited From'),
-    ]);
     this.healthEventsListSettings = this.settings.getNewOrExistingHealthEventsListSettings();
   }
 

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.html
@@ -133,8 +133,8 @@
       <h4>Unhealthy Evaluations</h4>
     </div>
     <div collapse-body>
-      <detail-list [list]="service.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
-        *ngIf="service && service.health"></detail-list>
+      <app-detail-list [list]="service.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"
+        *ngIf="service && service.health"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>
@@ -145,8 +145,8 @@
       <h4>Partitions</h4>
     </div>
     <div collapse-body>
-      <detail-list [list]="service.partitions.collection" [listSettings]="listSettings"
-        *ngIf="service && service.partitions.isInitialized"></detail-list>
+      <app-detail-list [list]="service.partitions.collection" [listSettings]="listSettings"
+        *ngIf="service && service.partitions.isInitialized"></app-detail-list>
     </div>
   </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
@@ -4,7 +4,7 @@ import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable, forkJoin, of } from 'rxjs';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { map } from 'rxjs/operators';
 import { HealthUtils, HealthStatisticsEntityKind } from 'src/app/Utils/healthUtils';
 import { IDashboardViewModel, DashboardViewModel } from 'src/app/ViewModels/DashboardViewModels';
@@ -15,7 +15,7 @@ import { ServiceHealth } from 'src/app/Models/DataModels/Service';
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends ServiceBaseController {
+export class EssentialsComponent extends ServiceBaseControllerDirective {
 
   listSettings: ListSettings;
   unhealthyEvaluationsListSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/service/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/service/events/events.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { DataService } from 'src/app/services/data.service';
 import { ServiceEventList } from 'src/app/Models/DataModels/collections/Collections';
 
@@ -8,7 +8,7 @@ import { ServiceEventList } from 'src/app/Models/DataModels/collections/Collecti
   templateUrl: './events.component.html',
   styleUrls: ['./events.component.scss']
 })
-export class EventsComponent extends ServiceBaseController {
+export class EventsComponent extends ServiceBaseControllerDirective {
 
   serviceEvents: ServiceEventList;
 

--- a/src/SfxWeb/src/app/views/service/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/service/manifest/manifest.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ServiceBaseController } from '../ServiceBase';
+import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
@@ -10,7 +10,7 @@ import { map, mergeMap } from 'rxjs/operators';
   templateUrl: './manifest.component.html',
   styleUrls: ['./manifest.component.scss']
 })
-export class ManifestComponent extends ServiceBaseController {
+export class ManifestComponent extends ServiceBaseControllerDirective {
   serviceManifest: string;
 
   constructor(protected data: DataService, injector: Injector) {

--- a/src/SfxWeb/src/app/views/system-applications/SystemApplicationBase.ts
+++ b/src/SfxWeb/src/app/views/system-applications/SystemApplicationBase.ts
@@ -3,12 +3,12 @@ import { Injector, Directive } from '@angular/core';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
-import { BaseController } from 'src/app/ViewModels/BaseController';
+import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { SystemApplication } from 'src/app/Models/DataModels/Application';
 import { ListSettings } from 'src/app/Models/ListSettings';
 
 @Directive()
-export class ServiceApplicationsBaseController extends BaseController {
+export class ServiceApplicationsBaseControllerDirective extends BaseControllerDirective {
     systemApp: SystemApplication;
     listSettings: ListSettings;
     unhealthyEvaluationsListSettings: ListSettings;

--- a/src/SfxWeb/src/app/views/system-applications/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/system-applications/base/base.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ITab } from 'src/app/shared/component/navbar/navbar.component';
-import { ServiceApplicationsBaseController } from '../SystemApplicationBase';
+import { ServiceApplicationsBaseControllerDirective } from '../SystemApplicationBase';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
 import { DataService } from 'src/app/services/data.service';
 import { TreeService } from 'src/app/services/tree.service';
@@ -10,7 +10,7 @@ import { TreeService } from 'src/app/services/tree.service';
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class BaseComponent extends ServiceApplicationsBaseController {
+export class BaseComponent extends ServiceApplicationsBaseControllerDirective {
   tabs: ITab[] = [{
     name: 'essentials',
     route: './'

--- a/src/SfxWeb/src/app/views/system-applications/details/details.component.html
+++ b/src/SfxWeb/src/app/views/system-applications/details/details.component.html
@@ -4,6 +4,6 @@
         <h4>
             Health Events
         </h4>
-        <detail-list [list]="systemApp.health.healthEvents" [listSettings]="healthEventsListSettings"></detail-list>
+        <app-detail-list [list]="systemApp.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/system-applications/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/system-applications/details/details.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ServiceApplicationsBaseController } from '../SystemApplicationBase';
+import { ServiceApplicationsBaseControllerDirective } from '../SystemApplicationBase';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { ListSettings } from 'src/app/Models/ListSettings';
@@ -9,7 +9,7 @@ import { ListSettings } from 'src/app/Models/ListSettings';
   templateUrl: './details.component.html',
   styleUrls: ['./details.component.scss']
 })
-export class DetailsComponent extends ServiceApplicationsBaseController {
+export class DetailsComponent extends ServiceApplicationsBaseControllerDirective {
 
   healthEventsListSettings: ListSettings;
 

--- a/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.html
@@ -21,7 +21,7 @@
                 <h4>Unhealthy Evaluations</h4>
             </div>
             <div collapse-body>
-                <detail-list [list]="systemApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></detail-list>
+                <app-detail-list [list]="systemApp.health.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>
             </div>
         </app-collapse-container>
     </div>
@@ -32,7 +32,7 @@
                 <h4>System</h4>
             </div>
             <div collapse-body>
-                <detail-list [list]="systemApp.services.collection" [listSettings]="listSettings"></detail-list>
+                <app-detail-list [list]="systemApp.services.collection" [listSettings]="listSettings"></app-detail-list>
             </div>
         </app-collapse-container>
     </div>

--- a/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ServiceApplicationsBaseController } from '../SystemApplicationBase';
+import { ServiceApplicationsBaseControllerDirective } from '../SystemApplicationBase';
 import { ListSettings, ListColumnSettingForLink, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingForBadge } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
   templateUrl: './essentials.component.html',
   styleUrls: ['./essentials.component.scss']
 })
-export class EssentialsComponent extends ServiceApplicationsBaseController {
+export class EssentialsComponent extends ServiceApplicationsBaseControllerDirective {
 
   listSettings: ListSettings;
   unhealthyEvaluationsListSettings: ListSettings;

--- a/src/SfxWeb/src/styles.scss
+++ b/src/SfxWeb/src/styles.scss
@@ -804,7 +804,7 @@ app-navbar {
     border-bottom-color: inherit;
 }
 
-.nav-tabs .nav-link.active {
+.nav-item > .active {
     border-bottom-color: #0075c9;
     border-bottom-style: solid;
     color: #FFFFFF;

--- a/src/SfxWeb/tslint.json
+++ b/src/SfxWeb/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "tslint:recommended",
   "rules": {
+  
     "align": {
       "options": [
         "parameters",
@@ -44,7 +45,7 @@
     "max-classes-per-file": false,
     "max-line-length": [
       true,
-      140
+      200
     ],
     "member-access": false,
     "member-ordering": [


### PR DESCRIPTION
This is the second half of the linter "catching up", this is all manual changes made that the auto linter could not fix.

The primary fixes were naming changes like
* inherited controller names
*renaming private vars to not use _
* add "app" prefix to components
*changing outputs to not start with "on"

Additionally there were a couple deprecation alerts
* fixing an rxjs deprecated function
* changing the tabs for repair tasks to a new format

Change linter rules from 140char lines to 200

