### PR TITLE
Repair job timeline additional improvments

### DIFF
--- a/src/SfxWeb/cypress/fixtures/cluster-page/repair-jobs/in-progress.json
+++ b/src/SfxWeb/cypress/fixtures/cluster-page/repair-jobs/in-progress.json
@@ -2,7 +2,7 @@
 	"Scope": {
 		"Kind": "Cluster"
 	},
-	"TaskId": "Azure/TenantUpdate/441efe72-c74d-4cfa-84df-515b44c89060/4/1145",
+	"TaskId": "Azure/TenantUpdate/441efe72-c74d-4cfa-84df-515b44c89060/4/1555",
 	"Version": "132362216205208555",
 	"Description": "",
 	"State": "Executing",
@@ -35,6 +35,55 @@
 		"PreparingUtcTimestamp": "2020-06-10T00:13:40.520Z",
 		"ApprovedUtcTimestamp": "2020-06-10T00:13:40.740Z",
 		"ExecutingUtcTimestamp": "2020-06-10T00:13:55.675Z",
+		"RestoringUtcTimestamp": "0001-01-01T00:00:00.000Z",
+		"CompletedUtcTimestamp": "0001-01-01T00:00:00.000Z",
+		"PreparingHealthCheckStartUtcTimestamp": "2020-06-10T00:13:40.580Z",
+		"PreparingHealthCheckEndUtcTimestamp": "2020-06-10T00:13:40.630Z",
+		"RestoringHealthCheckStartUtcTimestamp": "0001-01-01T00:00:00.000Z",
+		"RestoringHealthCheckEndUtcTimestamp": "0001-01-01T00:00:00.000Z"
+	},
+	"PreparingHealthCheckState": "Skipped",
+	"RestoringHealthCheckState": "NotStarted",
+	"PerformPreparingHealthCheck": false,
+	"PerformRestoringHealthCheck": false
+},
+{
+	"Scope": {
+		"Kind": "Cluster"
+	},
+	"TaskId": "Azure/TenantUpdate/441efe72-c74d-4cfa-84df-515b44c89060/4/1145",
+	"Version": "132362216205208555",
+	"Description": "",
+	"State": "Preparing",
+	"Flags": 0,
+	"Action": "System.Azure.Job.TenantUpdate",
+	"Target": {
+		"Kind": "Node",
+		"NodeNames": [
+			"_NS_24",
+			"_NS_28"
+		]
+	},
+	"Executor": "fabric:/System/InfrastructureService/NS",
+	"ExecutorData": "{\r\n  \"JobId\": \"441efe72-c74d-4cfa-84df-515b44c89060\",\r\n  \"UD\": 4,\r\n  \"StepId\": \"_NS_24\"\r\n}",
+	"Impact": {
+		"Kind": "Node",
+		"NodeImpactList": [
+			{
+				"NodeName": "_NS_24",
+				"ImpactLevel": "Restart"
+			}
+		]
+	},
+	"ResultStatus": "Pending",
+	"ResultCode": 0,
+	"ResultDetails": "",
+	"History": {
+		"CreatedUtcTimestamp": "2020-06-10T00:13:40.520Z",
+		"ClaimedUtcTimestamp": "2020-06-10T00:13:40.520Z",
+		"PreparingUtcTimestamp": "2020-06-10T00:13:40.520Z",
+		"ApprovedUtcTimestamp": "0001-01-01T00:00:00.000Z",
+		"ExecutingUtcTimestamp": "0001-01-01T00:00:00.000Z",
 		"RestoringUtcTimestamp": "0001-01-01T00:00:00.000Z",
 		"CompletedUtcTimestamp": "0001-01-01T00:00:00.000Z",
 		"PreparingHealthCheckStartUtcTimestamp": "2020-06-10T00:13:40.580Z",

--- a/src/SfxWeb/cypress/fixtures/upgrade-in-progress.json
+++ b/src/SfxWeb/cypress/fixtures/upgrade-in-progress.json
@@ -20,7 +20,7 @@
         },
         {
             "Name": "4",
-            "State": "Completed"
+            "State": "InProgress"
         }
     ],
     "UpgradeState": "RollingForwardInProgress",

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -183,6 +183,9 @@ context('Cluster page', () => {
     it('view completd repair job', () => {
       setup('fixture:cluster-page/repair-jobs/simple')
 
+      cy.get('[data-cy=Executing]').should('not.exist')
+
+
       cy.get('[data-cy=completedjobs]').within( ()=> {
         cy.contains('Completed Repair Tasks').click();  
         
@@ -200,6 +203,20 @@ context('Cluster page', () => {
 
     it('view in progress repair job', () => {
       setup('fixture:cluster-page/repair-jobs/in-progress')
+
+        
+      cy.get('[data-cy=Executing]').within( ()=> {      
+        cy.contains('Azure/TenantUpdate/441efe72-c74d-4cfa-84df-515b44c89060/4/1555')
+      })
+
+      cy.get('[data-cy=Approving]').within( ()=> {      
+        cy.contains('Azure/TenantUpdate/441efe72-c74d-4cfa-84df-515b44c89060/4/1145')
+      })
+
+      cy.get('[data-cy=top]').within( ()=> {      
+        cy.contains(2)  
+        cy.contains('System.Azure.Job.TenantUpdate')
+      })
 
       cy.get('[data-cy=pendingjobs]').within( ()=> {        
         cy.get('tbody > tr').first().within(() =>{

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -51,7 +51,7 @@ context('Cluster page', () => {
 
   describe("details", () => {
   
-    it('upgrade in progress', () => {
+    it.only('upgrade in progress', () => {
       cy.route('GET', upgradeProgress_route, 'fx:upgrade-in-progress').as("inprogres");
 
       cy.route('GET', apiUrl('/Partitions/guidID?*'), 'fx:cluster-page/upgrade/get-partition-info');
@@ -63,9 +63,7 @@ context('Cluster page', () => {
       cy.wait("@inprogres")
 
       cy.contains('Cluster Upgrade In Progress')
-      cy.contains('Current Upgrade Domain : 4')
-
-      cy.get('[data-cy=currentud').within(() => {
+      cy.get('[data-cy=currentud]').within(() => {
         cy.contains('1 - Upgrading ').click();
 
         cy.contains('guidID')
@@ -75,8 +73,11 @@ context('Cluster page', () => {
         cy.wait('@appinfo');
 
         cy.contains('Application name : VisualObjectsApplicationType')
-        cy.contains('min replica : 2')
+        cy.contains('Minimum Replica Set Size : 2')
 
+        cy.get('[data-cy=cud]').within(() => {
+          cy.contains('4')
+        })
       })
     })
 

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -51,7 +51,7 @@ context('Cluster page', () => {
 
   describe("details", () => {
   
-    it.only('upgrade in progress', () => {
+    it('upgrade in progress', () => {
       cy.route('GET', upgradeProgress_route, 'fx:upgrade-in-progress').as("inprogres");
 
       cy.route('GET', apiUrl('/Partitions/guidID?*'), 'fx:cluster-page/upgrade/get-partition-info');

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -161,7 +161,7 @@ context('Cluster page', () => {
     })
   })
 
-  describe.only("repair tasks", () => {
+  describe("repair tasks", () => {
     const setup = (file) => {
       cy.route('GET', apiUrl('/$/GetRepairTaskList?*'), file).as('repairs')
       cy.visit('/#/repairtasks')

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -38,9 +38,11 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
         this.collection.forEach(task => {
             if (task.inProgress) {
                 this.repairTasks.push(task);
+                const executingPhase = task.getPhase('Executing');
+                const approving = task.getPhase('Approved');
 
-                if (task.raw.State === RepairTask.PreparingStatus) {
-                    const approving = task.getPhase('Approved');
+                if (executingPhase.timestamp === '' &&
+                    approving.timestamp !== RepairTask.NonStartedTimeStamp) {
                     if (!longRunningApprovalRepairTask ||
                         approving.durationMilliseconds > longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
                         longRunningApprovalRepairTask = task;
@@ -48,9 +50,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                 }
 
                 if (task.raw.State === RepairTask.ExecutingStatus) {
-                    const executing = task.getPhase('Executing');
                     if (!longRunningExecutingRepairTask ||
-                        executing.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
+                        executingPhase.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
                             longRunningExecutingRepairTask = task;
                     }
                 }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -32,6 +32,9 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
         let longRunningApprovalRepairTask: RepairTask = null;
         this.repairTasks = [];
         this.completedRepairTasks = [];
+
+        let longRunningExecutingRepairTask: RepairTask = null;
+
         this.collection.forEach(task => {
             if (task.inProgress) {
                 this.repairTasks.push(task);
@@ -41,6 +44,10 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                     }
                     longRunningApprovalCount++;
                 }
+
+                // if (!longRunningExecutingRepairTask || longRunningExecutingRepairTask.getPhase('Executing')?.durationMilliseconds < task.getPhase('Executing').) {
+                //     longRunningExecutingRepairTask = task;
+                // }
             } else {
                 this.completedRepairTasks.push(task);
             }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -13,6 +13,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     repairTasks: RepairTask[] = [];
     completedRepairTasks: RepairTask[] = [];
 
+    public longRunningApprovalJob: RepairTask;
+
     public constructor(data: DataService) {
         super(data, parent);
     }
@@ -54,6 +56,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
         } else {
             this.data.warnings.removeNotificationById(RepairTaskCollection.bannerApprovalId);
         }
+
+        this.longRunningApprovalJob = longRunningApprovalRepairTask;
 
         return of(null);
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -39,7 +39,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
             if (task.inProgress) {
                 this.repairTasks.push(task);
 
-                if (task.raw.State === RepairTask.ApprovingStatus) {
+                if (task.raw.State === RepairTask.PreparingStatus) {
                     const approving = task.getPhase('Approved');
                     if (!longRunningApprovalRepairTask ||
                         approving.durationMilliseconds > longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
@@ -49,7 +49,6 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
 
                 if (task.raw.State === RepairTask.ExecutingStatus) {
                     const executing = task.getPhase('Executing');
-
                     if (!longRunningExecutingRepairTask ||
                         executing.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
                             longRunningExecutingRepairTask = task;

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -41,19 +41,19 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                 const executingPhase = task.getPhase('Executing');
                 const approving = task.getPhase('Approved');
 
+                // set the longest approving job if executing has no timestamp but approving does
+                // showing that the current phase is in approving
                 if (executingPhase.timestamp === '' &&
-                    approving.timestamp !== RepairTask.NonStartedTimeStamp) {
-                    if (!longRunningApprovalRepairTask ||
-                        approving.durationMilliseconds > longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
+                    approving.timestamp !== RepairTask.NonStartedTimeStamp &&
+                    (!longRunningApprovalRepairTask ||
+                        approving.durationMilliseconds > longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds)) {
                         longRunningApprovalRepairTask = task;
-                    }
                 }
 
-                if (task.raw.State === RepairTask.ExecutingStatus) {
-                    if (!longRunningExecutingRepairTask ||
-                        executingPhase.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
+                if (task.raw.State === RepairTask.ExecutingStatus &&
+                   (!longRunningExecutingRepairTask ||
+                        executingPhase.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds)) {
                             longRunningExecutingRepairTask = task;
-                    }
                 }
             } else {
                 this.completedRepairTasks.push(task);

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 import { StatusWarningLevel } from 'src/app/Common/Constants';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { DataService } from 'src/app/services/data.service';
-import { RepairTask } from '../repairTask';
+import { RepairTask, StatusCSS } from '../repairTask';
 import { DataModelCollectionBase } from './CollectionBase';
 
 export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
@@ -14,6 +14,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     completedRepairTasks: RepairTask[] = [];
 
     public longRunningApprovalJob: RepairTask;
+    public longestExecutingJob: RepairTask;
 
     public constructor(data: DataService) {
         super(data, parent);
@@ -28,32 +29,38 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     }
 
     protected updateInternal(): Observable<any> {
-        let longRunningApprovalCount = 0;
         let longRunningApprovalRepairTask: RepairTask = null;
+        let longRunningExecutingRepairTask: RepairTask = null;
+
         this.repairTasks = [];
         this.completedRepairTasks = [];
-
-        let longRunningExecutingRepairTask: RepairTask = null;
 
         this.collection.forEach(task => {
             if (task.inProgress) {
                 this.repairTasks.push(task);
-                if (task.getPhase('Approved').durationMilliseconds > RepairTaskCollection.minDurationApprovalbanner) {
-                    if (!longRunningApprovalRepairTask || longRunningApprovalRepairTask.duration < task.duration) {
+
+                if (task.raw.State === RepairTask.ApprovingStatus) {
+                    const approving = task.getPhase('Approved');
+                    if (!longRunningApprovalRepairTask ||
+                        approving.durationMilliseconds < longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
                         longRunningApprovalRepairTask = task;
                     }
-                    longRunningApprovalCount++;
                 }
 
-                // if (!longRunningExecutingRepairTask || longRunningExecutingRepairTask.getPhase('Executing')?.durationMilliseconds < task.getPhase('Executing').) {
-                //     longRunningExecutingRepairTask = task;
-                // }
+                if (task.raw.State === RepairTask.ExecutingStatus) {
+                    const executing = task.getPhase('Executing');
+
+                    if (!longRunningExecutingRepairTask ||
+                        executing.durationMilliseconds < longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
+                            longRunningExecutingRepairTask = task;
+                    }
+                }
             } else {
                 this.completedRepairTasks.push(task);
             }
         });
 
-        if (longRunningApprovalCount > 0) {
+        if (longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds > RepairTaskCollection.minDurationApprovalbanner) {
             this.data.warnings.addOrUpdateNotification({
                 message: `Action Required: There is a repair job (${longRunningApprovalRepairTask.id}) waiting for approval for ${longRunningApprovalRepairTask.displayDuration}. This can block updates to this cluster. Please see aka.ms/sflongapprovingjob for more information. `,
                 level: StatusWarningLevel.Warning,
@@ -65,6 +72,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
         }
 
         this.longRunningApprovalJob = longRunningApprovalRepairTask;
+        this.longestExecutingJob = longRunningExecutingRepairTask;
 
         return of(null);
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -42,7 +42,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                 if (task.raw.State === RepairTask.ApprovingStatus) {
                     const approving = task.getPhase('Approved');
                     if (!longRunningApprovalRepairTask ||
-                        approving.durationMilliseconds < longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
+                        approving.durationMilliseconds > longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds) {
                         longRunningApprovalRepairTask = task;
                     }
                 }
@@ -51,7 +51,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                     const executing = task.getPhase('Executing');
 
                     if (!longRunningExecutingRepairTask ||
-                        executing.durationMilliseconds < longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
+                        executing.durationMilliseconds > longRunningExecutingRepairTask.getPhase('Executing').durationMilliseconds) {
                             longRunningExecutingRepairTask = task;
                     }
                 }
@@ -59,6 +59,9 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
                 this.completedRepairTasks.push(task);
             }
         });
+
+        this.longRunningApprovalJob = longRunningApprovalRepairTask;
+        this.longestExecutingJob = longRunningExecutingRepairTask;
 
         if (longRunningApprovalRepairTask.getPhase('Approved').durationMilliseconds > RepairTaskCollection.minDurationApprovalbanner) {
             this.data.warnings.addOrUpdateNotification({
@@ -70,9 +73,6 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
         } else {
             this.data.warnings.removeNotificationById(RepairTaskCollection.bannerApprovalId);
         }
-
-        this.longRunningApprovalJob = longRunningApprovalRepairTask;
-        this.longestExecutingJob = longRunningExecutingRepairTask;
 
         return of(null);
     }

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
@@ -102,7 +102,7 @@ describe('RepairTask', () => {
         };
         const dateRef = new Date('2020-07-17T04:17:48.437Z');
         const task = new RepairTask(dataService, testData, dateRef);
-        console.log(task);
+
         expect(task.inProgress).toBe(true);
         expect(task.history).toContain({
             timestamp: '2020-07-17T03:17:48.437Z',

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
@@ -1,6 +1,7 @@
 import { RepairTask, InProgressStatus } from './repairTask';
 import { IRawRepairTask } from '../RawDataTypes';
 import { DataService } from 'src/app/services/data.service';
+import { TimeUtils } from 'src/app/Utils/TimeUtils';
 
 
 describe('RepairTask', () => {
@@ -101,12 +102,12 @@ describe('RepairTask', () => {
         };
         const dateRef = new Date('2020-07-17T04:17:48.437Z');
         const task = new RepairTask(dataService, testData, dateRef);
-
+        console.log(task)
         expect(task.inProgress).toBe(true);
         expect(task.history).toContain({
             timestamp: '2020-07-17T03:17:48.437Z',
             phase: 'Executing',
-            duration: '01:00:00.000',
+            duration: TimeUtils.formatDurationAsAspNetTimespan(60 * 60 * 1000),
             durationMilliseconds: 60 * 60 * 1000,
             displayInfo: InProgressStatus,
         });

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
@@ -102,7 +102,7 @@ describe('RepairTask', () => {
         };
         const dateRef = new Date('2020-07-17T04:17:48.437Z');
         const task = new RepairTask(dataService, testData, dateRef);
-        console.log(task)
+        console.log(task);
         expect(task.inProgress).toBe(true);
         expect(task.history).toContain({
             timestamp: '2020-07-17T03:17:48.437Z',

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -57,6 +57,8 @@ export const NotStartedStatus: IDisplayStatus = {
 
 
 export class RepairTask extends DataModelBase<IRawRepairTask> {
+    public static readonly ExecutingStatus = "Executing";
+    public static readonly ApprovingStatus = "Preparing";
     public static NonStartedTimeStamp = '0001-01-01T00:00:00.000Z';
 
     public get id(): string {

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -58,7 +58,7 @@ export const NotStartedStatus: IDisplayStatus = {
 
 export class RepairTask extends DataModelBase<IRawRepairTask> {
     public static readonly ExecutingStatus = 'Executing';
-    public static readonly ApprovingStatus = 'Preparing';
+    public static readonly PreparingStatus = 'Preparing';
     public static NonStartedTimeStamp = '0001-01-01T00:00:00.000Z';
 
     public get id(): string {
@@ -111,6 +111,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> {
             { timestamp: this.raw.History.CompletedUtcTimestamp, phase: 'Completed' },
         ];
 
+        // if the job has been cancelled there shouldnt be Approved or executing phases anymore
         if (this.raw.ResultStatus === 'Cancelled') {
             history = history.filter(stamp => !['Approved', 'Executing'].includes(stamp.phase) );
         }
@@ -240,9 +241,9 @@ export class RepairTask extends DataModelBase<IRawRepairTask> {
             this.generateHistoryPhase('Preparing', this.history.slice(0, 5)),
         ];
 
+        // cancelled jobs have no executing phase
         if (this.raw.ResultStatus === 'Cancelled') {
             this.historyPhases.push(this.generateHistoryPhase('Restoring', this.history.slice(6)));
-            console.log(this);
         }else {
             this.historyPhases.push(this.generateHistoryPhase('Executing', [this.history[5], this.history[6]]),
                                     this.generateHistoryPhase('Restoring', this.history.slice(7)));

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -57,8 +57,8 @@ export const NotStartedStatus: IDisplayStatus = {
 
 
 export class RepairTask extends DataModelBase<IRawRepairTask> {
-    public static readonly ExecutingStatus = "Executing";
-    public static readonly ApprovingStatus = "Preparing";
+    public static readonly ExecutingStatus = 'Executing';
+    public static readonly ApprovingStatus = 'Preparing';
     public static NonStartedTimeStamp = '0001-01-01T00:00:00.000Z';
 
     public get id(): string {

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -109,7 +109,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> {
             { timestamp: this.raw.History.CompletedUtcTimestamp, phase: 'Completed' },
         ];
 
-        if(this.raw.ResultStatus === "Cancelled") {
+        if (this.raw.ResultStatus === 'Cancelled') {
             history = history.filter(stamp => !['Approved', 'Executing'].includes(stamp.phase) );
         }
 
@@ -236,14 +236,14 @@ export class RepairTask extends DataModelBase<IRawRepairTask> {
 
         this.historyPhases = [
             this.generateHistoryPhase('Preparing', this.history.slice(0, 5)),
-        ]
+        ];
 
-        if(this.raw.ResultStatus === "Cancelled") {
-            this.historyPhases.push(this.generateHistoryPhase('Restoring', this.history.slice(6)))
-            console.log(this)
+        if (this.raw.ResultStatus === 'Cancelled') {
+            this.historyPhases.push(this.generateHistoryPhase('Restoring', this.history.slice(6)));
+            console.log(this);
         }else {
             this.historyPhases.push(this.generateHistoryPhase('Executing', [this.history[5], this.history[6]]),
-                                    this.generateHistoryPhase('Restoring', this.history.slice(7)))
+                                    this.generateHistoryPhase('Restoring', this.history.slice(7)));
         }
         return of(null);
     }

--- a/src/SfxWeb/src/app/Utils/TimeUtils.ts
+++ b/src/SfxWeb/src/app/Utils/TimeUtils.ts
@@ -94,39 +94,39 @@ export class TimeUtils {
         const hours = minutes / 60;
         const days = hours / 24;
 
-        if( duration < 1000) {
-            return `${milliseconds} milliseconds`
+        if ( duration < 1000) {
+            return `${milliseconds} milliseconds`;
         }
 
-        if( duration < (60 * 1000) ) {
-            return `${seconds} seconds`
+        if ( duration < (60 * 1000) ) {
+            return `${seconds} seconds`;
         }
-        
-        
-        if( duration < (60 * 60 * 1000) ) {
+
+
+        if ( duration < (60 * 60 * 1000) ) {
             return `${this.formatIndividualTime(minutes % 60, 0)}:`
-            + `${this.formatIndividualTime(seconds % 60, 2, 2)} minutes`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)} minutes`;
         }
 
-        if( duration < (60 * 60 * 1000* 24) ) {
+        if ( duration < (60 * 60 * 1000 * 24) ) {
             return `${Math.floor(hours % 24)}:`
             + `${this.formatIndividualTime(minutes % 60)}:`
             + `${this.formatIndividualTime(seconds % 60, 2, 2)}`
-            + ` hours`
+            + ` hours`;
         }
 
         return `${Math.floor(days) > 0 ? Math.floor(days) + ' days ' : ''}`
             + `${this.formatIndividualTime(hours % 24)}:`
             + `${this.formatIndividualTime(minutes % 60)}:`
-            + `${this.formatIndividualTime(seconds % 60, 2, 2)}`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)}`;
     }
 
     private static formatIndividualTime(duration: number, padStart = 2, substringSize: number = 0) {
         let floored = Math.floor(duration).toString();
-        if(substringSize > 0) {
-            floored = floored.substring(0, substringSize)
+        if (substringSize > 0) {
+            floored = floored.substring(0, substringSize);
         }
-        return floored.padStart(padStart, '0')
+        return floored.padStart(padStart, '0');
     }
 }
 

--- a/src/SfxWeb/src/app/Utils/TimeUtils.ts
+++ b/src/SfxWeb/src/app/Utils/TimeUtils.ts
@@ -118,7 +118,7 @@ export class TimeUtils {
         return `${Math.floor(days) > 0 ? Math.floor(days) + ' days ' : ''}`
             + `${this.formatIndividualTime(hours % 24)}:`
             + `${this.formatIndividualTime(minutes % 60)}:`
-            + `${this.formatIndividualTime(seconds % 60, 2, 2)}.`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)}`
     }
 
     private static formatIndividualTime(duration: number, padStart = 2, substringSize: number = 0) {

--- a/src/SfxWeb/src/app/Utils/TimeUtils.ts
+++ b/src/SfxWeb/src/app/Utils/TimeUtils.ts
@@ -94,6 +94,26 @@ export class TimeUtils {
         const hours = minutes / 60;
         const days = hours / 24;
 
+        if( duration < 1000) {
+            return `${milliseconds} milliseconds`
+        }
+
+        if( duration < (60 * 1000) ) {
+            return `${seconds} seconds`
+        }
+        
+        
+        if( duration < (60 * 60 * 1000) ) {
+            return `${Math.floor(minutes % 60).toString().padStart(2, '0')}:`
+            + `${Math.floor(seconds % 60).toString().substring(0, 2).padStart(2, '0')} minutes`
+        }
+
+        if( duration < (60 * 60 * 1000* 24) ) {
+            return `${Math.floor(hours % 24)}:`
+            + `${Math.floor(minutes % 60).toString().padStart(2, '0')}:`
+            + `${Math.floor(seconds % 60).toString().substring(0, 2).padStart(2, '0')}`
+            + ` hours`
+        }
 
         return `${Math.floor(days) > 0 ? Math.floor(days) + ' days ' : ''}`
             + `${Math.floor(hours % 24).toString().padStart(2, '0')}:`

--- a/src/SfxWeb/src/app/Utils/TimeUtils.ts
+++ b/src/SfxWeb/src/app/Utils/TimeUtils.ts
@@ -104,22 +104,29 @@ export class TimeUtils {
         
         
         if( duration < (60 * 60 * 1000) ) {
-            return `${Math.floor(minutes % 60).toString().padStart(2, '0')}:`
-            + `${Math.floor(seconds % 60).toString().substring(0, 2).padStart(2, '0')} minutes`
+            return `${this.formatIndividualTime(minutes % 60, 0)}:`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)} minutes`
         }
 
         if( duration < (60 * 60 * 1000* 24) ) {
             return `${Math.floor(hours % 24)}:`
-            + `${Math.floor(minutes % 60).toString().padStart(2, '0')}:`
-            + `${Math.floor(seconds % 60).toString().substring(0, 2).padStart(2, '0')}`
+            + `${this.formatIndividualTime(minutes % 60)}:`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)}`
             + ` hours`
         }
 
         return `${Math.floor(days) > 0 ? Math.floor(days) + ' days ' : ''}`
-            + `${Math.floor(hours % 24).toString().padStart(2, '0')}:`
-            + `${Math.floor(minutes % 60).toString().padStart(2, '0')}:`
-            + `${Math.floor(seconds % 60).toString().substring(0, 2).padStart(2, '0')}.`
-            + `${milliseconds.toString().padStart(3, '0')}`;
+            + `${this.formatIndividualTime(hours % 24)}:`
+            + `${this.formatIndividualTime(minutes % 60)}:`
+            + `${this.formatIndividualTime(seconds % 60, 2, 2)}.`
+    }
+
+    private static formatIndividualTime(duration: number, padStart = 2, substringSize: number = 0) {
+        let floored = Math.floor(duration).toString();
+        if(substringSize > 0) {
+            floored = floored.substring(0, substringSize)
+        }
+        return floored.padStart(padStart, '0')
     }
 }
 

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -182,6 +182,42 @@ export class Utils {
         onAddition(data);
     }
 
+}
 
+export interface ICounterMostCommonEntry {
+    key: string | number;
+    value: number;
+}
+
+export class Counter {
+    private counts = {};
+    constructor() {
+
+    }
+
+    public add(key: string | number, incrementalValue: number = 1): void {
+        if (this.counts[key] === undefined) {
+            this.counts[key]  = 0;
+        }
+        this.counts[key] += incrementalValue;
+    }
+
+    public clearAll(): void {
+        this.counts = {};
+    }
+
+    public mostCommon(): ICounterMostCommonEntry[] {
+        const l = Object.keys(this.counts).map(key => {
+            return {
+                key,
+                value: this.counts[key]
+            };
+        });
+        return l.sort(this.sortFunction);
+    }
+
+    private sortFunction(a: ICounterMostCommonEntry, b: ICounterMostCommonEntry): -1 | 0 | 1 {
+        return a.value > b.value ? -1 : 1;
+    }
 }
 

--- a/src/SfxWeb/src/app/modules/charts/charts.module.ts
+++ b/src/SfxWeb/src/app/modules/charts/charts.module.ts
@@ -4,14 +4,15 @@ import { DashboardTileComponent } from './dashboard-tile/dashboard-tile.componen
 import { DashboardTextTileComponent } from './dashboard-text-tile/dashboard-text-tile.component';
 import { BarChartComponent } from './bar-chart/bar-chart.component';
 import { RouterModule } from '@angular/router';
+import { DashboardTextScaleTileComponent } from './dashboard-text-scale-tile/dashboard-text-scale-tile.component';
 
 
 @NgModule({
-  declarations: [DashboardTileComponent, DashboardTextTileComponent, BarChartComponent],
+  declarations: [DashboardTileComponent, DashboardTextTileComponent, BarChartComponent, DashboardTextScaleTileComponent],
   imports: [
     CommonModule,
     RouterModule
   ],
-  exports: [DashboardTileComponent, DashboardTextTileComponent, BarChartComponent]
+  exports: [DashboardTileComponent, DashboardTextTileComponent, BarChartComponent, DashboardTextScaleTileComponent]
 })
 export class ChartsModule { }

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.html
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.html
@@ -4,6 +4,7 @@
             <div class="dashboard-tile-inner">
                 <div class="dashboard-tile-leftbar" [ngClass]="barClass"></div>
                 <div class="dashboard-tile-title">{{title}}</div>
+                <ng-content></ng-content>
                 <div class="dashboard-tile-innertext" *ngFor="let line of text">{{line}}</div>
             </div>
         </div>

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.html
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.html
@@ -1,0 +1,11 @@
+<div class="dashboard-wrapper">
+    <div class="dashboard dashboard-small" style="padding: 11px 7px;">
+        <div class="dashboard-tile">
+            <div class="dashboard-tile-inner">
+                <div class="dashboard-tile-leftbar" [ngClass]="barClass"></div>
+                <div class="dashboard-tile-title">{{title}}</div>
+                <div class="dashboard-tile-innertext" *ngFor="let line of text">{{line}}</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.scss
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.scss
@@ -1,0 +1,6 @@
+@import "../chart.scss";
+
+.dashboard-tile, .dashboard-tile-inner {
+    height: 100%;
+    width: 100%;
+}

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.spec.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardTextScaleTileComponent } from './dashboard-text-scale-tile.component';
+
+describe('DashboardTextScaleTileComponent', () => {
+  let component: DashboardTextScaleTileComponent;
+  let fixture: ComponentFixture<DashboardTextScaleTileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DashboardTextScaleTileComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DashboardTextScaleTileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard-text-scale-tile',
+  templateUrl: './dashboard-text-scale-tile.component.html',
+  styleUrls: ['./dashboard-text-scale-tile.component.scss']
+})
+export class DashboardTextScaleTileComponent implements OnInit {
+
+  @Input() barClass = '';
+  @Input() title: string;
+  @Input() link: string;
+  @Input() text: string[] = [];
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/SfxWeb/src/app/modules/partition-replication/replica-status/replica-status.component.spec.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replica-status/replica-status.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReplicaStatusComponent } from './replica-status.component';
 import { IRemoteReplicatorAcknowledgementDetail } from 'src/app/Models/RawDataTypes';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TimeUtils } from 'src/app/Utils/TimeUtils';
 
 describe('ReplicaStatusComponent', () => {
   let component: ReplicaStatusComponent;
@@ -111,7 +112,7 @@ describe('ReplicaStatusComponent', () => {
       NotReceivedCount: '100',
       ReceivedAndNotAppliedCount: '100'
     };
-    expect(component.getEstimatedDuration(details)).toEqual('00:00:30.000');
+    expect(component.getEstimatedDuration(details)).toEqual(TimeUtils.formatDurationAsAspNetTimespan(30 * 1000));
 
     const details2: IRemoteReplicatorAcknowledgementDetail = {
       AverageApplyDuration: '1500',
@@ -119,7 +120,7 @@ describe('ReplicaStatusComponent', () => {
       NotReceivedCount: '200',
       ReceivedAndNotAppliedCount: '100'
     };
-    expect(component.getEstimatedDuration(details2)).toEqual('00:07:50.000');
+    expect(component.getEstimatedDuration(details2)).toEqual(TimeUtils.formatDurationAsAspNetTimespan(7 * 1000 * 60 + 50 * 1000));
   });
 
 });

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -1,4 +1,15 @@
 <div style="min-height: 900px">
+    <div class="tile-container">
+        <app-dashboard-text-tile
+        [barClass]="repairTaskCollection.repairTasks.length > 0 ? 'badge-upgrade-active' : 'badge-upgrade-inactive'"
+        link="repairtasks" [count]="repairTaskCollection.repairTasks.length" *ngIf="repairTaskCollection.isInitialized"
+        title="REPAIR JOBS IN PROGRESS" style="display: block"></app-dashboard-text-tile>
+
+        <app-dashboard-text-scale-tile barClass="badge-upgrade-active" [text]="tileText" 
+        title="LONGEST RUNNING" *ngIf="repairTaskCollection.repairTasks.length > 0" class="long"
+            style="display: block"></app-dashboard-text-scale-tile>
+    </div>
+
     <div *ngIf="timelineData" style="margin-bottom: 20px;">
         <div data-cy="pendingjobs" class="essen-pane detail-pane" style="margin-bottom: 0px;">
             <app-collapse-container sectionName="Pending Repair Tasks" collapsed="true">

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -13,7 +13,7 @@
                     [ngClass]="l ? '': 'bottom'" class="highlight-hover">
                     <div class="tile-item">
                         <div style="font-size: 15px;" class="overflow-text">{{line.primaryText}}</div>
-                        <div class="left-auto">
+                        <div class="left-auto centering-row">
                             <span class="mif-watch mif-lg"></span>
                             {{line.topCorner}}
                         </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -1,5 +1,5 @@
 <div style="min-height: 900px">
-    <div class="tile-container">
+    <div class="tile-container" data-cy="tiles">
         <app-dashboard-text-tile
             [barClass]="repairTaskCollection.repairTasks.length > 0 ? 'badge-upgrade-active' : 'badge-upgrade-inactive'"
             link="repairtasks" [count]="repairTaskCollection.repairTasks.length"
@@ -7,10 +7,10 @@
         </app-dashboard-text-tile>
 
         <app-dashboard-text-scale-tile barClass="badge-upgrade-active" title="LONGEST RUNNING"
-            *ngIf="tileText.length > 0" class="long" style="display: block">
+            *ngIf="tileText.length > 0" class="long" style="display: block" data-cy="long">
             <div>
                 <div *ngFor="let line of tileText; let l = last" style="padding-bottom: 5px;"
-                    [ngClass]="l ? '': 'bottom'" class="highlight-hover">
+                    [ngClass]="l ? '': 'bottom'" class="highlight-hover" [attr.data-cy]="line.primaryText">
                     <div class="tile-item">
                         <div style="font-size: 15px;" class="overflow-text">{{line.primaryText}}</div>
                         <div class="left-auto centering-row">
@@ -31,7 +31,7 @@
         </app-dashboard-text-scale-tile>
 
         <app-dashboard-text-scale-tile class="long" title="TOP REPAIR JOB ACTIONS" *ngIf="tileText2.length > 0"
-            style="display: block">
+            style="display: block" data-cy="top">
             <div style="margin-top: 5px;">
                 <div *ngFor="let line of tileText2; let i = index" class="bottom">
                     <div class="highlight-hover tile-item">

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -8,6 +8,10 @@
         <app-dashboard-text-scale-tile barClass="badge-upgrade-active" [text]="tileText" 
         title="LONGEST RUNNING" *ngIf="repairTaskCollection.repairTasks.length > 0" class="long"
             style="display: block"></app-dashboard-text-scale-tile>
+
+        <app-dashboard-text-scale-tile barClass="badge-upgrade-active" [text]="tileText2" 
+        title="TOP REPAIR JOB ACTIONS" *ngIf="tileText2.length > 0"
+            style="display: block"></app-dashboard-text-scale-tile>
     </div>
 
     <div *ngIf="timelineData" style="margin-bottom: 20px;">

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -1,17 +1,50 @@
 <div style="min-height: 900px">
     <div class="tile-container">
         <app-dashboard-text-tile
-        [barClass]="repairTaskCollection.repairTasks.length > 0 ? 'badge-upgrade-active' : 'badge-upgrade-inactive'"
-        link="repairtasks" [count]="repairTaskCollection.repairTasks.length" *ngIf="repairTaskCollection.isInitialized"
-        title="REPAIR JOBS IN PROGRESS" style="display: block"></app-dashboard-text-tile>
+            [barClass]="repairTaskCollection.repairTasks.length > 0 ? 'badge-upgrade-active' : 'badge-upgrade-inactive'"
+            link="repairtasks" [count]="repairTaskCollection.repairTasks.length"
+            *ngIf="repairTaskCollection.isInitialized" title="REPAIR JOBS IN PROGRESS" style="display: block">
+        </app-dashboard-text-tile>
 
-        <app-dashboard-text-scale-tile barClass="badge-upgrade-active" [text]="tileText" 
-        title="LONGEST RUNNING" *ngIf="repairTaskCollection.repairTasks.length > 0" class="long"
-            style="display: block"></app-dashboard-text-scale-tile>
+        <app-dashboard-text-scale-tile barClass="badge-upgrade-active" title="LONGEST RUNNING"
+            *ngIf="tileText.length > 0" class="long" style="display: block">
+            <div>
+                <div *ngFor="let line of tileText; let l = last" style="padding-bottom: 5px;"
+                    [ngClass]="l ? '': 'bottom'" class="highlight-hover">
+                    <div class="tile-item">
+                        <div style="font-size: 15px;" class="overflow-text">{{line.primaryText}}</div>
+                        <div class="left-auto">
+                            <span class="mif-watch mif-lg"></span>
+                            {{line.topCorner}}
+                        </div>
+                    </div>
+                    <div style="display: flex; flex-direction: row">
+                        <div>
+                            {{line.secondaryText}}
+                        </div>
+                        <div class="left-auto">
+                            <app-clip-board [text]="line.secondaryText"></app-clip-board>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </app-dashboard-text-scale-tile>
 
-        <app-dashboard-text-scale-tile barClass="badge-upgrade-active" [text]="tileText2" 
-        title="TOP REPAIR JOB ACTIONS" *ngIf="tileText2.length > 0"
-            style="display: block"></app-dashboard-text-scale-tile>
+        <app-dashboard-text-scale-tile class="long" title="TOP REPAIR JOB ACTIONS" *ngIf="tileText2.length > 0"
+            style="display: block">
+            <div style="margin-top: 5px;">
+                <div *ngFor="let line of tileText2; let i = index" class="bottom">
+                    <div class="highlight-hover tile-item">
+                        <div [ngStyle]="{'font-size': ( 25 - i * 5 ) + 'px' }" class="tile-list-entry">{{line.value}}
+                        </div>
+                        <div>{{line.key}}</div>
+                        <div class="left-auto">
+                            <app-clip-board [text]="line.key"></app-clip-board>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </app-dashboard-text-scale-tile>
     </div>
 
     <div *ngIf="timelineData" style="margin-bottom: 20px;">
@@ -41,26 +74,29 @@
         </div>
 
         <div style="margin-left: 15px;">
-            <app-event-store-timeline [events]="timelineData" [fitOnDataChange]="false" data-cy="timeline" 
-            [displayMoveToStart]="false" [displayMoveToEnd]="false"></app-event-store-timeline>
+            <app-event-store-timeline [events]="timelineData" [fitOnDataChange]="false" data-cy="timeline"
+                [displayMoveToStart]="false" [displayMoveToEnd]="false"></app-event-store-timeline>
         </div>
     </div>
-    
+
     <div class="detail-pane essen-pane" data-cy="pendingjobs">
         <app-collapse-container sectionName="Pending Repair Tasks">
             <h4 collapse-header>
                 Pending Repair Tasks
             </h4>
-            <app-detail-list [list]="repairTaskCollection.repairTasks" [listSettings]="repairTaskListSettings" collapse-body (sorted)="sorted($event, false)"></app-detail-list>
+            <app-detail-list [list]="repairTaskCollection.repairTasks" [listSettings]="repairTaskListSettings"
+                collapse-body (sorted)="sorted($event, false)"></app-detail-list>
         </app-collapse-container>
     </div>
-    
+
     <div class="detail-pane essen-pane" data-cy="completedjobs">
         <app-collapse-container collapsed=true sectionName="Completed Repair Tasks">
             <h4 collapse-header>
                 Completed Repair Tasks
             </h4>
-            <app-detail-list [list]="repairTaskCollection.completedRepairTasks" [listSettings]="completedRepairTaskListSettings" collapse-body (sorted)="sorted($event)"></app-detail-list>
+            <app-detail-list [list]="repairTaskCollection.completedRepairTasks"
+                [listSettings]="completedRepairTaskListSettings" collapse-body (sorted)="sorted($event)">
+            </app-detail-list>
         </app-collapse-container>
     </div>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.html
@@ -7,9 +7,9 @@
         </app-dashboard-text-tile>
 
         <app-dashboard-text-scale-tile barClass="badge-upgrade-active" title="LONGEST RUNNING"
-            *ngIf="tileText.length > 0" class="long" style="display: block" data-cy="long">
+            *ngIf="longestRunning.length > 0" class="long" style="display: block" data-cy="long">
             <div>
-                <div *ngFor="let line of tileText; let l = last" style="padding-bottom: 5px;"
+                <div *ngFor="let line of longestRunning; let l = last" style="padding-bottom: 5px;"
                     [ngClass]="l ? '': 'bottom'" class="highlight-hover" [attr.data-cy]="line.primaryText">
                     <div class="tile-item">
                         <div style="font-size: 15px;" class="overflow-text">{{line.primaryText}}</div>
@@ -30,10 +30,10 @@
             </div>
         </app-dashboard-text-scale-tile>
 
-        <app-dashboard-text-scale-tile class="long" title="TOP REPAIR JOB ACTIONS" *ngIf="tileText2.length > 0"
+        <app-dashboard-text-scale-tile class="long" title="TOP REPAIR JOB ACTIONS" *ngIf="MostCommonActions.length > 0"
             style="display: block" data-cy="top">
             <div style="margin-top: 5px;">
-                <div *ngFor="let line of tileText2; let i = index" class="bottom">
+                <div *ngFor="let line of MostCommonActions; let i = index" class="bottom">
                     <div class="highlight-hover tile-item">
                         <div [ngStyle]="{'font-size': ( 25 - i * 5 ) + 'px' }" class="tile-list-entry">{{line.value}}
                         </div>

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
@@ -7,10 +7,14 @@
     border-bottom: 1px solid #4c4c4c;
 }
 
-.tile-item {
+.centering-row {
     display: flex;
     flex-direction: row;
     align-items: center;
+}
+
+.tile-item {
+    @extend .centering-row;
     height: 35px;
 }
 

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
@@ -2,3 +2,31 @@
     margin: 5px;
     position: relative;
 }
+
+.bottom {
+    border-bottom: 1px solid #4c4c4c;
+}
+
+.tile-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 35px;
+}
+
+.tile-list-entry {
+    width: 50px;
+    text-align: center;
+    margin-right: 10px;
+}
+
+
+.left-auto {
+    margin-left: auto;
+}
+
+.overflow-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.scss
@@ -16,6 +16,7 @@
 .tile-item {
     @extend .centering-row;
     height: 35px;
+    position: relative;
 }
 
 .tile-list-entry {

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -21,8 +21,8 @@ import { Counter } from 'src/app/Utils/Utils';
 export class RepairTasksComponent extends BaseControllerDirective {
   public repairTaskCollection: RepairTaskCollection;
 
-  tileText: string[] = [];
-  tileText2: string[] = [];
+  tileText: any[] = [];
+  tileText2: any[] = [];
 
   // used for timeline
   sortedRepairTasks: RepairTask[] = [];
@@ -132,27 +132,30 @@ export class RepairTasksComponent extends BaseControllerDirective {
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.repairTaskCollection.refresh(messageHandler).pipe(map(() => {
-      this.tileText = [];
       this.tileText2 = [];
       let counter = new Counter();
-
       this.repairTaskCollection.collection.forEach(task => {
         counter.add(task.raw.Action)
       })
+      this.tileText2 = counter.mostCommon().slice(0,3);
 
-      this.tileText2 = counter.mostCommon().slice(0,3).map(pair => `${pair.key}:${pair.value}`)
-      console.log(counter.mostCommon());
-
-      if (this.repairTaskCollection.longRunningApprovalJob) {
-        this.tileText.push('Approving');
-        this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.id);
-        this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.displayDuration);
+      this.tileText = [];
+      const longRunningApprovalJob = this.repairTaskCollection.longRunningApprovalJob;
+      if (longRunningApprovalJob) {
+        this.tileText.push({
+          primaryText: 'Approving',
+          secondaryText: longRunningApprovalJob.id,
+          topCorner: longRunningApprovalJob.displayDuration
+        });
       }
 
-      if (this.repairTaskCollection.longRunningApprovalJob) {
-        this.tileText.push('Executing');
-        this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.id);
-        this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.displayDuration);
+      const longRunningExecutingRepairJob = this.repairTaskCollection.longestExecutingJob;
+      if (longRunningExecutingRepairJob) {
+        this.tileText.push({
+          primaryText: 'Executing',
+          secondaryText: longRunningExecutingRepairJob.id,
+          topCorner: longRunningExecutingRepairJob.displayDuration
+        });
       }
     }));
   }

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -11,6 +11,7 @@ import { ITimelineData, EventStoreUtils } from 'src/app/Models/eventstore/timeli
 import { DataSet, DataGroup, DataItem } from 'vis-timeline';
 import { RepairTaskCollection } from 'src/app/Models/DataModels/collections/RepairTaskCollection';
 import { map } from 'rxjs/operators';
+import { Counter } from 'src/app/Utils/Utils';
 
 @Component({
   selector: 'app-repair-tasks',
@@ -21,6 +22,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
   public repairTaskCollection: RepairTaskCollection;
 
   tileText: string[] = [];
+  tileText2: string[] = [];
 
   // used for timeline
   sortedRepairTasks: RepairTask[] = [];
@@ -131,6 +133,15 @@ export class RepairTasksComponent extends BaseControllerDirective {
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.repairTaskCollection.refresh(messageHandler).pipe(map(() => {
       this.tileText = [];
+      this.tileText2 = [];
+      let counter = new Counter();
+
+      this.repairTaskCollection.collection.forEach(task => {
+        counter.add(task.raw.Action)
+      })
+
+      this.tileText2 = counter.mostCommon().slice(0,3).map(pair => `${pair.key}:${pair.value}`)
+      console.log(counter.mostCommon());
 
       if (this.repairTaskCollection.longRunningApprovalJob) {
         this.tileText.push('Approving');

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -29,7 +29,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
 
   tileText: ITileListItem[] = [];
   tileText2: ICounterMostCommonEntry[] = [];
-  
+
   // used for timeline
   sortedRepairTasks: RepairTask[] = [];
   sortedCompletedRepairTasks: RepairTask[] = [];

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -11,7 +11,13 @@ import { ITimelineData, EventStoreUtils } from 'src/app/Models/eventstore/timeli
 import { DataSet, DataGroup, DataItem } from 'vis-timeline';
 import { RepairTaskCollection } from 'src/app/Models/DataModels/collections/RepairTaskCollection';
 import { map } from 'rxjs/operators';
-import { Counter } from 'src/app/Utils/Utils';
+import { Counter, ICounterMostCommonEntry } from 'src/app/Utils/Utils';
+
+interface ITileListItem {
+  primaryText: string;
+  secondaryText: string;
+  topCorner: string;
+}
 
 @Component({
   selector: 'app-repair-tasks',
@@ -21,9 +27,9 @@ import { Counter } from 'src/app/Utils/Utils';
 export class RepairTasksComponent extends BaseControllerDirective {
   public repairTaskCollection: RepairTaskCollection;
 
-  tileText: any[] = [];
-  tileText2: any[] = [];
-
+  tileText: ITileListItem[] = [];
+  tileText2: ICounterMostCommonEntry[] = [];
+  
   // used for timeline
   sortedRepairTasks: RepairTask[] = [];
   sortedCompletedRepairTasks: RepairTask[] = [];

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -27,8 +27,8 @@ interface ITileListItem {
 export class RepairTasksComponent extends BaseControllerDirective {
   public repairTaskCollection: RepairTaskCollection;
 
-  tileText: ITileListItem[] = [];
-  tileText2: ICounterMostCommonEntry[] = [];
+  longestRunning: ITileListItem[] = [];
+  MostCommonActions: ICounterMostCommonEntry[] = [];
 
   // used for timeline
   sortedRepairTasks: RepairTask[] = [];
@@ -138,17 +138,15 @@ export class RepairTasksComponent extends BaseControllerDirective {
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.repairTaskCollection.refresh(messageHandler).pipe(map(() => {
-      this.tileText2 = [];
-      const counter = new Counter();
-      this.repairTaskCollection.collection.forEach(task => {
-        counter.add(task.raw.Action);
-      });
-      this.tileText2 = counter.mostCommon().slice(0, 3);
 
-      this.tileText = [];
+      const counter = new Counter();
+      this.repairTaskCollection.collection.forEach(task => counter.add(task.raw.Action));
+      this.MostCommonActions = counter.mostCommon().slice(0, 3);
+
+      this.longestRunning = [];
       const longRunningApprovalJob = this.repairTaskCollection.longRunningApprovalJob;
       if (longRunningApprovalJob) {
-        this.tileText.push({
+        this.longestRunning.push({
           primaryText: 'Approving',
           secondaryText: longRunningApprovalJob.id,
           topCorner: longRunningApprovalJob.displayDuration
@@ -157,7 +155,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
 
       const longRunningExecutingRepairJob = this.repairTaskCollection.longestExecutingJob;
       if (longRunningExecutingRepairJob) {
-        this.tileText.push({
+        this.longestRunning.push({
           primaryText: 'Executing',
           secondaryText: longRunningExecutingRepairJob.id,
           topCorner: longRunningExecutingRepairJob.displayDuration

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -133,11 +133,11 @@ export class RepairTasksComponent extends BaseControllerDirective {
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.repairTaskCollection.refresh(messageHandler).pipe(map(() => {
       this.tileText2 = [];
-      let counter = new Counter();
+      const counter = new Counter();
       this.repairTaskCollection.collection.forEach(task => {
-        counter.add(task.raw.Action)
-      })
-      this.tileText2 = counter.mostCommon().slice(0,3);
+        counter.add(task.raw.Action);
+      });
+      this.tileText2 = counter.mostCommon().slice(0, 3);
 
       this.tileText = [];
       const longRunningApprovalJob = this.repairTaskCollection.longRunningApprovalJob;

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -132,17 +132,17 @@ export class RepairTasksComponent extends BaseControllerDirective {
     return this.repairTaskCollection.refresh(messageHandler).pipe(map(() => {
       this.tileText = [];
 
-      if(this.repairTaskCollection.longRunningApprovalJob) {
-        this.tileText.push("Approving")
+      if (this.repairTaskCollection.longRunningApprovalJob) {
+        this.tileText.push('Approving');
         this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.id);
         this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.displayDuration);
       }
 
-      if(this.repairTaskCollection.longRunningApprovalJob) {
-        this.tileText.push("Executing")
+      if (this.repairTaskCollection.longRunningApprovalJob) {
+        this.tileText.push('Executing');
         this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.id);
         this.tileText.push(this.repairTaskCollection.longRunningApprovalJob.displayDuration);
       }
-    }))
+    }));
   }
 }

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -144,7 +144,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
       this.MostCommonActions = counter.mostCommon().slice(0, 3);
 
       this.longestRunning = [];
-      console.log(this.repairTaskCollection);
+
       const longRunningApprovalJob = this.repairTaskCollection.longRunningApprovalJob;
       if (longRunningApprovalJob) {
         this.longestRunning.push({

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -144,6 +144,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
       this.MostCommonActions = counter.mostCommon().slice(0, 3);
 
       this.longestRunning = [];
+      console.log(this.repairTaskCollection);
       const longRunningApprovalJob = this.repairTaskCollection.longRunningApprovalJob;
       if (longRunningApprovalJob) {
         this.longestRunning.push({

--- a/src/SfxWeb/src/app/views/cluster/upgrade-info/upgrade-info.component.html
+++ b/src/SfxWeb/src/app/views/cluster/upgrade-info/upgrade-info.component.html
@@ -62,7 +62,7 @@
 
 <div *ngIf="clusterUpgradeProgress.isUpgrading" data-cy="currentud">
     <div class="essential-container">
-        <div class="essential-item">
+        <div class="essential-item" data-cy="cud">
             <div class="essential-head">
                 Current Upgrade Domain
             </div>

--- a/src/SfxWeb/src/styles.scss
+++ b/src/SfxWeb/src/styles.scss
@@ -877,6 +877,10 @@ app-navbar {
     grid-row: span 2;
   }
 
+.long {
+    grid-column: span 2;
+}
+
 .tile-container {
     display: grid;
     grid-auto-flow: dense;


### PR DESCRIPTION
Fix order by duration to not use string comparison of display date formatting
Provide more easily readable dates.
Fix issue where cancelled jobs showed as in progress, will not show as finished with no execution phase.
Add tiles to the top of the repair job page.
![increased timereadability](https://user-images.githubusercontent.com/15344718/111555802-63fe4200-8746-11eb-9845-a5486e51a8f7.PNG)
![repairjobtiles](https://user-images.githubusercontent.com/15344718/112699498-305ba000-8e49-11eb-84d9-cbf5e0886c1e.PNG)

