### PR TITLE
[Wait to Merge] Add support for auxiliary replicas

### DIFF
--- a/src/SfxWeb/cypress/fixtures/service-page/service-description-with-aux.json
+++ b/src/SfxWeb/cypress/fixtures/service-page/service-description-with-aux.json
@@ -1,0 +1,31 @@
+{
+    "ServiceKind": "Stateful",
+    "ApplicationName": "fabric:/VisualObjectsApplicationType",
+    "ServiceName": "fabric:/VisualObjectsApplicationType/VisualObjects.ActorService",
+    "ServiceTypeName": "VisualObjects.ActorServiceType",
+    "InitializationData": [],
+    "PartitionDescription": {
+        "PartitionScheme": "UniformInt64Range",
+        "Count": 10,
+        "LowKey": "-9223372036854775808",
+        "HighKey": "9223372036854775807"
+    },
+    "TargetReplicaSetSize": 3,
+    "MinReplicaSetSize": 2,
+    "AuxiliaryReplicaCount": 2,
+    "HasPersistedState": true,
+    "PlacementConstraints": "",
+    "CorrelationScheme": [],
+    "ServiceLoadMetrics": [],
+    "ServicePlacementPolicies": [],
+    "Flags": 47,
+    "ReplicaRestartWaitDurationSeconds": 1800,
+    "QuorumLossWaitDurationSeconds": 3214202341,
+    "StandByReplicaKeepDurationSeconds": 604800,
+    "DefaultMoveCost": "Zero",
+    "IsDefaultMoveCostSpecified": true,
+    "ServicePackageActivationMode": "SharedProcess",
+    "ServiceDnsName": "",
+    "ScalingPolicies": [],
+    "ServicePlacementTimeLimitSeconds": 0
+}

--- a/src/SfxWeb/cypress/integration/service.spec.js
+++ b/src/SfxWeb/cypress/integration/service.spec.js
@@ -106,17 +106,17 @@ context('service', () => {
 
     describe("stateful - with auxiliary replicas", () => {
         beforeEach(() => {
-            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetDescription?*`), "fx:service-page/service-description-with-aux").as("descriptionWithAux");
-            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}?*`), "fx:service-page/service-info").as("serviceInfo");
-            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetPartitions?*`), "fx:service-page/service-partitions").as("partitions");
-            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetHealth?*`), "fx:service-page/service-health").as("health");
-
+            addRoute("descriptionWithAux", "service-page/service-description-with-aux", apiUrl(`${routeFormatter(appName, serviceName)}/$/GetDescription?*`));
+            addRoute("serviceInfo", "service-page/service-info", apiUrl(`${routeFormatter(appName, serviceName)}?*`));
+            addRoute("partitions", "service-page/service-partitions", apiUrl(`${routeFormatter(appName, serviceName)}/$/GetPartitions?*`));
+            addRoute("health", "service-page/service-health", apiUrl(`${routeFormatter(appName, serviceName)}/$/GetHealth?*`));
+ 
             cy.visit(urlFormatter(appName, serviceName))
         })
 
         it('view details - with auxiliary replicas', () => {
             cy.wait(waitRequest);
-            cy.wait("@descriptionWithAux");
+            cy.wait("@getdescriptionWithAux");
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('details').click();

--- a/src/SfxWeb/cypress/integration/service.spec.js
+++ b/src/SfxWeb/cypress/integration/service.spec.js
@@ -58,7 +58,7 @@ context('service', () => {
 
         it('view details', () => {
             cy.wait(waitRequest);
-            cy.wait('@description');
+            cy.wait('@getdescription');
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('details').click();

--- a/src/SfxWeb/cypress/integration/service.spec.js
+++ b/src/SfxWeb/cypress/integration/service.spec.js
@@ -58,9 +58,14 @@ context('service', () => {
 
         it('view details', () => {
             cy.wait(waitRequest);
+            cy.wait('@description');
 
             cy.get('[data-cy=navtabs]').within(() => {
                 cy.contains('details').click();
+            })
+
+            cy.get('[data-cy=serviceDescription]').within(() => {
+                cy.contains("Auxiliary Replica Count").should('not.exist');
             })
 
             cy.url().should('include', '/details')
@@ -97,6 +102,33 @@ context('service', () => {
 
             cy.url().should('include', '/backup')
         })
+    })
+
+    describe("stateful - with auxiliary replicas", () => {
+        beforeEach(() => {
+            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetDescription?*`), "fx:service-page/service-description-with-aux").as("descriptionWithAux");
+            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}?*`), "fx:service-page/service-info").as("serviceInfo");
+            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetPartitions?*`), "fx:service-page/service-partitions").as("partitions");
+            cy.route(apiUrl(`${routeFormatter(appName, serviceName)}/$/GetHealth?*`), "fx:service-page/service-health").as("health");
+
+            cy.visit(urlFormatter(appName, serviceName))
+        })
+
+        it('view details - with auxiliary replicas', () => {
+            cy.wait(waitRequest);
+            cy.wait("@descriptionWithAux");
+
+            cy.get('[data-cy=navtabs]').within(() => {
+                cy.contains('details').click();
+            })
+
+            cy.get('[data-cy=serviceDescription]').within(() => {
+                cy.contains("Auxiliary Replica Count")
+            })
+
+            cy.url().should('include', '/details')
+        })
+
     })
 
     describe("stateless", () => {

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -153,8 +153,9 @@ export class SortPriorities {
         Primary: 2,
         ActiveSecondary: 3,
         IdleSecondary: 4,
-        ActiveSecondaryAuxiliary: 5,
-        IdleSecondaryAuxiliary: 6,
+        PrimaryAuxiliary: 5,
+        ActiveAuxiliary: 6,
+        IdleAuxiliary: 7,
     };
 }
 

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -152,7 +152,9 @@ export class SortPriorities {
         None: 1,
         Primary: 2,
         ActiveSecondary: 3,
-        IdleSecondary: 4
+        IdleSecondary: 4,
+        ActiveSecondaryAuxiliary: 5,
+        IdleSecondaryAuxiliary: 6,
     };
 }
 

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -309,10 +309,10 @@ export class CreateServiceDescription {
         } else {
             delete descriptionCloned.StandByReplicaKeepDurationSeconds;
         }
-        
+
         if (this.raw.AuxiliaryReplicaCount !== null && this.raw.AuxiliaryReplicaCount > 0) {
             // tslint:disable-next-line:no-bitwise
-            flags ^= 0x20;
+            flags ^= 0x80;
         } else {
             delete descriptionCloned.AuxiliaryReplicaCount;
             if (this.raw.ServiceLoadMetrics !== null && this.raw.ServiceLoadMetrics.length > 0) {

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -309,6 +309,17 @@ export class CreateServiceDescription {
         } else {
             delete descriptionCloned.StandByReplicaKeepDurationSeconds;
         }
+        
+        if (this.raw.AuxiliaryReplicaCount !== null && this.raw.AuxiliaryReplicaCount > 0) {
+            // tslint:disable-next-line:no-bitwise
+            flags ^= 0x20;
+        } else {
+            delete descriptionCloned.AuxiliaryReplicaCount;
+            if (this.raw.ServiceLoadMetrics !== null && this.raw.ServiceLoadMetrics.length > 0) {
+                descriptionCloned.ServiceLoadMetrics.forEach(metric => delete metric.AuxiliaryDefaultLoad);
+            }
+        }
+
         descriptionCloned.Flags = flags;
         descriptionCloned.InitializationData = Utils.hexToBytes(this.initializationData);
         return descriptionCloned;
@@ -392,7 +403,8 @@ export class CreateServiceDescription {
             Name: '',
             Weight: '1',
             PrimaryDefaultLoad: null,
-            SecondaryDefaultLoad: null
+            SecondaryDefaultLoad: null,
+            AuxiliaryDefaultLoad: null,
         });
     }
 
@@ -419,6 +431,7 @@ export class CreateServiceDescription {
             StandByReplicaKeepDurationSeconds: null,
             TargetReplicaSetSize: 1,
             MinReplicaSetSize: 1,
+            AuxiliaryReplicaCount: 0,
             HasPersistedState: this.serviceType.raw.ServiceTypeDescription.HasPersistedState,
             InstanceCount: 1,
             PlacementConstraints: '',

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -489,6 +489,7 @@ export interface IRawPartition {
         PartitionInformation: IRawPartitionInformation;
         TargetReplicaSetSize: number;
         MinReplicaSetSize: number;
+        AuxiliaryReplicaCount: number;
         InstanceCount: number;
         HealthState: string;
         PartitionStatus: string;
@@ -725,6 +726,7 @@ export interface IRawServiceDescription {
     // STATEFUL
     TargetReplicaSetSize: number;
     MinReplicaSetSize: number;
+    AuxiliaryReplicaCount: number;
     HasPersistedState: boolean;
     ReplicaRestartWaitDurationSeconds: number;
     QuorumLossWaitDurationSeconds: number;
@@ -787,6 +789,7 @@ export interface IRawServiceLoadMetricDescription {
         Weight: string;
         PrimaryDefaultLoad: number;
         SecondaryDefaultLoad: number;
+        AuxiliaryDefaultLoad?: number;
     }
 
 export interface IRawServiceType {
@@ -922,6 +925,7 @@ export interface IRawUpdateServiceDescription {
         Flags?: number;
         TargetReplicaSetSize?: number;
         MinReplicaSetSize?: number;
+        AuxiliaryReplicaCount?: number;
         InstanceCount?: number;
         ReplicaRestartWaitDurationSeconds?: number;
         QuorumLossWaitDurationSeconds?: number;
@@ -931,6 +935,7 @@ export interface IRawUpdateServiceDescription {
 export interface IRawCreateServiceDescription extends IRawCreateServiceFromTemplateDescription, IRawUpdateServiceDescription {
         PartitionDescription: IRawPartitionDescription;
         TargetReplicaSetSize: number;
+        AuxiliaryReplicaCount: number;
         HasPersistedState: boolean;
         PlacementConstraints: string;
         CorrelationScheme: IRawServiceCorrelationDescription[];

--- a/src/SfxWeb/src/app/views/application/create-service/create-service.component.html
+++ b/src/SfxWeb/src/app/views/application/create-service/create-service.component.html
@@ -69,8 +69,8 @@
                     <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">
                         <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="description.raw.TargetReplicaSetSize" aria-label="Target Replica Set Size" min="1" aria-valuemin="1" integer>
                     </dd>
-                    <dt *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">Auxiliary Replica Count</dt>
-                    <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">
+                    <dt *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful && serviceType.raw.ServiceTypeDescription.HasPersistedState">Auxiliary Replica Count</dt>
+                    <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful && serviceType.raw.ServiceTypeDescription.HasPersistedState">
                         <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="description.raw.AuxiliaryReplicaCount" aria-label="Auxiliary Replica Count" min="0" aria-valuemin="0" integer>
                     </dd>
                     <dt *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful" title="Replica Restart Wait Duration">Replica Restart Wait Duration</dt>

--- a/src/SfxWeb/src/app/views/application/create-service/create-service.component.html
+++ b/src/SfxWeb/src/app/views/application/create-service/create-service.component.html
@@ -69,6 +69,10 @@
                     <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">
                         <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="description.raw.TargetReplicaSetSize" aria-label="Target Replica Set Size" min="1" aria-valuemin="1" integer>
                     </dd>
+                    <dt *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">Auxiliary Replica Count</dt>
+                    <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">
+                        <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="description.raw.AuxiliaryReplicaCount" aria-label="Auxiliary Replica Count" min="0" aria-valuemin="0" integer>
+                    </dd>
                     <dt *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful" title="Replica Restart Wait Duration">Replica Restart Wait Duration</dt>
                     <dd *ngIf="serviceType.raw.ServiceTypeDescription.IsStateful">
                         <input type="number" class="input-flat" autocomplete="off" placeholder="Duration in seconds" [ngModelOptions]="{standalone: true}" [(ngModel)]="description.raw.ReplicaRestartWaitDurationSeconds"
@@ -258,6 +262,7 @@
                                         <th>Name</th>
                                         <th>Primary</th>
                                         <th>Secondary</th>
+                                        <th *ngIf="description.raw.AuxiliaryReplicaCount > 0">Auxiliary</th>
                                         <th>Weight</th>
                                         <th>
                                             <button (click)="description.addLoadMetric()" class="simple-button">Add</button>
@@ -274,6 +279,9 @@
                                         </td>
                                         <td>
                                             <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="loadMetric.SecondaryDefaultLoad" required aria-label="Secondary default load" min="0" aria-valuemin="0">
+                                        </td>
+                                        <td *ngIf="description.raw.AuxiliaryReplicaCount > 0">
+                                            <input type="number" class="input-flat" autocomplete="off" [ngModelOptions]="{standalone: true}" [(ngModel)]="loadMetric.AuxiliaryDefaultLoad" required aria-label="Auxiliary default load" min="0" aria-valuemin="0">
                                         </td>
                                         <td>
                                             <div ngbDropdown container="body">

--- a/src/SfxWeb/src/app/views/service/details/details.component.html
+++ b/src/SfxWeb/src/app/views/service/details/details.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div *ngIf="service">
-    <div class="detail-pane essen-pane">
+    <div class="detail-pane essen-pane" data-cy="serviceDescription">
         <h4>
             Service Description
         </h4>
@@ -11,7 +11,7 @@
     </div>
     
     <div class="detail-pane essen-pane">
-        <h4>
+        <h4> 
             Health Events
         </h4>
         <app-detail-list [list]="service.health.healthEvents" [listSettings]="healthEventsListSettings"></app-detail-list>


### PR DESCRIPTION
This will add the support necessary for auxiliary replicas.
- Allow creation of service with auxiliary replica count specified
- Allow assignment of default load to auxiliary replicas
- Auxiliary replica count is only visible to persisted stateful services
- All actions available on secondary (restart replica) are available to auxiliary replicas
- Detailed replica view of auxiliary replica, similar to that of primary/secondary replicas already.

Backwards compatibility: SF backend is built in a way that if a auxiliary replica count is sent to an older SF, it is ignored, allowing for a newer SFX to still communicate.

Screenshots:
Auxiliary replica is available if service is stateful persisted:
![image](https://user-images.githubusercontent.com/16497214/110995496-717f8a80-8348-11eb-96e1-d3b200c72bf8.png)
![image](https://user-images.githubusercontent.com/16497214/110995447-60367e00-8348-11eb-8600-d39005488739.png)

Service view after all replicas are up (note auxiliary replica in left hand view):
![image](https://user-images.githubusercontent.com/16497214/110995324-29f8fe80-8348-11eb-89e6-9236a515d898.png)

And unavailable if service is stateful non-persisted:
![image](https://user-images.githubusercontent.com/16497214/110995580-9411a380-8348-11eb-81fb-052f164fd0ee.png)
![image](https://user-images.githubusercontent.com/16497214/110995596-9bd14800-8348-11eb-983f-7890bda8f7c5.png)

Unavailable to stateless services:
![image](https://user-images.githubusercontent.com/16497214/110996681-47c76300-834a-11eb-8b66-3c485b2b15bf.png)


