### PR TITLE
Improved node page

### DIFF
--- a/src/SfxWeb/cypress/integration/node.spec.js
+++ b/src/SfxWeb/cypress/integration/node.spec.js
@@ -13,7 +13,7 @@ context('node page', () => {
         cy.route(apiUrl(`Nodes/${nodeName}/?*`), 'fx:node-page/node-info').as('nodeInfo');
         cy.route(apiUrl(`Nodes/${nodeName}/$/GetHealth?*`), 'fx:node-page/health').as('health');
         cy.route(apiUrl(`Nodes/${nodeName}/$/GetApplications?*`), 'fx:node-page/apps').as('apps');
-
+        cy.route('GET', apiUrl(`/Nodes/${nodeName}/$/GetLoadInformation?*`), 'fixture:node-load/get-node-load-information').as("nodeLoad")
     })
 
     describe("essentials", () => {
@@ -25,6 +25,12 @@ context('node page', () => {
             cy.get('[data-cy=header]').within(() => {
                 cy.contains('_nt_0').click();
               });
+
+            cy.get('[data-cy=tiles]').within(() => {
+                cy.contains('6').click();
+                cy.contains('2').click();
+                cy.contains('5').click();
+            });
 
             cy.get('[data-cy=appsList]').within(() => {
                 checkTableSize(1);
@@ -50,8 +56,6 @@ context('node page', () => {
 
     describe("details", () => {
         it('view details', () => {
-            cy.route('GET', apiUrl(`/Nodes/${nodeName}/$/GetLoadInformation?*`), 'fixture:node-load/get-node-load-information').as("nodeLoad")
-
             cy.visit(`/#/node/${nodeName}`)
 
             cy.wait([nodeInfoRef, "@health"]);

--- a/src/SfxWeb/src/app/modules/charts/chart.scss
+++ b/src/SfxWeb/src/app/modules/charts/chart.scss
@@ -104,10 +104,13 @@ $dashboard-small-padding-horizontal: 12px;
             display: block;
             position: relative;
             text-align: left;
-
+            width: 100%;
+            height: 100%;
+            
             .dashboard-tile-inner {
                 position: relative;
-                display: inline-block;
+                width: 100%;
+                height: 100%;
                 padding-left: $dashboard-datapoint-leftbar-width * 2 + 10px !important;
 
                 .dashboard-tile-leftbar {

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.html
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.html
@@ -1,11 +1,20 @@
-<a class="dashboard-wrapper" [routerLink]="link">
-    <div class="dashboard dashboard-small" style="padding: 11px 7px;">
-        <div class="dashboard-tile">
-            <div class="dashboard-tile-inner">
-                <div class="dashboard-tile-leftbar" [ngClass]="barClass"></div>
-                <div class="dashboard-tile-title">{{title}}</div>
-                <div class="dashboard-tile-number">{{count}}</div>
+<ng-template #internal>
+    <div class="dashboard-wrapper">
+
+        <div class="dashboard dashboard-small" style="padding: 11px 7px;">
+            <div class="dashboard-tile">
+                <div class="dashboard-tile-inner">
+                    <div class="dashboard-tile-leftbar" [ngClass]="barClass"></div>
+                    <div class="dashboard-tile-title">{{title}}</div>
+                    <div class="dashboard-tile-number" [style.margin]="middleMargin">{{count}}</div>
+                    <ng-content></ng-content>
+
+                </div>
             </div>
         </div>
     </div>
+</ng-template>
+
+<a *ngIf="link; else internal" [routerLink]="link">
+    <ng-container *ngTemplateOutlet="internal"></ng-container>
 </a>

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
@@ -11,6 +11,7 @@ export class DashboardTextTileComponent {
   @Input() title: string;
   @Input() count: string | number;
   @Input() link: string;
+  @Input() middleMargin: string = "20px 0";
   constructor() { }
 
 }

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
@@ -11,7 +11,7 @@ export class DashboardTextTileComponent {
   @Input() title: string;
   @Input() count: string | number;
   @Input() link: string;
-  @Input() middleMargin: string = "20px 0";
+  @Input() middleMargin = '20px 0';
   constructor() { }
 
 }

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -74,7 +74,7 @@
   </div>
 </div>
 
-<div *ngIf="node?.loadInformation?.isInitialized" class="tile-container">
+<div *ngIf="node?.loadInformation?.isInitialized" class="tile-container" data-cy="tiles">
   <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="Total Replica Count">
   </app-dashboard-text-tile>
   <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="Primary Count">

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -20,15 +20,6 @@
 
     <div class="essential-item ">
       <div class="essential-head">
-        Health State
-      </div>
-      <div class="essential-body">
-        <app-health-badge [badgeClass]="node.healthState.badgeClass" [text]="node.healthState.text"></app-health-badge>
-      </div>
-    </div>
-
-    <div class="essential-item ">
-      <div class="essential-head">
         Fault Domain
       </div>
       <div class="essential-body">
@@ -42,6 +33,15 @@
       </div>
       <div class="essential-body">
         {{node.nodeStatus}}
+      </div>
+    </div>
+
+    <div class="essential-item ">
+      <div class="essential-head">
+        Health State
+      </div>
+      <div class="essential-body">
+        <app-health-badge [badgeClass]="node.healthState.badgeClass" [text]="node.healthState.text"></app-health-badge>
       </div>
     </div>
 

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -75,11 +75,11 @@
 </div>
 
 <div *ngIf="node?.loadInformation?.isInitialized" class="tile-container" data-cy="tiles">
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="Total Replica Count">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="TOTAL REPLICA COUNT">
   </app-dashboard-text-tile>
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="Primary Count">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="PRIMARY REPLICA COUNT">
   </app-dashboard-text-tile>
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.ReplicaCount" title="Replica Count">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.ReplicaCount" title="SECONDARY REPLICA COUNT">
   </app-dashboard-text-tile>
 </div>
 

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -1,6 +1,6 @@
 <div class="detail-pane essen-pane" *ngIf="node">
   <div class="essential-container">
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Name
       </div>
@@ -9,7 +9,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Upgrade Domain
       </div>
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Health State
       </div>
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Fault Domain
       </div>
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Status
       </div>
@@ -45,7 +45,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         IP Address or Domain Name
       </div>
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Type
       </div>
@@ -63,7 +63,7 @@
       </div>
     </div>
 
-    <div class="essential-item essential-half">
+    <div class="essential-item ">
       <div class="essential-head">
         Is Seed Node
       </div>
@@ -72,6 +72,15 @@
       </div>
     </div>
   </div>
+</div>
+
+<div *ngIf="node?.loadInformation?.isInitialized" class="tile-container">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="Total Replica Count">
+  </app-dashboard-text-tile>
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="Primary Count">
+  </app-dashboard-text-tile>
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.ReplicaCount" title="Replica Count">
+  </app-dashboard-text-tile>
 </div>
 
 <div class="detail-pane essen-pane" *ngIf="node && node.isDeactivating" data-cy="deactivated">

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -74,12 +74,21 @@
   </div>
 </div>
 
+<div class="essen-pane help-text-container">
+  <a target="_blank" href="https://aka.ms/sf/loadinformation">
+  Learn more about these metrics <span class="mif-info" ></span>
+  </a>
+</div>
+
 <div *ngIf="node?.loadInformation?.isInitialized" class="tile-container" data-cy="tiles">
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="TOTAL REPLICA COUNT">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.Count" title="TOTAL COUNT" middleMargin="5px 0">
+    Count of all service objects (stateless and stateful) on the node
   </app-dashboard-text-tile>
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="PRIMARY REPLICA COUNT">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.PrimaryCount" title="PRIMARY COUNT" middleMargin="5px 0">
+    Count of Primary replicas on the node    
   </app-dashboard-text-tile>
-  <app-dashboard-text-tile [count]="node.loadInformation.metrics.ReplicaCount" title="SECONDARY REPLICA COUNT">
+  <app-dashboard-text-tile [count]="node.loadInformation.metrics.ReplicaCount" title="REPLICA COUNT" middleMargin="5px 0">
+    Count of total stateful replicas on the node
   </app-dashboard-text-tile>
 </div>
 

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.scss
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.scss
@@ -1,0 +1,7 @@
+@import "src/vars.scss";
+
+
+.help-text-container {
+    width: $tile-width;
+    margin-bottom: 5px;
+}

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
@@ -1,6 +1,6 @@
 import { Component, Injector } from '@angular/core';
 import { map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { Observable, forkJoin } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { ListSettings, ListColumnSetting, ListColumnSettingForLink, ListColumnSettingForBadge, ListColumnSettingWithFilter } from 'src/app/Models/ListSettings';
@@ -35,8 +35,11 @@ export class EssentialsComponent extends NodeBaseControllerDirective {
   }
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
-    return this.node.deployedApps.refresh(messageHandler).pipe(map(deployedApps => {
+    return forkJoin([
+      this.node.loadInformation.refresh(messageHandler),
+      this.node.deployedApps.refresh(messageHandler).pipe(map(deployedApps => {
         this.deployedApps = deployedApps;
-      }));
+      }))
+    ]);
   }
 }

--- a/src/SfxWeb/src/app/views/node/node.module.ts
+++ b/src/SfxWeb/src/app/views/node/node.module.ts
@@ -11,6 +11,7 @@ import { EventsComponent } from './events/events.component';
 import { EventStoreModule } from 'src/app/modules/event-store/event-store.module';
 import { UpgradeProgressModule } from 'src/app/modules/upgrade-progress/upgrade-progress.module';
 import { NodeDeactivationModule } from 'src/app/modules/node-deactivation/node-deactivation.module';
+import { ChartsModule } from 'src/app/modules/charts/charts.module';
 
 @NgModule({
   declarations: [BaseComponent, EssentialsComponent, DetailsComponent, EventsComponent],
@@ -21,7 +22,8 @@ import { NodeDeactivationModule } from 'src/app/modules/node-deactivation/node-d
     DetailListTemplatesModule,
     EventStoreModule,
     UpgradeProgressModule,
-    NodeDeactivationModule
+    NodeDeactivationModule,
+    ChartsModule
   ]
 })
 export class NodeModule { }

--- a/src/SfxWeb/src/styles.scss
+++ b/src/SfxWeb/src/styles.scss
@@ -880,7 +880,7 @@ app-navbar {
 .tile-container {
     display: grid;
     grid-auto-flow: dense;
-    grid-template-columns: repeat(auto-fit, 240px);
+    grid-template-columns: repeat(auto-fit, $tile-width);
     grid-gap: 10px;
     grid-auto-rows: 150px;
     margin-bottom: 15px;

--- a/src/SfxWeb/src/vars.scss
+++ b/src/SfxWeb/src/vars.scss
@@ -189,3 +189,5 @@ $tooltip-color: $font-color-invert !default;
 $tooltip-bg: $tooltip-background !default;
 $tooltip-opacity: 1 !default;
 $tooltip-max-width: 100% !default;
+
+$tile-width: 240px;


### PR DESCRIPTION

![newnodetiles](https://user-images.githubusercontent.com/15344718/111712758-84dc9b00-880b-11eb-9e59-e771d5973d96.PNG)
Include information pulled from node load metrics to the main page to provide more information about the state of entities on the node.