### PR TITLE
Implemented #438

### DIFF
--- a/src/Sfx/App/partials/action-confirmation-dialog.html
+++ b/src/Sfx/App/partials/action-confirmation-dialog.html
@@ -8,7 +8,7 @@
                autocomplete="off" ng-show="::action.confirmationKeyword" ng-model="usertypedkeyword" aria-label="Type in '{{::action.confirmationKeyword}} to confirm">
     </div>
     <div class="modal-footer">
-        <button type="submit" class="btn btn-primary" data-dismiss="modal" ng-disabled="action.confirmationKeyword !== usertypedkeyword" ng-click="ok()">{{::action.title}}</button>
+        <button type="submit" class="btn btn-primary" data-dismiss="modal" ng-disabled="action.confirmationKeyword !== usertypedkeyword.trim()" ng-click="ok()">{{::action.title}}</button>
         <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="usertypedkeyword = null; cancel()">Cancel</button>
     </div>
 </form>

--- a/src/Sfx/App/partials/action-confirmation-dialog.html
+++ b/src/Sfx/App/partials/action-confirmation-dialog.html
@@ -8,7 +8,7 @@
                autocomplete="off" ng-show="::action.confirmationKeyword" ng-model="usertypedkeyword" aria-label="Type in '{{::action.confirmationKeyword}} to confirm">
     </div>
     <div class="modal-footer">
-        <button type="submit" class="btn btn-primary" data-dismiss="modal" ng-disabled="action.confirmationKeyword !== usertypedkeyword.trim()" ng-click="ok()">{{::action.title}}</button>
+        <button type="submit" class="btn btn-primary" data-dismiss="modal" ng-disabled="action.confirmationKeyword !== usertypedkeyword" ng-click="ok()">{{::action.title}}</button>
         <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="usertypedkeyword = null; cancel()">Cancel</button>
     </div>
 </form>

--- a/src/SfxWeb/src/app/shared/component/action-dialog/action-dialog.component.html
+++ b/src/SfxWeb/src/app/shared/component/action-dialog/action-dialog.component.html
@@ -9,7 +9,7 @@
         </label>
     </div>
     <div class="modal-footer">
-        <button type="submit" class="solid-button blue" [disabled]="data.confirmationKeyword !== userInput" (click)="ok()">{{data.title}}</button>
+        <button type="submit" class="solid-button blue" [disabled]="data.confirmationKeyword !== userInput.trim()" (click)="ok()">{{data.title}}</button>
         <button type="button" class="flat-button" (click)="cancel()">Cancel</button>
     </div>
 </form>


### PR DESCRIPTION
Implemented #438 allowing whitespace around the confirmation value so as to make copy/pasting more convenient