### PR TITLE
added checkboxes for empty credentials for file share backup policy

### DIFF
--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
@@ -38,7 +38,7 @@
             <dd>
                 <input type="text" class="input-flat" formControlName="Path" name="Path">
             </dd>
-            <dt>IsPrimaryCredentialEmpty</dt>
+            <dt>IsPrimaryCredsEmpty</dt>
             <dd class="checkbox-container-default">
                 <input type="checkbox" formControlName="IsEmptyPrimaryCredential"/>
             </dd>
@@ -51,7 +51,7 @@
                 <input type="password" class="input-flat" formControlName="PrimaryPassword"
                     name="PrimaryPassword" [attr.disabled]="localForm.value.IsEmptyPrimaryCredential?true:null">
             </dd>
-            <dt>IsSecondaryCredentialEmpty</dt>
+            <dt>IsSecondaryCredsEmpty</dt>
             <dd class="checkbox-container-default">
                 <input type="checkbox" formControlName="IsEmptySecondaryCredential"/>
             </dd>

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
@@ -38,32 +38,32 @@
             <dd>
                 <input type="text" class="input-flat" formControlName="Path" name="Path">
             </dd>
-            <dt>IsPrimaryCredsEmpty</dt>
+            <dt>Empty Primary Creds</dt>
             <dd class="checkbox-container-default">
                 <input type="checkbox" formControlName="IsEmptyPrimaryCredential"/>
             </dd>
             <dt>PrimaryUserName</dt>
             <dd>
-                <input type="text" class="input-flat" formControlName="PrimaryUserName" name="PrimaryUserName" [attr.disabled]="localForm.value.IsEmptyPrimaryCredential?true:null">
+                <input type="text" class="input-flat" formControlName="PrimaryUserName" name="PrimaryUserName" >
             </dd>
             <dt>PrimaryPassword</dt>
             <dd>
                 <input type="password" class="input-flat" formControlName="PrimaryPassword"
-                    name="PrimaryPassword" [attr.disabled]="localForm.value.IsEmptyPrimaryCredential?true:null">
+                    name="PrimaryPassword" >
             </dd>
-            <dt>IsSecondaryCredsEmpty</dt>
+            <dt>Empty Secondary Creds</dt>
             <dd class="checkbox-container-default">
                 <input type="checkbox" formControlName="IsEmptySecondaryCredential"/>
             </dd>
             <dt>SecondaryUserName</dt>
             <dd>
                 <input type="text" class="input-flat" formControlName="SecondaryUserName"
-                    name="SecondaryUserName" [attr.disabled]="localForm.value.IsEmptySecondaryCredential?true:null">
+                    name="SecondaryUserName" >
             </dd>
             <dt>SecondaryPassword</dt>
             <dd>
                 <input type="password" class="input-flat" formControlName="SecondaryPassword"
-                    name="SecondaryPassword" [attr.disabled]="localForm.value.IsEmptySecondaryCredential?true:null">
+                    name="SecondaryPassword" >
             </dd>
         </dl>
     </div>

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
@@ -38,24 +38,32 @@
             <dd>
                 <input type="text" class="input-flat" formControlName="Path" name="Path">
             </dd>
+            <dt>IsPrimaryCredentialEmpty</dt>
+            <dd class="checkbox-container-default">
+                <input type="checkbox" formControlName="IsEmptyPrimaryCredential"/>
+            </dd>
             <dt>PrimaryUserName</dt>
             <dd>
-                <input type="text" class="input-flat" formControlName="PrimaryUserName" name="PrimaryUserName">
+                <input type="text" class="input-flat" formControlName="PrimaryUserName" name="PrimaryUserName" [attr.disabled]="localForm.value.IsEmptyPrimaryCredential?true:null">
             </dd>
             <dt>PrimaryPassword</dt>
             <dd>
                 <input type="password" class="input-flat" formControlName="PrimaryPassword"
-                    name="PrimaryPassword">
+                    name="PrimaryPassword" [attr.disabled]="localForm.value.IsEmptyPrimaryCredential?true:null">
+            </dd>
+            <dt>IsSecondaryCredentialEmpty</dt>
+            <dd class="checkbox-container-default">
+                <input type="checkbox" formControlName="IsEmptySecondaryCredential"/>
             </dd>
             <dt>SecondaryUserName</dt>
             <dd>
                 <input type="text" class="input-flat" formControlName="SecondaryUserName"
-                    name="SecondaryUserName">
+                    name="SecondaryUserName" [attr.disabled]="localForm.value.IsEmptySecondaryCredential?true:null">
             </dd>
             <dt>SecondaryPassword</dt>
             <dd>
                 <input type="password" class="input-flat" formControlName="SecondaryPassword"
-                    name="SecondaryPassword">
+                    name="SecondaryPassword" [attr.disabled]="localForm.value.IsEmptySecondaryCredential?true:null">
             </dd>
         </dl>
     </div>

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -91,34 +91,42 @@ export class StorageFormComponent implements OnInit {
     storage.get('Path').updateValueAndValidity();
   }
   updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean){
-    if(IsEmptyPrimaryCredential === true)
+    if(IsEmptyPrimaryCredential)
     {
       storage.get('PrimaryUserName').setValidators(null);
       storage.get('PrimaryPassword').setValidators(null);
       storage.get('PrimaryUserName').setValue('');
       storage.get('PrimaryPassword').setValue('');
+      storage.get('PrimaryUserName').disable();
+      storage.get('PrimaryPassword').disable();
     }
     else
     {
       storage.get('PrimaryUserName').setValidators([Validators.required]);
       storage.get('PrimaryPassword').setValidators([Validators.required]);
+      storage.get('PrimaryUserName').enable();
+      storage.get('PrimaryPassword').enable();
     }
     storage.get('PrimaryUserName').updateValueAndValidity();
     storage.get('PrimaryPassword').updateValueAndValidity();
   }
 
   updateStorageKindValidatorsSecondaryCredentials(storage: AbstractControl, IsEmptySecondaryCredential: boolean){
-    if(IsEmptySecondaryCredential === true)
+    if(IsEmptySecondaryCredential)
     {
       storage.get('SecondaryUserName').setValidators(null);
       storage.get('SecondaryPassword').setValidators(null);
       storage.get('SecondaryUserName').setValue('');
       storage.get('SecondaryPassword').setValue('');
+      storage.get('SecondaryUserName').disable();
+      storage.get('SecondaryPassword').disable();
     }
     else
     {
       storage.get('SecondaryUserName').setValidators([Validators.required]);
       storage.get('SecondaryPassword').setValidators([Validators.required]);
+      storage.get('SecondaryUserName').enable();
+      storage.get('SecondaryPassword').enable();
     }
     storage.get('SecondaryUserName').updateValueAndValidity();
     storage.get('SecondaryPassword').updateValueAndValidity();

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -22,8 +22,10 @@ export class StorageFormComponent implements OnInit {
       Path: [''],
       ConnectionString: [''],
       ContainerName: [''],
+      IsEmptyPrimaryCredential: [false],
       PrimaryUserName: [''],
       PrimaryPassword: [''],
+      IsEmptySecondaryCredential: [false],
       SecondaryUserName: [''],
       SecondaryPassword: ['']
     });
@@ -35,7 +37,16 @@ export class StorageFormComponent implements OnInit {
         this.updateStorageKindValidators(this.localForm, storageKind);
       }
     });
-
+    this.localForm.get('IsEmptyPrimaryCredential').valueChanges.subscribe(IsEmptyPrimaryCredential => {
+      if (this.required) {
+        this.updateStorageKindValidatorsPrimaryCredentials(this.localForm, IsEmptyPrimaryCredential);
+      }
+    });
+    this.localForm.get('IsEmptySecondaryCredential').valueChanges.subscribe(IsEmptySecondaryCredential => {
+      if (this.required) {
+        this.updateStorageKindValidatorsSecondaryCredentials(this.localForm, IsEmptySecondaryCredential);
+      }
+    });
     // set default data or if none then give it a default state;
     this.data = this.data || {
       StorageKind: 'AzureBlobStore',
@@ -43,8 +54,10 @@ export class StorageFormComponent implements OnInit {
       Path: '',
       ConnectionString: '',
       ContainerName: '',
+      IsEmptyPrimaryCredential: false,
       PrimaryUserName: '',
       PrimaryPassword: '',
+      IsEmptySecondaryCredential: false,
       SecondaryUserName: '',
       SecondaryPassword: ''
     };
@@ -71,10 +84,39 @@ export class StorageFormComponent implements OnInit {
 
       storage.get('Path').setValidators([Validators.required]);
     }
-
+    this.updateStorageKindValidatorsPrimaryCredentials(storage, false);
+    this.updateStorageKindValidatorsSecondaryCredentials(storage, false);
     storage.get('ContainerName').updateValueAndValidity();
     storage.get('ConnectionString').updateValueAndValidity();
     storage.get('Path').updateValueAndValidity();
   }
+  updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean){
+    if(IsEmptyPrimaryCredential === true)
+    {
+      storage.get('PrimaryUserName').setValidators(null);
+      storage.get('PrimaryPassword').setValidators(null);
+    }
+    else
+    {
+      storage.get('PrimaryUserName').setValidators([Validators.required]);
+      storage.get('PrimaryPassword').setValidators([Validators.required]);
+    }
+    storage.get('PrimaryUserName').updateValueAndValidity();
+    storage.get('PrimaryPassword').updateValueAndValidity();
+  }
 
+  updateStorageKindValidatorsSecondaryCredentials(storage: AbstractControl, IsEmptySecondaryCredential: boolean){
+    if(IsEmptySecondaryCredential === true)
+    {
+      storage.get('SecondaryUserName').setValidators(null);
+      storage.get('SecondaryPassword').setValidators(null);
+    }
+    else
+    {
+      storage.get('SecondaryUserName').setValidators([Validators.required]);
+      storage.get('SecondaryPassword').setValidators([Validators.required]);
+    }
+    storage.get('SecondaryUserName').updateValueAndValidity();
+    storage.get('SecondaryPassword').updateValueAndValidity();
+  }
 }

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -90,8 +90,8 @@ export class StorageFormComponent implements OnInit {
     storage.get('ConnectionString').updateValueAndValidity();
     storage.get('Path').updateValueAndValidity();
   }
-  updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean){
-    if(IsEmptyPrimaryCredential)
+  updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean) {
+    if (IsEmptyPrimaryCredential)
     {
       storage.get('PrimaryUserName').setValidators(null);
       storage.get('PrimaryPassword').setValidators(null);
@@ -111,8 +111,8 @@ export class StorageFormComponent implements OnInit {
     storage.get('PrimaryPassword').updateValueAndValidity();
   }
 
-  updateStorageKindValidatorsSecondaryCredentials(storage: AbstractControl, IsEmptySecondaryCredential: boolean){
-    if(IsEmptySecondaryCredential)
+  updateStorageKindValidatorsSecondaryCredentials(storage: AbstractControl, IsEmptySecondaryCredential: boolean) {
+    if (IsEmptySecondaryCredential)
     {
       storage.get('SecondaryUserName').setValidators(null);
       storage.get('SecondaryPassword').setValidators(null);

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -95,6 +95,8 @@ export class StorageFormComponent implements OnInit {
     {
       storage.get('PrimaryUserName').setValidators(null);
       storage.get('PrimaryPassword').setValidators(null);
+      storage.get('PrimaryUserName').setValue('');
+      storage.get('PrimaryPassword').setValue('');
     }
     else
     {
@@ -110,6 +112,8 @@ export class StorageFormComponent implements OnInit {
     {
       storage.get('SecondaryUserName').setValidators(null);
       storage.get('SecondaryPassword').setValidators(null);
+      storage.get('SecondaryUserName').setValue('');
+      storage.get('SecondaryPassword').setValue('');
     }
     else
     {

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
@@ -35,14 +35,6 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
       delete data.RetentionPolicy;
     }
     delete data.retentionPolicyRequired;
-    if(data.Storage.IsEmptyPrimaryCredential){
-      data.Storage.PrimaryUserName="";
-      data.Storage.PrimaryPassword="";
-    }
-    if(data.Storage.IsEmptySecondaryCredential){
-      data.Storage.SecondaryUserName="";
-      data.Storage.SecondaryPassword="";
-    }
     delete data.Storage.IsEmptyPrimaryCredential;
     delete data.Storage.IsEmptySecondaryCredential;
 

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
@@ -35,7 +35,16 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
       delete data.RetentionPolicy;
     }
     delete data.retentionPolicyRequired;
-
+    if(data.Storage.IsEmptyPrimaryCredential){
+      data.Storage.PrimaryUserName="";
+      data.Storage.PrimaryPassword="";
+    }
+    if(data.Storage.IsEmptySecondaryCredential){
+      data.Storage.SecondaryUserName="";
+      data.Storage.SecondaryPassword="";
+    }
+    delete data.Storage.IsEmptyPrimaryCredential;
+    delete data.Storage.IsEmptySecondaryCredential;
 
     if (data.Schedule.ScheduleKind === 'TimeBased' && data.Schedule.ScheduleFrequencyType === 'Weekly') {
       data.Schedule.RunDays = data.Schedule.RunDays.map( (status: boolean, index: number ) => status ? this.weekDay[index] : null).filter( day => day !== null);


### PR DESCRIPTION
https://msazure.visualstudio.com/One/_workitems/edit/7507750
https://github.com/microsoft/service-fabric-explorer/issues/439

The changes are for adding checkboxes to indicate that the credentials for file share storage is empty while creating or updating backup policy. It is set to false by default. Hence if the primary or secondary credentials are not required the checkbox needs to be checked and username & password fields will be disabled.