### PR TITLE
Export table option and cleaning up table config

### DIFF
--- a/src/SfxWeb/cypress/integration/app.spec.js
+++ b/src/SfxWeb/cypress/integration/app.spec.js
@@ -89,7 +89,7 @@ context('app', () => {
 
     describe("backups", () => {
         it('view backup', () => {
-            cy.wait(waitRequest);
+            cy.wait([waitRequest, FIXTURE_REF_MANIFEST]);
             cy.route(apiUrl(`/Applications/${appName}/$/GetBackupConfigurationInfo?*`)).as('backup');
 
             cy.get('[data-cy=navtabs]').within(() => {

--- a/src/SfxWeb/cypress/integration/app.spec.js
+++ b/src/SfxWeb/cypress/integration/app.spec.js
@@ -49,13 +49,11 @@ context('app', () => {
 
     describe("details", () => {
         it('view details', () => {
-            cy.wait(waitRequest);
+            cy.wait([waitRequest, "@apphealth"]);
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('details').click();
             })
-
-            cy.wait("@apphealth")
 
             cy.url().should('include', '/details')
         })

--- a/src/SfxWeb/cypress/integration/app.spec.js
+++ b/src/SfxWeb/cypress/integration/app.spec.js
@@ -90,10 +90,13 @@ context('app', () => {
     describe("backups", () => {
         it('view backup', () => {
             cy.wait(waitRequest);
+            cy.route(apiUrl(`/Applications/${appName}/$/GetBackupConfigurationInfo?*`)).as('backup');
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('backup').click();
             })
+
+            cy.wait("@backup")
 
             cy.url().should('include', '/backup')
         })

--- a/src/SfxWeb/cypress/integration/app.spec.js
+++ b/src/SfxWeb/cypress/integration/app.spec.js
@@ -62,13 +62,14 @@ context('app', () => {
     })
 
     describe("deployments", () => {
-        it('view details', () => {
+        it('view deployments', () => {
             cy.wait(waitRequest);
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('deployments').click();
             })
 
+            cy.wait(waitRequest);
             cy.url().should('include', '/deployments')
         })
     })

--- a/src/SfxWeb/cypress/integration/node.spec.js
+++ b/src/SfxWeb/cypress/integration/node.spec.js
@@ -49,11 +49,11 @@ context('node page', () => {
 
     describe("details", () => {
         it('view details', () => {
-            cy.route('GET', apiUrl('/Nodes/_nt_0/$/GetLoadInformation?*'), 'fixture:node-load/get-node-load-information').as("nodeLoad")
+            cy.route('GET', apiUrl(`/Nodes/${nodeName}/$/GetLoadInformation?*`), 'fixture:node-load/get-node-load-information').as("nodeLoad")
 
             cy.visit(`/#/node/${nodeName}`)
 
-            cy.wait(nodeInfoRef);
+            cy.wait([nodeInfoRef, "@health"]);
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('details').click();

--- a/src/SfxWeb/cypress/integration/table.spec.js
+++ b/src/SfxWeb/cypress/integration/table.spec.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+import {
+    apiUrl, addDefaultFixtures, FIXTURE_REF_CLUSTERHEALTH
+} from './util';
+
+context('table', () => {
+
+    beforeEach(() => {
+        cy.server()
+        addDefaultFixtures();
+        cy.visit('')
+
+        cy.wait(FIXTURE_REF_CLUSTERHEALTH)
+    })
+
+    describe("export", () => {
+        const rowsSelector = "[data-cy=row]";
+        const columnSelector = "[data-cy=columns]";
+        const exportButtonSelector = "[data-cy=export]";
+
+        beforeEach(() => {
+            cy.get('[data-cy=health]').within(() => {
+                cy.contains("Export").click();
+            })
+        })
+        
+        it('unselect 1 column', () => {
+            cy.get('[data-cy=modal]').within(() => {
+                cy.get(columnSelector).within(() => {
+                    cy.contains('Health State').click();
+                })
+
+                cy.get(exportButtonSelector).click();
+                cy.get(rowsSelector).first().should('contain', 'Kind,Description')
+            })
+        })
+
+        it('unselect all columns', () => {
+            cy.get('[data-cy=modal]').within(() => {
+                cy.get(columnSelector).within(() => {
+                    cy.contains('Health State').click();
+                    cy.contains('Kind').click();
+                    cy.contains('Description').click();
+                })
+
+                cy.get(exportButtonSelector).click();
+                cy.get(rowsSelector).first().should(elem => expect(elem.text().trim()).length(0));
+            })
+        })
+
+        it('rows show up properly ', () => {
+            cy.get('[data-cy=modal]').within(() => {
+                cy.get(exportButtonSelector).click();
+
+                cy.get(rowsSelector).should('have.length', 5);
+                cy.get(rowsSelector).first().should('contain', 'Kind,Health State,Description')
+            })
+        })
+    })
+})
+
+/*
+test TODO
+paged data
+    select new page
+
+refresh data
+filter
+reset all
+*/

--- a/src/SfxWeb/cypress/integration/table.spec.js
+++ b/src/SfxWeb/cypress/integration/table.spec.js
@@ -24,7 +24,7 @@ context('table', () => {
                 cy.contains("Export").click();
             })
         })
-        
+
         it('unselect 1 column', () => {
             cy.get('[data-cy=modal]').within(() => {
                 cy.get(columnSelector).within(() => {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -409,13 +409,12 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
             new ListColumnSetting(
                 'raw.category',
                 'Event Category',
-                ['raw.category'],
                 {
                     enableFilter: true,
                     getDisplayHtml: (item) => (!item.raw.category ? 'Operational' : item.raw.category)
                 }),
-            new ListColumnSetting('raw.timeStampString', 'Timestamp', ['raw.timeStamp']),
-            new ListColumnSetting('raw.timeStamp', 'Timestamp(UTC)', ['raw.timeStamp'])],
+            new ListColumnSetting('raw.timeStampString', 'Timestamp'),
+            new ListColumnSetting('raw.timeStamp', 'Timestamp(UTC)')],
             [
                 new ListColumnSettingWithEventStoreFullDescription()
             ],

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -413,7 +413,7 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
                     enableFilter: true,
                     getDisplayHtml: (item) => (!item.raw.category ? 'Operational' : item.raw.category)
                 }),
-            new ListColumnSetting('raw.timeStampString', 'Timestamp'),
+            new ListColumnSetting('raw.timeStampString', 'Timestamp', {sortPropertyPaths: ['raw.timestamp']}),
             new ListColumnSetting('raw.timeStamp', 'Timestamp(UTC)')],
             [
                 new ListColumnSettingWithEventStoreFullDescription()

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -410,8 +410,10 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
                 'raw.category',
                 'Event Category',
                 ['raw.category'],
-                true,
-                (item) => (!item.raw.category ? 'Operational' : item.raw.category)),
+                {
+                    enableFilter: true,
+                    getDisplayHtml: (item) => (!item.raw.category ? 'Operational' : item.raw.category)
+                }),
             new ListColumnSetting('raw.timeStampString', 'Timestamp', ['raw.timeStamp']),
             new ListColumnSetting('raw.timeStamp', 'Timestamp(UTC)', ['raw.timeStamp'])],
             [

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -124,6 +124,15 @@ export class FilterValue {
     }
 }
 
+/**
+* @param sortPropertyPaths The properties to sort against when user click the column header, instead of defaulting to property path
+* @param enableFilter Whether to enable filters for this column
+* @param getDisplayHtml Customize the HTML to render in this column giving a specific item
+* @param colspan The colspan for the extra line, does not affect the first line
+* @param clickEvent A callback that will be executed on click
+* @param canNotExport This column will not be selectable when exporting table
+* @param alternateExportFormat Provide a different export formatting
+*/
 export interface IListColumnAdditionalSettings {
     sortPropertyPaths?: string[];
     enableFilter?: boolean;
@@ -160,16 +169,10 @@ export class ListColumnSetting {
      * Create a column setting
      * @param propertyPath The property path to retrieve display object/value
      * @param displayName The property name displayed in the column header
-     * @param sortPropertyPaths The properties to sort against when user click the column header
-     * @param enableFilter Whether to enable filters for this column
-     * @param getDisplayHtml Customize the HTML to render in this column giving a specific item
-     * @param colspan The colspan for the extra line, does not affect the first line
-     * @param clickEvent A callback that will be executed on click
      */
     public constructor(
         public propertyPath: string,
         public displayName: string,
-        // public sortPropertyPaths: string[] = [propertyPath],
         public config?: IListColumnAdditionalSettings) {
 
         const internalConfig: IListColumnAdditionalSettings = {
@@ -295,7 +298,7 @@ export class ListColumnSettingWithEventStoreRowDisplay extends ListColumnSetting
     }
 }
 
-export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSetting implements ITemplate{
+export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSetting implements ITemplate {
     template = FullDescriptionComponent;
     public constructor() {
         super('raw.eventInstanceId', '', {
@@ -306,11 +309,11 @@ export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSe
 }
 
 
-export class ListColumnSettingWithCustomComponent extends ListColumnSetting implements ITemplate{
+export class ListColumnSettingWithCustomComponent extends ListColumnSetting implements ITemplate {
     public constructor(public template: Type<DetailBaseComponent>,
-                       public propertyPath: string = '',
-                       public displayName: string = '',
-                       config?: IListColumnAdditionalSettings) {
+        public propertyPath: string = '',
+        public displayName: string = '',
+        config?: IListColumnAdditionalSettings) {
 
         super(propertyPath, displayName, config);
     }

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -308,9 +308,9 @@ export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSe
 
 export class ListColumnSettingWithCustomComponent extends ListColumnSetting implements ITemplate{
     public constructor(public template: Type<DetailBaseComponent>,
-        public propertyPath: string = '',
-        public displayName: string = '',
-        config?: IListColumnAdditionalSettings) {
+                       public propertyPath: string = '',
+                       public displayName: string = '',
+                       config?: IListColumnAdditionalSettings) {
 
         super(propertyPath, displayName, config);
     }

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -96,7 +96,7 @@ export class ListSettings {
     }
 
     public isSortedByColumn(columnSetting: ListColumnSetting): boolean {
-        return Utils.arraysAreEqual(this.sortPropertyPaths, columnSetting.sortPropertyPaths);
+        return Utils.arraysAreEqual(this.sortPropertyPaths, columnSetting.config.sortPropertyPaths);
     }
 
     public reset(): void {
@@ -125,6 +125,7 @@ export class FilterValue {
 }
 
 export interface IListColumnAdditionalSettings {
+    sortPropertyPaths?: string[];
     enableFilter?: boolean;
     getDisplayHtml?: (item, property) => string;
     colspan?: number;
@@ -149,7 +150,7 @@ export class ListColumnSetting {
     }
 
     public get sortable(): boolean {
-        return this.sortPropertyPaths && this.sortPropertyPaths.length > 0;
+        return this.config.sortPropertyPaths.length > 0;
     }
 
     /**
@@ -165,7 +166,7 @@ export class ListColumnSetting {
     public constructor(
         public propertyPath: string,
         public displayName: string,
-        public sortPropertyPaths: string[] = [propertyPath],
+        // public sortPropertyPaths: string[] = [propertyPath],
         public config?: IListColumnAdditionalSettings) {
 
             const internalConfig: IListColumnAdditionalSettings = {
@@ -173,10 +174,11 @@ export class ListColumnSetting {
                 colspan: 1,
                 clickEvent: (item) => null,
                 canNotExport: false,
+                sortPropertyPaths: [propertyPath],
                 ...config
-            }
-            
-            this.config = internalConfig
+            };
+
+            this.config = internalConfig;
     }
 
     public reset(): void {
@@ -221,10 +223,10 @@ export class ListColumnSetting {
 export class ListColumnSettingForBadge extends ListColumnSetting {
     public constructor(
         propertyPath: string,
-        displayName: string,
-        sortPropertyPaths: string[] = [propertyPath + '.text']) {
+        displayName: string) {
 
-        super(propertyPath, displayName, sortPropertyPaths, { enableFilter: true,
+        super(propertyPath, displayName, { enableFilter: true,
+            sortPropertyPaths: [propertyPath + '.text'],
                                                              getDisplayHtml: (item, property) => HtmlUtils.getBadgeHtml(property),
                                                             alternateExportFormat: (item: ITextAndBadge) => item.text });
     }
@@ -242,9 +244,8 @@ export class ListColumnSettingWithFilter extends ListColumnSetting {
     public constructor(
         propertyPath: string,
         displayName: string,
-        sortPropertyPaths: string[] = [propertyPath]) {
-
-        super(propertyPath, displayName, sortPropertyPaths, { enableFilter: true});
+        config?: IListColumnAdditionalSettings) {
+        super(propertyPath, displayName, { enableFilter: true, ...config});
     }
 }
 
@@ -254,7 +255,7 @@ export class ListColumnSettingForLink extends ListColumnSetting {
         propertyPath: string,
         displayName: string,
         public href: (item: any) => string) {
-        super(propertyPath, displayName, [propertyPath], {
+        super(propertyPath, displayName, {
             enableFilter: false,
         });
     }
@@ -265,10 +266,9 @@ export class ListColumnSettingWithCopyText extends ListColumnSetting {
     public constructor(
         propertyPath: string,
         displayName: string,
-        sortPropertyPath: string[] = [],
         config?: IListColumnAdditionalSettings) {
 
-        super(propertyPath, displayName, sortPropertyPath, config);
+        super(propertyPath, displayName, config);
     }
 }
 
@@ -277,24 +277,23 @@ export class ListColumnSettingWithUtcTime extends ListColumnSetting {
     public constructor(
         propertyPath: string,
         displayName: string,
-        sortPropertyPath: string[] = [],
         config?: IListColumnAdditionalSettings) {
 
-        super(propertyPath, displayName, sortPropertyPath, config);
+        super(propertyPath, displayName, config);
     }
 }
 
 export class ListColumnSettingWithEventStoreRowDisplay extends ListColumnSetting {
     template = RowDisplayComponent;
     public constructor() {
-        super('raw.kind', 'Type', ['raw.kind'], { enableFilter: true});
+        super('raw.kind', 'Type', { enableFilter: true});
     }
 }
 
 export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSetting {
     template = FullDescriptionComponent;
     public constructor() {
-        super('raw.eventInstanceId', '', [], {
+        super('raw.eventInstanceId', '', {
             colspan : -1,
             enableFilter: false
         });
@@ -306,9 +305,8 @@ export class ListColumnSettingWithCustomComponent extends ListColumnSetting {
     public constructor(public template: Type<DetailBaseComponent>,
                        public propertyPath: string = '',
                        public displayName: string = '',
-                       public sortPropertyPaths: string[] = [propertyPath],
                        config?: IListColumnAdditionalSettings) {
 
-        super(propertyPath, displayName, sortPropertyPaths, config);
+        super(propertyPath, displayName, config);
     }
 }

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -134,6 +134,9 @@ export interface IListColumnAdditionalSettings {
     alternateExportFormat?: (item) => string;
 }
 
+export interface ITemplate {
+    template: Type<DetailBaseComponent>;
+}
 export class ListColumnSetting {
     // This array contains all unique values in the specified property of items in current list.
     // This will be populated by DetailListDirective when the list changes.
@@ -169,16 +172,16 @@ export class ListColumnSetting {
         // public sortPropertyPaths: string[] = [propertyPath],
         public config?: IListColumnAdditionalSettings) {
 
-            const internalConfig: IListColumnAdditionalSettings = {
-                enableFilter: false,
-                colspan: 1,
-                clickEvent: (item) => null,
-                canNotExport: false,
-                sortPropertyPaths: [propertyPath],
-                ...config
-            };
+        const internalConfig: IListColumnAdditionalSettings = {
+            enableFilter: false,
+            colspan: 1,
+            clickEvent: (item) => null,
+            canNotExport: false,
+            sortPropertyPaths: [propertyPath],
+            ...config
+        };
 
-            this.config = internalConfig;
+        this.config = internalConfig;
     }
 
     public reset(): void {
@@ -225,10 +228,12 @@ export class ListColumnSettingForBadge extends ListColumnSetting {
         propertyPath: string,
         displayName: string) {
 
-        super(propertyPath, displayName, { enableFilter: true,
+        super(propertyPath, displayName, {
+            enableFilter: true,
             sortPropertyPaths: [propertyPath + '.text'],
-                                                             getDisplayHtml: (item, property) => HtmlUtils.getBadgeHtml(property),
-                                                            alternateExportFormat: (item: ITextAndBadge) => item.text });
+            getDisplayHtml: (item, property) => HtmlUtils.getBadgeHtml(property),
+            alternateExportFormat: (item: ITextAndBadge) => item.text
+        });
     }
 
     public getTextValue(item: any): string {
@@ -245,7 +250,7 @@ export class ListColumnSettingWithFilter extends ListColumnSetting {
         propertyPath: string,
         displayName: string,
         config?: IListColumnAdditionalSettings) {
-        super(propertyPath, displayName, { enableFilter: true, ...config});
+        super(propertyPath, displayName, { enableFilter: true, ...config });
     }
 }
 
@@ -283,29 +288,29 @@ export class ListColumnSettingWithUtcTime extends ListColumnSetting {
     }
 }
 
-export class ListColumnSettingWithEventStoreRowDisplay extends ListColumnSetting {
+export class ListColumnSettingWithEventStoreRowDisplay extends ListColumnSetting implements ITemplate {
     template = RowDisplayComponent;
     public constructor() {
-        super('raw.kind', 'Type', { enableFilter: true});
+        super('raw.kind', 'Type', { enableFilter: true });
     }
 }
 
-export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSetting {
+export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSetting implements ITemplate{
     template = FullDescriptionComponent;
     public constructor() {
         super('raw.eventInstanceId', '', {
-            colspan : -1,
+            colspan: -1,
             enableFilter: false
         });
     }
 }
 
 
-export class ListColumnSettingWithCustomComponent extends ListColumnSetting {
+export class ListColumnSettingWithCustomComponent extends ListColumnSetting implements ITemplate{
     public constructor(public template: Type<DetailBaseComponent>,
-                       public propertyPath: string = '',
-                       public displayName: string = '',
-                       config?: IListColumnAdditionalSettings) {
+        public propertyPath: string = '',
+        public displayName: string = '',
+        config?: IListColumnAdditionalSettings) {
 
         super(propertyPath, displayName, config);
     }

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -125,14 +125,14 @@ export class FilterValue {
 }
 
 /**
-* @param sortPropertyPaths The properties to sort against when user click the column header, instead of defaulting to property path
-* @param enableFilter Whether to enable filters for this column
-* @param getDisplayHtml Customize the HTML to render in this column giving a specific item
-* @param colspan The colspan for the extra line, does not affect the first line
-* @param clickEvent A callback that will be executed on click
-* @param canNotExport This column will not be selectable when exporting table
-* @param alternateExportFormat Provide a different export formatting
-*/
+ * @param sortPropertyPaths The properties to sort against when user click the column header, instead of defaulting to property path
+ * @param enableFilter Whether to enable filters for this column
+ * @param getDisplayHtml Customize the HTML to render in this column giving a specific item
+ * @param colspan The colspan for the extra line, does not affect the first line
+ * @param clickEvent A callback that will be executed on click
+ * @param canNotExport This column will not be selectable when exporting table
+ * @param alternateExportFormat Provide a different export formatting
+ */
 export interface IListColumnAdditionalSettings {
     sortPropertyPaths?: string[];
     enableFilter?: boolean;
@@ -311,9 +311,9 @@ export class ListColumnSettingWithEventStoreFullDescription extends ListColumnSe
 
 export class ListColumnSettingWithCustomComponent extends ListColumnSetting implements ITemplate {
     public constructor(public template: Type<DetailBaseComponent>,
-        public propertyPath: string = '',
-        public displayName: string = '',
-        config?: IListColumnAdditionalSettings) {
+                       public propertyPath: string = '',
+                       public displayName: string = '',
+                       config?: IListColumnAdditionalSettings) {
 
         super(propertyPath, displayName, config);
     }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list-templates.module.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list-templates.module.ts
@@ -11,11 +11,12 @@ import { SharedModule } from 'src/app/shared/shared.module';
 import { NgbPaginationModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { UtcTimestampComponent } from './utc-timestamp/utc-timestamp.component';
+import { ExportModalComponent } from './export-modal/export-modal.component';
 
 
 
 @NgModule({
-  declarations: [HyperLinkComponent, DetailTableResolverComponent, ResolverDirective, CopyTextComponent, ResolverDirective, DetailListComponent, PagerComponent, UtcTimestampComponent],
+  declarations: [HyperLinkComponent, DetailTableResolverComponent, ResolverDirective, CopyTextComponent, ResolverDirective, DetailListComponent, PagerComponent, UtcTimestampComponent, ExportModalComponent],
   imports: [
     CommonModule,
     RouterModule,

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list-templates.module.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list-templates.module.ts
@@ -16,7 +16,8 @@ import { ExportModalComponent } from './export-modal/export-modal.component';
 
 
 @NgModule({
-  declarations: [HyperLinkComponent, DetailTableResolverComponent, ResolverDirective, CopyTextComponent, ResolverDirective, DetailListComponent, PagerComponent, UtcTimestampComponent, ExportModalComponent],
+  declarations: [HyperLinkComponent, DetailTableResolverComponent, ResolverDirective, CopyTextComponent, ResolverDirective,
+                 DetailListComponent, PagerComponent, UtcTimestampComponent, ExportModalComponent],
   imports: [
     CommonModule,
     RouterModule,

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -2,6 +2,8 @@
         <app-input [placeholder]="searchText" [model]="listSettings.search" (changed)="listSettings.search = $event; updateList()"></app-input>
         <button class="simple-button"  (click)="resetAll()">Reset All</button>
 
+        <button class="simple-button" style="float: right;" (click)="export()"> <span class="mif-download2"></span> Export</button>
+
         <label aria-live="off" aria-atomic="true" class="sr-only">There are {{sortedFilteredList.length}} items in the search result    </label>
         <div class="table-responsive">
             <table class="table detail-list">
@@ -55,7 +57,7 @@
                                 <button class="row-expander {{item.isSecondRowCollapsed ? 'mif-chevron-thin-down' : 'mif-chevron-thin-up' }} flat-button" (click)="handleClickRow(item, $event)"
                                 *ngIf="i === 0 && listSettings.secondRowCollapsible && listSettings.showSecondRow(item)" [attr.aria-expanded]="!item.isSecondRowCollapsed"
                                 [title]="item.isSecondRowCollapsed ? 'Expand the row' : 'Collapse the row'"></button>
-                                <span *ngIf="!columnSetting.template" [innerHtml]="columnSetting.getDisplayContentsInHtml(item)" (click)="columnSetting.clickEvent(item);" style="cursor: auto;"></span>
+                                <span *ngIf="!columnSetting.template" [innerHtml]="columnSetting.getDisplayContentsInHtml(item)" (click)="columnSetting.config.clickEvent(item);" style="cursor: auto;"></span>
                                 <app-detail-table-resolver *ngIf="columnSetting.template" [template]="columnSetting.template" [item]="item" [setting]="columnSetting" ></app-detail-table-resolver>                                
                             </div>
                             </td>
@@ -67,11 +69,11 @@
                             <!-- TODO  track by columnSetting.propertyPath -->
                                 <td class="no-border"
                                 *ngFor="let columnSetting of listSettings.secondRowColumnSettings; trackBy: trackByColumnSetting; let i = index;"
-                                [colSpan]="columnSetting.colspan === -1 ? (listSettings.columnSettings.length - listSettings.secondRowColumnSettings.length + 1) : columnSetting.colspan"
+                                [colSpan]="columnSetting.config.colspan === -1 ? (listSettings.columnSettings.length - listSettings.secondRowColumnSettings.length + 1) : columnSetting.config.colspan"
                                 [ngClass]="{'no-padding': listSettings.secondRowCollapsible && item.isSecondRowCollapsed}">
                                 <div 
                                     [ngClass]="{'shift-expander-col': i === 0 && listSettings.secondRowCollapsible}">
-                                    <span *ngIf="!columnSetting.template" [innerHtml]="columnSetting.getDisplayContentsInHtml(item)" (click)="columnSetting.clickEvent(item);" style="cursor: auto;"></span>
+                                    <span *ngIf="!columnSetting.template" [innerHtml]="columnSetting.getDisplayContentsInHtml(item)" (click)="columnSetting.config.clickEvent(item);" style="cursor: auto;"></span>
                                     <app-detail-table-resolver *ngIf="columnSetting.template" [template]="columnSetting.template" [item]="item" [setting]="columnSetting" ></app-detail-table-resolver>
                                 </div>
                             </td>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -14,7 +14,7 @@
                         [attr.aria-sort]="listSettings.isSortedByColumn(columnSetting) ? listSettings.sortReverse ? 'ascending' : 'descending' : 'none'">
                         <!-- Header label -->
                         <button  class="flat-button" [ngClass]="{'active': columnSetting.sortable, 'shift-expander-col': i === 0 && listSettings.secondRowCollapsible}" tabindex="0"
-                            (click)="sort(columnSetting);" [title]="'Sort by' + columnSetting.displayName + listSettings.sortReverse ? 'ascending' : 'descending'">
+                            style="padding-left: 0px;" (click)="sort(columnSetting);" [title]="'Sort by' + columnSetting.displayName + listSettings.sortReverse ? 'ascending' : 'descending'">
                             {{columnSetting.displayName}}
                       </button>
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -83,7 +83,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
         list: this.sortedFilteredList,
         config: this.listSettings
       }
-    })
+    });
   }
 
   public handleClickRow(item: any, event: any): void {
@@ -98,7 +98,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   }
 
   sort(columnSetting: ListColumnSetting) {
-    this.listSettings.sort(columnSetting.sortPropertyPaths);
+    this.listSettings.sort(columnSetting.config.sortPropertyPaths);
     this.updateList();
 
     if (!Utils.isIEOrEdge) {

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -16,6 +16,8 @@ import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { MatDialog } from '@angular/material/dialog';
+import { ExportModalComponent } from '../export-modal/export-modal.component';
 @Component({
   selector: 'app-detail-list',
   templateUrl: './detail-list.component.html',
@@ -38,7 +40,8 @@ export class DetailListComponent implements OnInit, OnDestroy {
   debouncerHandlerSubscription: Subscription;
   @ViewChildren(NgbDropdown) dropdowns: QueryList<NgbDropdown>;
 
-  constructor(private liveAnnouncer: LiveAnnouncer) { }
+  constructor(private liveAnnouncer: LiveAnnouncer,
+              private dialog: MatDialog) { }
 
   @Input()
   set list(data: any[] | DataModelCollectionBase<any>) {
@@ -71,6 +74,16 @@ export class DetailListComponent implements OnInit, OnDestroy {
 
   resetAll() {
     this.listSettings.reset();
+  }
+
+  export() {
+    this.dialog.open(ExportModalComponent, {
+      panelClass: 'mat-dialog-container-wrapper',
+      data : {
+        list: this.sortedFilteredList,
+        config: this.listSettings
+      }
+    })
   }
 
   public handleClickRow(item: any, event: any): void {
@@ -144,7 +157,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
 
     // Update each column filter values by scanning through the list and found out all unique values exist in current column
     listSettings.columnSettings.forEach((columnSetting: ListColumnSetting) => {
-        if (!columnSetting.enableFilter) {
+        if (!columnSetting.config.enableFilter) {
             return;
         }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
@@ -1,0 +1,28 @@
+<div class="action-modal">
+    <div class="modal-header">
+        <h4 class="modal-title">Export Table</h4>
+    </div>
+    <div class="modal-body" style="display: flex; flex-direction: column;">
+        Export the table to CSV by selecting which columns to include.
+        
+        <ul>
+            <ng-container  *ngFor="let column of data.config.columnSettings">
+                <li *ngIf="!column.config.canNotExport" >
+                    <input type="checkbox" [name]="column.displayName" [(ngModel)]="selected[column.displayName]"
+                            [id]="column.displayName" style="margin-right: 5px;">  <label [for]="column.displayName">{{column.displayName}}</label>
+                </li>
+            </ng-container >
+        </ul>
+
+        <div class="text-wrapper" contenteditable="true" *ngIf="text.length > 0">
+            <div *ngFor="let row of text" class="text-row">
+                {{row}}
+            </div>
+        </div>
+
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="solid-button blue" (click)="export()">Export</button>
+        <button type="button" class="flat-button" (click)="dialogRef.close()">Cancel</button>
+    </div>
+</div>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
@@ -4,19 +4,20 @@
     </div>
     <div class="modal-body" style="display: flex; flex-direction: column;">
         Export the table to CSV by selecting which columns to include.
-        
+
         <ul data-cy="columns">
-            <ng-container  *ngFor="let column of data.config.columnSettings">
-                <li *ngIf="!column.config.canNotExport" >
+            <ng-container *ngFor="let column of data.config.columnSettings">
+                <li *ngIf="!column.config.canNotExport">
                     <input type="checkbox" [name]="column.displayName" [(ngModel)]="selected[column.displayName]"
-                            [id]="column.displayName" style="margin-right: 5px;">  <label [for]="column.displayName">{{column.displayName}}</label>
+                        [id]="column.displayName" style="margin-right: 5px;"> <label
+                        [for]="column.displayName">{{column.displayName}}</label>
                 </li>
-            </ng-container >
+            </ng-container>
         </ul>
 
         <div style="margin: auto; margin-bottom: 10px;" *ngIf="text.length > 0">
             Copy to Clipboard
-            <app-clip-board [text]="copyText" ></app-clip-board>
+            <app-clip-board [text]="copyText"></app-clip-board>
         </div>
 
         <div class="text-wrapper" contenteditable="true" *ngIf="text.length > 0">

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
@@ -14,6 +14,11 @@
             </ng-container >
         </ul>
 
+        <div style="margin: auto; margin-bottom: 10px;" *ngIf="text.length > 0">
+            Copy to Clipboard
+            <app-clip-board [text]="copyText" ></app-clip-board>
+        </div>
+
         <div class="text-wrapper" contenteditable="true" *ngIf="text.length > 0">
             <div *ngFor="let row of text" class="text-row">
                 {{row}}

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.html
@@ -1,11 +1,11 @@
-<div class="action-modal">
+<div class="action-modal" data-cy="modal">
     <div class="modal-header">
         <h4 class="modal-title">Export Table</h4>
     </div>
     <div class="modal-body" style="display: flex; flex-direction: column;">
         Export the table to CSV by selecting which columns to include.
         
-        <ul>
+        <ul data-cy="columns">
             <ng-container  *ngFor="let column of data.config.columnSettings">
                 <li *ngIf="!column.config.canNotExport" >
                     <input type="checkbox" [name]="column.displayName" [(ngModel)]="selected[column.displayName]"
@@ -20,14 +20,12 @@
         </div>
 
         <div class="text-wrapper" contenteditable="true" *ngIf="text.length > 0">
-            <div *ngFor="let row of text" class="text-row">
-                {{row}}
-            </div>
+            <div *ngFor="let row of text" class="text-row" data-cy="row">{{row}}</div>
         </div>
 
     </div>
     <div class="modal-footer">
-        <button type="submit" class="solid-button blue" (click)="export()">Export</button>
+        <button type="submit" class="solid-button blue" (click)="export()" data-cy="export">Export</button>
         <button type="button" class="flat-button" (click)="dialogRef.close()">Cancel</button>
     </div>
 </div>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.scss
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.scss
@@ -1,0 +1,25 @@
+ul {
+    list-style: none;
+}
+
+li {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+label {
+    margin-bottom: 0px;
+}
+
+.text-row {
+    white-space: nowrap;
+}
+
+.text-wrapper {
+    overflow: auto;
+    flex: auto;
+    border: 1px solid gray;
+    padding: 5px;
+    border-radius: 5px;
+}

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.spec.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExportModalComponent } from './export-modal.component';
+
+describe('ExportModalComponent', () => {
+  let component: ExportModalComponent;
+  let fixture: ComponentFixture<ExportModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ExportModalComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExportModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -9,7 +9,7 @@ import { IExportInfo, exportInfo } from './utils';
 export class ExportModalComponent implements OnInit {
 
   public text = [];
-
+  public copyText = "";
   public selected: Record<string, boolean> = {};
   constructor(@Inject(MAT_DIALOG_DATA) public data: IExportInfo,
               public dialogRef: MatDialogRef<ExportModalComponent>) { }
@@ -20,5 +20,6 @@ export class ExportModalComponent implements OnInit {
 
   export() {
     this.text = exportInfo(this.data, this.selected);
+    this.copyText = this.text.join("\n")
   }
 }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -1,0 +1,24 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { IExportInfo, exportInfo } from './utils';
+@Component({
+  selector: 'app-export-modal',
+  templateUrl: './export-modal.component.html',
+  styleUrls: ['./export-modal.component.scss']
+})
+export class ExportModalComponent implements OnInit {
+
+  public text = [];
+
+  public selected: Record<string, boolean> = {};
+  constructor(@Inject(MAT_DIALOG_DATA) public data: IExportInfo,
+              public dialogRef: MatDialogRef<ExportModalComponent>) { }
+
+  ngOnInit(): void {
+    this.selected = this.data.config.columnSettings.reduce( (previous, current) => {previous[current.displayName] = true; return previous}, {});
+  }
+
+  export() {
+    this.text = exportInfo(this.data, this.selected);
+  }
+}

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -9,7 +9,7 @@ import { IExportInfo, exportInfo } from './utils';
 export class ExportModalComponent implements OnInit {
 
   public text = [];
-  public copyText = "";
+  public copyText = '';
   public selected: Record<string, boolean> = {};
   constructor(@Inject(MAT_DIALOG_DATA) public data: IExportInfo,
               public dialogRef: MatDialogRef<ExportModalComponent>) { }
@@ -20,6 +20,6 @@ export class ExportModalComponent implements OnInit {
 
   export() {
     this.text = exportInfo(this.data, this.selected);
-    this.copyText = this.text.join("\n")
+    this.copyText = this.text.join('\n');
   }
 }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -15,7 +15,7 @@ export class ExportModalComponent implements OnInit {
               public dialogRef: MatDialogRef<ExportModalComponent>) { }
 
   ngOnInit(): void {
-    this.selected = this.data.config.columnSettings.reduce( (previous, current) => {previous[current.displayName] = true; return previous}, {});
+    this.selected = this.data.config.columnSettings.reduce((previous, current) => { previous[current.displayName] = true; return previous; }, {});
   }
 
   export() {

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
@@ -3,10 +3,10 @@ import { Utils } from 'src/app/Utils/Utils';
 
 export interface IExportInfo {
     config: ListSettings;
-    list: any[]
+    list: any[];
 }
 
-const delimiter = ",";
+const delimiter = ',';
 
 export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>) => {
     const selectedColumns = info.config.columnSettings.filter(column => selected[column.displayName] && !column.config.canNotExport);
@@ -15,7 +15,7 @@ export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>)
 
     const rows = info.list.map(item => {
         const row = selectedColumns.map(column => {
-            let value = Utils.result(item, column.propertyPath)
+            let value = Utils.result(item, column.propertyPath);
 
             if (column.config.alternateExportFormat !== undefined) {
                 value = column.config.alternateExportFormat(value);
@@ -25,7 +25,7 @@ export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>)
         }).join(delimiter);
 
         return row;
-    })
+    });
 
     return [header, ...rows];
-}
+};

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
@@ -1,0 +1,31 @@
+import { ListSettings } from 'src/app/Models/ListSettings';
+import { Utils } from 'src/app/Utils/Utils';
+
+export interface IExportInfo {
+    config: ListSettings;
+    list: any[]
+}
+
+const delimiter = ",";
+
+export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>) => {
+    const selectedColumns = info.config.columnSettings.filter(column => selected[column.displayName] && !column.config.canNotExport);
+
+    const header = selectedColumns.map(column => column.displayName);
+
+    const rows = info.list.map(item => {
+        const row = selectedColumns.map(column => {
+            let value = Utils.result(item, column.propertyPath)
+
+            if (column.config.alternateExportFormat !== undefined) {
+                value = column.config.alternateExportFormat(value);
+            }
+
+            return value;
+        }).join(delimiter);
+
+        return row;
+    })
+
+    return [header, ...rows];
+}

--- a/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
@@ -24,7 +24,7 @@ export class ListColumnSettingWithDisplayName extends ListColumnSetting {
   template = DisplayNameColumnComponent;
   imagestore: ImageStore;
   public constructor(imagestore: ImageStore) {
-      super('displayName', 'name', ['isFolder', 'displayName']);
+      super('displayName', 'name', {sortPropertyPaths: ['isFolder', 'displayName']});
       this.imagestore = imagestore;
   }
 }

--- a/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
@@ -71,7 +71,7 @@ export class ListColumnSettingWithDisplaySize extends ListColumnSetting {
   template = DisplaySizeColumnComponent;
   imagestore: ImageStore;
   public constructor(imagestore: ImageStore) {
-      super('displayedSize', 'Size', ['isFolder', 'size', 'displayName']);
+      super('displayedSize', 'Size', {sortPropertyPaths: ['isFolder', 'size', 'displayName']});
       this.imagestore = imagestore;
   }
 }

--- a/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
@@ -36,7 +36,7 @@ export class FolderActionsComponent  implements DetailBaseComponent {
 export class ListColumnSettingWithImageStoreActions extends ListColumnSetting {
   template = FolderActionsComponent;
   public constructor(public imagestore: ImageStore) {
-      super('', '', [], {
+      super('', '', {
         canNotExport: true
       });
   }

--- a/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
@@ -36,6 +36,8 @@ export class FolderActionsComponent  implements DetailBaseComponent {
 export class ListColumnSettingWithImageStoreActions extends ListColumnSetting {
   template = FolderActionsComponent;
   public constructor(public imagestore: ImageStore) {
-      super('', '');
+      super('', '', [], {
+        canNotExport: true
+      });
   }
 }

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
@@ -29,7 +29,7 @@ export class ImagestoreViewerComponent implements OnInit {
       new ListColumnSettingWithDisplayName(this.imagestoreRoot),
       new ListColumnSettingWithDisplaySize(this.imagestoreRoot),
       new ListColumnSettingWithUtcTime('modifiedDate', 'Date modified'),
-      new ListColumnSetting('fileCount', 'Count of Files', ['isFolder', 'fileCount'])
+      new ListColumnSetting('fileCount', 'Count of Files', {sortPropertyPaths: ['isFolder', 'fileCount']})
     ]);
   }
 

--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -95,8 +95,8 @@ export class SettingsService {
           ],
           // Second row with description
           [
-              new ListColumnSetting('placeholder', 'placeholder', null, {enableFilter: false}), // Empty column
-              new ListColumnSettingWithCopyText('description', 'Description', [], {enableFilter: false, colspan: 7})
+              new ListColumnSetting('placeholder', 'placeholder', {enableFilter: false}), // Empty column
+              new ListColumnSettingWithCopyText('description', 'Description', {enableFilter: false, colspan: 7})
           ],
           false,
           (item) => item.description.length > 0
@@ -121,7 +121,7 @@ export class SettingsService {
 
   public getNewOrExistingBackupPolicyListSettings(listKey: string = 'backupPolicies') {
       return this.getNewOrExistingListSettings(listKey, null, [
-        new ListColumnSetting('raw.Name', 'Name', ['raw.Name'], {
+        new ListColumnSetting('raw.Name', 'Name', {
             enableFilter: false,
             getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
             colspan: 1,

--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -95,8 +95,8 @@ export class SettingsService {
           ],
           // Second row with description
           [
-              new ListColumnSetting('placeholder', 'placeholder', null, false), // Empty column
-              new ListColumnSettingWithCopyText('description', 'Description', [], false, 7)
+              new ListColumnSetting('placeholder', 'placeholder', null, {enableFilter: false}), // Empty column
+              new ListColumnSettingWithCopyText('description', 'Description', [], {enableFilter: false, colspan: 7})
           ],
           false,
           (item) => item.description.length > 0
@@ -121,7 +121,12 @@ export class SettingsService {
 
   public getNewOrExistingBackupPolicyListSettings(listKey: string = 'backupPolicies') {
       return this.getNewOrExistingListSettings(listKey, null, [
-          new ListColumnSetting('raw.Name', 'Name', ['raw.Name'], false, (item, property) =>  `<span class="link">${property}</span>`, 1, item => item.action.run()),
+        new ListColumnSetting('raw.Name', 'Name', ['raw.Name'], {
+            enableFilter: false,
+            getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
+            colspan: 1,
+            clickEvent: item => item.action.run()
+          }),
           new ListColumnSetting('raw.Schedule.ScheduleKind', 'ScheduleKind'),
           new ListColumnSetting('raw.Storage.StorageKind', 'StorageKind'),
           new ListColumnSetting('raw.AutoRestoreOnDataLoss', 'AutoRestoreOnDataLoss'),

--- a/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
@@ -24,6 +24,6 @@ export class ActionRowComponent implements OnInit, DetailBaseComponent {
 export class ListColumnSettingForApplicationType extends ListColumnSetting {
   template = ActionRowComponent;
   public constructor() {
-      super('actions', 'Actions', null, {enableFilter: false});
+      super('actions', 'Actions', {enableFilter: false});
   }
 }

--- a/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
@@ -24,6 +24,6 @@ export class ActionRowComponent implements OnInit, DetailBaseComponent {
 export class ListColumnSettingForApplicationType extends ListColumnSetting {
   template = ActionRowComponent;
   public constructor() {
-      super('actions', 'Actions', null, false);
+      super('actions', 'Actions', null, {enableFilter: false});
   }
 }

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -34,8 +34,8 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
           new ListColumnSettingForApplicationType()
       ],
       [
-          new ListColumnSetting('placeholder', 'placeholder', null, {enableFilter: false}), // Empty column
-          new ListColumnSetting('raw.StatusDetails', 'Status Details', null, {
+          new ListColumnSetting('placeholder', 'placeholder', {enableFilter: false}), // Empty column
+          new ListColumnSetting('raw.StatusDetails', 'Status Details', {
             enableFilter: false,
             getDisplayHtml: (item) => HtmlUtils.getSpanWithCustomClass('preserve-whitespace-wrap', item.raw.StatusDetails),
             colspan: 100

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -34,8 +34,12 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
           new ListColumnSettingForApplicationType()
       ],
       [
-          new ListColumnSetting('placeholder', 'placeholder', null, false), // Empty column
-          new ListColumnSetting('raw.StatusDetails', 'Status Details', null, false, (item) => HtmlUtils.getSpanWithCustomClass('preserve-whitespace-wrap', item.raw.StatusDetails), 100)
+          new ListColumnSetting('placeholder', 'placeholder', null, {enableFilter: false}), // Empty column
+          new ListColumnSetting('raw.StatusDetails', 'Status Details', null, {
+            enableFilter: false,
+            getDisplayHtml: (item) => HtmlUtils.getSpanWithCustomClass('preserve-whitespace-wrap', item.raw.StatusDetails),
+            colspan: 100
+          })
       ],
       false /* collapsable */,
       (item) => item.raw.StatusDetails, /* only show second row when status details is not empty */

--- a/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
@@ -33,6 +33,6 @@ export class ActionRowComponent implements DetailBaseComponent {
 export class ListColumnSettingForApplicationServiceRow extends ListColumnSetting {
   template = ActionRowComponent;
   public constructor() {
-      super('actions', 'Actions', null, false);
+      super('actions', 'Actions', null, {enableFilter: false});
   }
 }

--- a/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
@@ -33,6 +33,6 @@ export class ActionRowComponent implements DetailBaseComponent {
 export class ListColumnSettingForApplicationServiceRow extends ListColumnSetting {
   template = ActionRowComponent;
   public constructor() {
-      super('actions', 'Actions', null, {enableFilter: false});
+      super('actions', 'Actions', {enableFilter: false});
   }
 }

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -28,7 +28,7 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
 
   setup() {
     this.applicationBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('backupConfigurationInfoCollection', ['raw.PolicyName'], [
-      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], {
+      new ListColumnSetting('raw.PolicyName', 'Policy Name', {
         enableFilter: false,
         getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
         clickEvent: item => item.action.run()

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -28,7 +28,11 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
 
   setup() {
     this.applicationBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('backupConfigurationInfoCollection', ['raw.PolicyName'], [
-      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], false, (item, property) =>  `<span class="link">${property}</span>`, 1, item => item.action.run()),
+      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], {
+        enableFilter: false,
+        getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
+        clickEvent: item => item.action.run()
+      }),
       new ListColumnSetting('raw.Kind', 'Kind'),
       new ListColumnSetting('raw.PolicyInheritedFrom', 'Policy Inherited From'),
       new ListColumnSetting('raw.ServiceName', 'Service Name'),

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
@@ -31,7 +31,10 @@ export class UpgradingComponent extends BaseControllerDirective {
       new ListColumnSettingForLink('parent.raw.TypeName', 'Application Type', item => item.parent.appTypeViewPath),
       new ListColumnSetting('parent.raw.TypeVersion', 'Current Version'),
       new ListColumnSetting('raw.TargetApplicationTypeVersion', 'Target Version'),
-      new ListColumnSetting('upgrade', 'Progress by Upgrade Domain', null, false, (item) => HtmlUtils.getUpgradeProgressHtml('item.upgradeDomains')),
+      new ListColumnSetting('upgrade', 'Progress by Upgrade Domain', null, {
+        enableFilter: false,
+        getDisplayHtml: (item) => HtmlUtils.getUpgradeProgressHtml('item.upgradeDomains')
+      }),
       new ListColumnSettingWithFilter('raw.UpgradeState', 'Upgrade State')
     ]);
   }

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
@@ -31,7 +31,7 @@ export class UpgradingComponent extends BaseControllerDirective {
       new ListColumnSettingForLink('parent.raw.TypeName', 'Application Type', item => item.parent.appTypeViewPath),
       new ListColumnSetting('parent.raw.TypeVersion', 'Current Version'),
       new ListColumnSetting('raw.TargetApplicationTypeVersion', 'Target Version'),
-      new ListColumnSetting('upgrade', 'Progress by Upgrade Domain', null, {
+      new ListColumnSetting('upgrade', 'Progress by Upgrade Domain', {
         enableFilter: false,
         getDisplayHtml: (item) => HtmlUtils.getUpgradeProgressHtml('item.upgradeDomains')
       }),

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
@@ -88,7 +88,7 @@
     </div>
 </div>
 
-<div class="detail-pane essen-pane">
+<div class="detail-pane essen-pane" data-cy="health">
     <h4>Unhealthy Evaluations</h4>
     <app-detail-list [list]="clusterHealth.unhealthyEvaluations" [listSettings]="unhealthyEvaluationsListSettings"></app-detail-list>	
 </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -38,10 +38,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
     this.repairTaskListSettings = this.settings.getNewOrExistingListSettings('repair', null,
     [
         new ListColumnSetting('raw.TaskId', 'TaskId'),
-        new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], {enableFilter: true}),
+        new ListColumnSetting('raw.Action', 'Action', {enableFilter: true}),
         new ListColumnSetting('raw.Target.NodeNames', 'Target'),
         new ListColumnSetting('impactedNodes', 'Impact'),
-        new ListColumnSetting('raw.State', 'State', ['raw.State'], {enableFilter: true}),
+        new ListColumnSetting('raw.State', 'State', {enableFilter: true}),
         new ListColumnSetting('createdAt', 'Created at'),
         new ListColumnSetting('displayDuration', 'Duration'),
     ],
@@ -49,7 +49,6 @@ export class RepairTasksComponent extends BaseControllerDirective {
       new ListColumnSettingWithCustomComponent(RepairTaskViewComponent,
         '',
         '',
-        [],
         {
           enableFilter: false,
           colspan: -1
@@ -62,10 +61,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
     this.completedRepairTaskListSettings = this.settings.getNewOrExistingListSettings('completedRepair', null,
         [
             new ListColumnSetting('raw.TaskId', 'TaskId'),
-            new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], {enableFilter: true}),
+            new ListColumnSetting('raw.Action', 'Action', {enableFilter: true}),
             new ListColumnSetting('raw.Target.NodeNames', 'Target'),
             new ListColumnSetting('impactedNodes', 'Impact'),
-            new ListColumnSetting('raw.ResultStatus', 'Result Status', ['raw.ResultStatus'], {enableFilter: true}),
+            new ListColumnSetting('raw.ResultStatus', 'Result Status', {enableFilter: true}),
             new ListColumnSetting('createdAt', 'Created at'),
             new ListColumnSetting('displayDuration', 'Duration'),
         ],
@@ -73,7 +72,6 @@ export class RepairTasksComponent extends BaseControllerDirective {
           new ListColumnSettingWithCustomComponent(RepairTaskViewComponent,
             '',
             '',
-            [],
             {
               enableFilter: false,
               colspan: -1

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -38,10 +38,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
     this.repairTaskListSettings = this.settings.getNewOrExistingListSettings('repair', null,
     [
         new ListColumnSetting('raw.TaskId', 'TaskId'),
-        new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], true),
+        new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], {enableFilter: true}),
         new ListColumnSetting('raw.Target.NodeNames', 'Target'),
         new ListColumnSetting('impactedNodes', 'Impact'),
-        new ListColumnSetting('raw.State', 'State', ['raw.State'], true),
+        new ListColumnSetting('raw.State', 'State', ['raw.State'], {enableFilter: true}),
         new ListColumnSetting('createdAt', 'Created at'),
         new ListColumnSetting('displayDuration', 'Duration'),
     ],
@@ -50,9 +50,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
         '',
         '',
         [],
-        false,
-        -1
-        )
+        {
+          enableFilter: false,
+          colspan: -1
+        })
   ],
     true,
     (item) => (Object.keys(item).length > 0),
@@ -61,10 +62,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
     this.completedRepairTaskListSettings = this.settings.getNewOrExistingListSettings('completedRepair', null,
         [
             new ListColumnSetting('raw.TaskId', 'TaskId'),
-            new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], true),
+            new ListColumnSetting('raw.Action', 'Action', ['raw.Action'], {enableFilter: true}),
             new ListColumnSetting('raw.Target.NodeNames', 'Target'),
             new ListColumnSetting('impactedNodes', 'Impact'),
-            new ListColumnSetting('raw.ResultStatus', 'Result Status', ['raw.ResultStatus'], true),
+            new ListColumnSetting('raw.ResultStatus', 'Result Status', ['raw.ResultStatus'], {enableFilter: true}),
             new ListColumnSetting('createdAt', 'Created at'),
             new ListColumnSetting('displayDuration', 'Duration'),
         ],
@@ -73,9 +74,10 @@ export class RepairTasksComponent extends BaseControllerDirective {
             '',
             '',
             [],
-            false,
-            -1
-            )
+            {
+              enableFilter: false,
+              colspan: -1
+            })
       ],
         true,
         (item) => true,

--- a/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
@@ -58,7 +58,7 @@ export class BaseComponent extends BaseControllerDirective {
                 new ListColumnSettingForLink('id', 'Id', item => item.viewPath),
                 new ListColumnSetting('raw.PartitionId', 'Partition Id'),
                 new ListColumnSettingWithFilter('raw.ServiceKind', 'Service Kind'),
-                new ListColumnSettingWithFilter('role', 'Replica Role', defaultSortProperties),
+                new ListColumnSettingWithFilter('role', 'Replica Role', {sortPropertyPaths: defaultSortProperties}),
                 new ListColumnSettingWithFilter('raw.ReplicaStatus', 'Status')
             ];
 

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
@@ -30,7 +30,7 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
 
   setup() {
     this.partitionBackupListSettings = this.settings.getNewOrExistingListSettings('partitionBackups', [null], [
-      new ListColumnSetting('raw.BackupId', 'BackupId', ['raw.BackupId'], {
+      new ListColumnSetting('raw.BackupId', 'BackupId', {
         enableFilter: false,
         getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
         clickEvent: item => item.action.run()

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
@@ -30,7 +30,11 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
 
   setup() {
     this.partitionBackupListSettings = this.settings.getNewOrExistingListSettings('partitionBackups', [null], [
-      new ListColumnSetting('raw.BackupId', 'BackupId', ['raw.BackupId'], false, (item, property) =>  `<span class="link">${property}</span>`, 1, item => item.action.run()),
+      new ListColumnSetting('raw.BackupId', 'BackupId', ['raw.BackupId'], {
+        enableFilter: false,
+        getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
+        clickEvent: item => item.action.run()
+      }),
       new ListColumnSetting('raw.BackupType', 'BackupType'),
       new ListColumnSetting('raw.EpochOfLastBackupRecord.DataLossVersion', 'Data Loss Version'),
       new ListColumnSetting('raw.EpochOfLastBackupRecord.ConfigurationVersion', 'Configuration Version'),

--- a/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
@@ -34,7 +34,7 @@ export class EssentialsComponent extends PartitionBaseControllerDirective {
         const columnSettings = [
             new ListColumnSettingForLink('id', 'Id', item => item.viewPath),
             new ListColumnSetting('raw.NodeName', 'Node Name'),
-            new ListColumnSettingWithFilter('role', 'Replica Role', defaultSortProperties),
+            new ListColumnSettingWithFilter('role', 'Replica Role', {sortPropertyPaths: defaultSortProperties}),
             new ListColumnSettingForBadge('healthState', 'Health State'),
             new ListColumnSettingWithFilter('raw.ReplicaStatus', 'Status')
         ];

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -28,7 +28,11 @@ export class BackupComponent extends ServiceBaseControllerDirective {
 
   setup() {
     this.serviceBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('serviceBackupConfigurationInfoListSettings', ['raw.PolicyName'], [
-      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], false, (item, property) =>  `<span class="link">${property}</span>`, 1, item => item.action.run()),
+      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], {
+        enableFilter: false, 
+        getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`, 
+        clickEvent: item => item.action.run()
+      }),
       new ListColumnSetting('raw.Kind', 'Kind'),
       new ListColumnSetting('raw.PolicyInheritedFrom', 'Policy Inherited From'),
       new ListColumnSetting('raw.PartitionId', 'Partition Id'),

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -28,9 +28,9 @@ export class BackupComponent extends ServiceBaseControllerDirective {
 
   setup() {
     this.serviceBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('serviceBackupConfigurationInfoListSettings', ['raw.PolicyName'], [
-      new ListColumnSetting('raw.PolicyName', 'Policy Name', ['raw.PolicyName'], {
-        enableFilter: false, 
-        getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`, 
+      new ListColumnSetting('raw.PolicyName', 'Policy Name', {
+        enableFilter: false,
+        getDisplayHtml: (item, property) =>  `<span class="link">${property}</span>`,
         clickEvent: item => item.action.run()
       }),
       new ListColumnSetting('raw.Kind', 'Kind'),


### PR DESCRIPTION
![exportTable](https://user-images.githubusercontent.com/15344718/96057768-8958ee00-0e3e-11eb-92f8-0300eee875d5.PNG)
![exported](https://user-images.githubusercontent.com/15344718/96057775-8bbb4800-0e3e-11eb-8253-b4d4509c9638.PNG)


Cleaning up existing design for table settings, moving most options into a config object because the constructors have gotten too long and hard to maintain default values.