### PR TITLE
remove the base redirect if the page fails the first time to load

### DIFF
--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -32,7 +32,7 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
              this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => this.refresh(this.messageService))));
 
-             this.subscriptions.add(this.common().pipe(mergeMap(() => this.refresh(this.messageService))).subscribe())
+             this.subscriptions.add(this.common().pipe(mergeMap(() => this.refresh(this.messageService))).subscribe());
         }));
 
          console.log(this);

--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -30,14 +30,9 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
              this.setup();
 
-             this.subscriptions.add(this.common().pipe(mergeMap( () => this.refresh())).subscribe(
-                 () => {
-                     this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => this.refresh(this.messageService))));
-                 },
-                 () => {
-                     this.router.navigate(['/']);
-                 }
-             ));
+             this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => this.refresh(this.messageService))));
+
+             this.subscriptions.add(this.common().pipe(mergeMap(() => this.refresh(this.messageService))).subscribe())
         }));
 
          console.log(this);


### PR DESCRIPTION
If a page failed to load, instead of trying to redirect and not include the refreshSubject just show the errors for failed requests.