### PR TITLE
retain more view state and pass it forward during refreshes for repair tasks

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -230,11 +230,11 @@ export class RepairTask {
         this.isSecondRowCollapsed = previousTask.isSecondRowCollapsed;
         this.activeTab = previousTask.activeTab;
         previousTask.historyPhases.forEach( (phase, index) => {
-            //if starting collapsed is false, let it open.
-            if(this.historyPhases[index].startCollapsed) {
+            // if starting collapsed is false, let it open.
+            if (this.historyPhases[index].startCollapsed) {
                 this.historyPhases[index].startCollapsed = phase.startCollapsed;
             }
-        })
+        });
 
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -58,6 +58,8 @@ export class RepairTask {
 
     // Initially keep additional details collapsed.
     public isSecondRowCollapsed = true;
+    public activeTab = 1;
+
     public impactedNodes: string[] = [];
     public history: IRepairTaskHistoryPhase[] = [];
     public createdAt = '';
@@ -224,4 +226,15 @@ export class RepairTask {
         };
     }
 
+    updateViewInfo(previousTask: RepairTask) {
+        this.isSecondRowCollapsed = previousTask.isSecondRowCollapsed;
+        this.activeTab = previousTask.activeTab;
+        previousTask.historyPhases.forEach( (phase, index) => {
+            //if starting collapsed is false, let it open.
+            if(this.historyPhases[index].startCollapsed) {
+                this.historyPhases[index].startCollapsed = phase.startCollapsed;
+            }
+        })
+
+    }
 }

--- a/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.html
@@ -2,8 +2,8 @@
     Copy raw repair Job <app-clip-board [text]="copyText"></app-clip-board>
 </div>
 
-<div ngbNav #nav="ngbNav">
-    <div ngbNavItem>
+<div ngbNav #nav="ngbNav" [(activeId)]="item.activeTab">
+    <div [ngbNavItem]="1">
         <a ngbNavLink style="font-size: 12pt;">
             Condensed
         </a>
@@ -16,7 +16,7 @@
                     <div style="font-size: larger;">
                         Phase <div style="float: right">Duration</div>
                     </div>
-                    <app-collapse-container *ngFor="let phase of item.historyPhases" [collapsed]="phase.startCollapsed" hideTooltip="true">
+                    <app-collapse-container *ngFor="let phase of item.historyPhases" [collapsed]="phase.startCollapsed" hideTooltip="true" (collapsedChange)="phase.startCollapsed = $event">
                         <div style="margin-bottom: .5em;" collapse-header [ngClass]='phase.statusCss'>
                             {{phase.name}} : {{phase.status}} <span *ngIf="phase.durationMilliseconds > 0" style="float: right;">{{phase.duration}}</span>
                         </div>
@@ -68,7 +68,7 @@
 
         </ng-template>
     </div>
-    <div ngbNavItem>
+    <div [ngbNavItem]="2">
         <a ngbNavLink style="font-size: 12pt;">
             Full Description
         </a>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -125,13 +125,13 @@ export class RepairTasksComponent extends BaseControllerDirective {
     return this.data.restClient.getRepairTasks(messageHandler).pipe(map(data => {
       const expandedDict = {};
       this.completedRepairTasks.concat(this.repairTasks).forEach( (repairTask) => {
-          expandedDict[repairTask.raw.TaskId] = repairTask.isSecondRowCollapsed;
+          expandedDict[repairTask.raw.TaskId] = repairTask;
       });
       this.completedRepairTasks = [];
       this.repairTasks = [];
       data.map(json => new RepairTask(json)).forEach(task => {
         if (task.raw.TaskId in expandedDict) {
-          task.isSecondRowCollapsed = expandedDict[task.raw.TaskId];
+          task.updateViewInfo(expandedDict[task.raw.TaskId]);
         }
 
         if (task.inProgress) {


### PR DESCRIPTION
When viewing a repair task it will not shut history phases or switch back to the condensed tab between refreshes now.
closes #451 #391 