### PR TITLE
show used/unused app types.

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -20,6 +20,8 @@ import { RoutesService } from 'src/app/services/routes.service';
 // -----------------------------------------------------------------------------
 
 export class ApplicationType extends DataModelBase<IRawApplicationType> {
+    /*IsInUse is only set on the AppType on the appType Essential page*/
+    public isInUse: boolean = null;
     public serviceTypes: ServiceTypeCollection;
 
     public constructor(data: DataService, raw?: IRawApplicationType) {

--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -113,7 +113,7 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplicationType> {
         return this.data.restClient.getApplicationTypes(this.name, messageHandler).pipe(map(response => {
-            CollectionUtils.updateDataModelCollection(this.appTypes, response.map( rawAppType => new ApplicationType(this.data, rawAppType)));
+            this.appTypes = CollectionUtils.updateDataModelCollection(this.appTypes, response.map( rawAppType => new ApplicationType(this.data, rawAppType)));
             return response[0];
             }));
     }

--- a/src/SfxWeb/src/app/views/application-type/application-type.module.ts
+++ b/src/SfxWeb/src/app/views/application-type/application-type.module.ts
@@ -10,6 +10,7 @@ import { DetailListTemplatesModule } from 'src/app/modules/detail-list-templates
 import { ActionRowComponent } from './action-row/action-row.component';
 import { CreateApplicationComponent } from './create-application/create-application.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 
 @NgModule({
@@ -21,6 +22,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
     DetailListTemplatesModule,
     ReactiveFormsModule,
     FormsModule,
+    NgbNavModule
   ],
   entryComponents: [ActionRowComponent]
 })

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
@@ -3,7 +3,27 @@
         <h4 collapse-header>
             Application Type versions
         </h4>    
-        <app-detail-list [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings" collapse-body data-cy="appTypeVersions"></app-detail-list>	
+        <div collapse-body>
+            <div ngbNav #nav="ngbNav" >
+                <div ngbNavItem>
+                    <a ngbNavLink style="font-size: 12pt;">
+                        Active
+                    </a>
+                    <ng-template ngbNavContent>
+                        <app-detail-list [list]="activeAppTypes" [listSettings]="activeAppTypesListSettings" data-cy="appTypeVersions"></app-detail-list>	
+                    </ng-template>
+                </div>
+                <div ngbNavItem>
+                    <a ngbNavLink style="font-size: 12pt;">
+                        All
+                    </a>
+                    <ng-template ngbNavContent>
+                        <app-detail-list [list]="appTypeGroup.appTypes" [listSettings]="appTypesListSettings"></app-detail-list>	
+                    </ng-template>
+                </div>
+            </div>
+            <div [ngbNavOutlet]="nav"></div>
+        </div>
     </app-collapse-container>
 </div>
 
@@ -15,3 +35,5 @@
         <app-detail-list [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-body data-cy="applicationsList"></app-detail-list>	
     </app-collapse-container>
 </div>
+
+

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.html
@@ -35,5 +35,3 @@
         <app-detail-list [list]="appTypeGroup.apps" [listSettings]="appsListSettings" collapse-body data-cy="applicationsList"></app-detail-list>	
     </app-collapse-container>
 </div>
-
-

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -3,11 +3,12 @@ import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { Observable } from 'rxjs';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType';
+import { ApplicationType, ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType';
 import { ListSettings, ListColumnSetting, ListColumnSettingWithFilter, ListColumnSettingForBadge, ListColumnSettingForLink } from 'src/app/Models/ListSettings';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
 import { ApplicationTypeBaseControllerDirective } from '../ApplicationTypeBase';
 import { ListColumnSettingForApplicationType } from '../action-row/action-row.component';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-essentials',
@@ -18,44 +19,72 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   appTypeGroup: ApplicationTypeGroup;
   appsListSettings: ListSettings;
   appTypesListSettings: ListSettings;
+  activeAppTypesListSettings: ListSettings;
+
+  activeAppTypes: ApplicationType[] = [];
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {
     super(data, injector);
   }
 
   setup() {
-    this.appTypesListSettings = this.settings.getNewOrExistingListSettings(
-      'appTypeAppTypes',
-      ['raw.Version'],
-      [
-          new ListColumnSetting('name', 'Name'),
-          new ListColumnSetting('raw.Version', 'Version'),
-          new ListColumnSettingWithFilter('raw.Status', 'Status'),
-          new ListColumnSettingForApplicationType()
-      ],
-      [
-          new ListColumnSetting('placeholder', 'placeholder', {enableFilter: false}), // Empty column
-          new ListColumnSetting('raw.StatusDetails', 'Status Details', {
-            enableFilter: false,
-            getDisplayHtml: (item) => HtmlUtils.getSpanWithCustomClass('preserve-whitespace-wrap', item.raw.StatusDetails),
-            colspan: 100
-          })
-      ],
-      false /* collapsable */,
-      (item) => item.raw.StatusDetails, /* only show second row when status details is not empty */
-      false /* searchable */);
+    this.activeAppTypesListSettings = this.getNewOrExistingAppTypeListSettings();
+    this.appTypesListSettings = this.getNewOrExistingAppTypeListSettings(true);
 
     this.appsListSettings = this.settings.getNewOrExistingListSettings('appTypeApps', ['name'], [
-        new ListColumnSettingForLink('name', 'Name', item => item.viewPath),
-        new ListColumnSetting('raw.TypeName', 'Application Type'),
-        new ListColumnSetting('raw.TypeVersion', 'Version'),
-        new ListColumnSettingForBadge('healthState', 'Health State'),
-        new ListColumnSettingWithFilter('raw.Status', 'Status'),
+      new ListColumnSettingForLink('name', 'Name', item => item.viewPath),
+      new ListColumnSetting('raw.TypeName', 'Application Type'),
+      new ListColumnSetting('raw.TypeVersion', 'Version'),
+      new ListColumnSettingForBadge('healthState', 'Health State'),
+      new ListColumnSettingWithFilter('raw.Status', 'Status'),
     ]);
   }
 
-  refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
-    return this.data.getApps(true, messageHandler);
+  refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
+    return this.data.getApps(true, messageHandler).pipe(map(() => {
+      try {
+        this.activeAppTypes = [];
+        this.appTypeGroup.appTypes.forEach(appType => {
+          const used = this.appTypeGroup.apps.some(app => app.raw.TypeVersion === appType.raw.Version);
+          appType.isInUse = used;
+          if (used) {
+            this.activeAppTypes.push(appType);
+          }
+        });
+      } catch (e) {
+        console.log(e);
+      }
+    })
+    );
+  }
+
+  public getNewOrExistingAppTypeListSettings(includeIsUsedColumn: boolean = false) {
+    let listKey = 'appTypeAppTypes';
+    const settings = [
+      new ListColumnSetting('name', 'Name'),
+      new ListColumnSetting('raw.Version', 'Version'),
+      new ListColumnSettingWithFilter('raw.Status', 'Status'),
+      new ListColumnSettingForApplicationType()
+    ];
+
+    const nestedList = [
+      new ListColumnSetting('placeholder', 'placeholder', { enableFilter: false }), // Empty column
+      new ListColumnSetting('raw.StatusDetails', 'Status Details', {
+        enableFilter: false,
+        getDisplayHtml: (item) => HtmlUtils.getSpanWithCustomClass('preserve-whitespace-wrap', item.raw.StatusDetails),
+        colspan: 100
+      })
+    ];
+
+    if (includeIsUsedColumn) {
+      settings.splice(3, 0, new ListColumnSetting('isInUse', 'In use'));
+      listKey += 'andUsedCol';
+    }
+
+    return this.settings.getNewOrExistingListSettings(listKey, ['raw.Version'], settings, nestedList,
+      false,
+      (item) => item.raw.StatusDetails,
+      false);
   }
 
 }

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -21,6 +21,7 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   appTypesListSettings: ListSettings;
   activeAppTypesListSettings: ListSettings;
 
+  //have a separate list for active app types in addition to the app types on the appTypeGroup
   activeAppTypes: ApplicationType[] = [];
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {
@@ -43,6 +44,7 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.data.getApps(true, messageHandler).pipe(map(() => {
       try {
+        //check on refresh which appTypes are being used by at least one application
         this.activeAppTypes = [];
         this.appTypeGroup.appTypes.forEach(appType => {
           const used = this.appTypeGroup.apps.some(app => app.raw.TypeVersion === appType.raw.Version);
@@ -77,7 +79,7 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
     ];
 
     if (includeIsUsedColumn) {
-      settings.splice(3, 0, new ListColumnSetting('isInUse', 'In use'));
+      settings.splice(3, 0, new ListColumnSetting('isInUse', 'In Use'));
       listKey += 'andUsedCol';
     }
 

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -21,7 +21,7 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   appTypesListSettings: ListSettings;
   activeAppTypesListSettings: ListSettings;
 
-  //have a separate list for active app types in addition to the app types on the appTypeGroup
+  // have a separate list for active app types in addition to the app types on the appTypeGroup
   activeAppTypes: ApplicationType[] = [];
 
   constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {
@@ -44,7 +44,7 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return this.data.getApps(true, messageHandler).pipe(map(() => {
       try {
-        //check on refresh which appTypes are being used by at least one application
+        // check on refresh which appTypes are being used by at least one application
         this.activeAppTypes = [];
         this.appTypeGroup.appTypes.forEach(appType => {
           const used = this.appTypeGroup.apps.some(app => app.raw.TypeVersion === appType.raw.Version);


### PR DESCRIPTION
Provide a tabbed view for showing in use app types and a separate tab for all app types including a column listed used/unused
![activeapps](https://user-images.githubusercontent.com/15344718/114082845-1c5d6880-9863-11eb-9372-4b96e8ea9dcf.PNG)
![allapptypes](https://user-images.githubusercontent.com/15344718/114082843-1c5d6880-9863-11eb-86ee-96feb7dd9b98.PNG)
closes #511 