### PR TITLE
Multiple event store

### DIFF
--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -21,7 +21,7 @@
         </div>
         <div>
             <div class="btn-group btn-group-toggle" ngbRadioGroup [(ngModel)]="showAllEvents" name="radioBasic">
-                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="timelineGenerator">
+                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="listEventStoreData"><!-- This is no the optimal condition -->
                     <input ngbButton type="radio" [value]="false"> Correlated
                 </label>
                 <label class="flat-button checkbox-push solid-grey" ngbButtonLabel>
@@ -43,8 +43,13 @@
             <app-event-store-timeline [events]="timeLineEventsData" ></app-event-store-timeline>
         </div>
 
-        <app-detail-list [list]="eventsList.collection" [listSettings]="eventsList.settings" [isLoading]="!eventsList.isInitialized"></app-detail-list>
-    
+        <div *ngFor="let eventStoreData of listEventStoreData">
+            <h2> {{eventStoreData.displayName}} </h2>
+            <app-detail-list [list]="eventStoreData.eventsList.collection" 
+            [listSettings]="eventStoreData.eventsList.settings" 
+            [isLoading]="!eventStoreData.eventsList.isInitialized"></app-detail-list>
+        </div>
+        
         <div>
             <div style="float: right; padding: 15px 0 0 0; margin: 0px;">
                 <span class="dropdown-toggle dark-background-link bowtie-icon bowtie-status-error"

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -21,7 +21,7 @@
         </div>
         <div>
             <div class="btn-group btn-group-toggle" ngbRadioGroup [(ngModel)]="showAllEvents" name="radioBasic">
-                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="!checkAllOption()">
+                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="showCorrelatedBtn">
                     <input ngbButton type="radio" [value]="false"> Correlated
                 </label>
                 <label class="flat-button checkbox-push solid-grey" ngbButtonLabel>

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -21,7 +21,7 @@
         </div>
         <div>
             <div class="btn-group btn-group-toggle" ngbRadioGroup [(ngModel)]="showAllEvents" name="radioBasic">
-                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="listEventStoreData"><!-- This is no the optimal condition -->
+                <label class="flat-button checkbox-push solid-grey" ngbButtonLabel *ngIf="!checkAllOption()">
                     <input ngbButton type="radio" [value]="false"> Correlated
                 </label>
                 <label class="flat-button checkbox-push solid-grey" ngbButtonLabel>
@@ -42,7 +42,7 @@
         <div *ngIf="timeLineEventsData">
             <app-event-store-timeline [events]="timeLineEventsData" ></app-event-store-timeline>
         </div>
-
+        <br>
         <div *ngFor="let eventStoreData of listEventStoreData">
             <h2> {{eventStoreData.displayName}} </h2>
             <app-detail-list [list]="eventStoreData.eventsList.collection" 

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -19,7 +19,7 @@ export interface IEventStoreData {
     eventsList: EventListBase<any>;
     timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
     timelineData?: ITimelineData;
-    displayName : string;
+    displayName: string;
 }
 
 @Component({
@@ -85,7 +85,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         this.debouncerHandlerSubscription.unsubscribe();
     }
 
-    /*
+    /* TODO: Find out what does this function does
     public reset(): void {
         this.isResetEnabled = false;
         if (this.eventsList.resetDateWindow()) {
@@ -98,8 +98,8 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         }
     }
     */
-
-    private resetSelectionProperties(data : IEventStoreData): void {
+   
+    private resetSelectionProperties(data: IEventStoreData): void {
         this.startDate = data.eventsList.startDate;
         this.endDate = data.eventsList.endDate;
         this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
@@ -116,15 +116,15 @@ export class EventStoreComponent implements OnInit, OnDestroy {
     private setNewDateWindow(): void {
         let eventListChange = false;
 
-        for (let eventStoreData of this.listEventStoreData) {
-            if (eventStoreData.eventsList.setDateWindow(this.startDate, this.endDate)) {
-                this.resetSelectionProperties(eventStoreData);
+        for (const data of this.listEventStoreData) {
+            if (data.eventsList.setDateWindow(this.startDate, this.endDate)) {
+                this.resetSelectionProperties(data);
                 this.isResetEnabled = true;
-                eventStoreData.eventsList.reload().subscribe(data => {
+                data.eventsList.reload().subscribe(data => {
                     eventListChange = true;
                 });
             } else {
-                this.resetSelectionProperties(eventStoreData);
+                this.resetSelectionProperties(data);
             }
         }
 
@@ -142,11 +142,11 @@ export class EventStoreComponent implements OnInit, OnDestroy {
             this.timeLineEventsData.groups.add(group);
         });
 
-        this.timeLineEventsData.potentiallyMissingEvents = 
+        this.timeLineEventsData.potentiallyMissingEvents =
         this.timeLineEventsData.potentiallyMissingEvents || data.potentiallyMissingEvents;
     }
 
-    public clearCurrentData() : void{
+    public clearCurrentData(): void{
         this.timeLineEventsData = {
             start : this.startDate,
             end : this.endDate,
@@ -160,14 +160,14 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         let listRawEvents = [];
         let completedSubscriptions = 0;
 
-        for (let data of this.listEventStoreData) {
+        for (const data of this.listEventStoreData) {
             data.eventsList.ensureInitialized().subscribe(() => {
                 try {
                     if (this.pshowAllEvents) {
                         listRawEvents = listRawEvents.concat(data.eventsList.collection);
                         completedSubscriptions++;
 
-                        let receivedAllSubscriptions = (completedSubscriptions === this.listEventStoreData.length);
+                        const receivedAllSubscriptions = (completedSubscriptions === this.listEventStoreData.length);
 
                         if (receivedAllSubscriptions) {
                             listRawEvents = listRawEvents.map(event => event.raw);
@@ -178,7 +178,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
                                 end: this.endDate,
                                 items: d.items,
                                 groups: d.groups
-                            }
+                            };
                         }
                     } else if (data.timelineGenerator) {
                         const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -147,15 +147,8 @@ export class EventStoreComponent implements OnInit, OnDestroy {
                       rawEventlist = rawEventlist.concat(data.eventsList.collection.map(event => event.raw));
 
                   } else if (data.timelineGenerator) {
-                      const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
+                      data.timelineData = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
 
-                      data.timelineData = {
-                          groups: d.groups,
-                          items: d.items,
-                          start: this.startDate,
-                          end: this.endDate,
-                          potentiallyMissingEvents: d.potentiallyMissingEvents
-                      };
                       this.mergeTimelineData(combinedTimelineData, data.timelineData);
                   }
               } catch (e) {

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -98,7 +98,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         }
     }
     */
-   
+
     private resetSelectionProperties(data: IEventStoreData): void {
         this.startDate = data.eventsList.startDate;
         this.endDate = data.eventsList.endDate;
@@ -120,7 +120,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
             if (data.eventsList.setDateWindow(this.startDate, this.endDate)) {
                 this.resetSelectionProperties(data);
                 this.isResetEnabled = true;
-                data.eventsList.reload().subscribe(data => {
+                data.eventsList.reload().subscribe(d => {
                     eventListChange = true;
                 });
             } else {
@@ -152,10 +152,10 @@ export class EventStoreComponent implements OnInit, OnDestroy {
             end : this.endDate,
             groups : new DataSet<DataGroup>(),
             items : new DataSet<DataGroup>()
-        }
+        };
     }
 
-    public setTimelineData() : void{
+    public setTimelineData(): void{
         this.clearCurrentData();
         let listRawEvents = [];
         let completedSubscriptions = 0;

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -111,7 +111,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
           return data.eventsList.reload();
       });
 
-      if (subs) {
+      if (subs.length > 0) {
           forkJoin(subs).subscribe(() => this.setTimelineData());
       }
   }

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -135,12 +135,12 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   }
 
   public setTimelineData(): void {
-      let rawEventlist = [];
-      const combinedTimelineData = this.initializeTimelineData();
-
       const subs = this.listEventStoreData.map(data => data.eventsList.ensureInitialized());
 
       forkJoin(subs).subscribe(() => {
+          let rawEventlist = [];
+          const combinedTimelineData = this.initializeTimelineData();
+
           for (const data of this.listEventStoreData) {
               try {
                   if (this.pshowAllEvents) {

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -7,140 +7,197 @@ import { IOnDateChange } from '../double-slider/double-slider.component';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { DataService } from 'src/app/services/data.service';
+import { hostViewClassName } from '@angular/compiler';
+import { DataGroup, DataItem, DataSet } from 'vis-timeline/standalone/esm';
 
 export interface IQuickDates {
     display: string;
     hours: number;
 }
+
+export interface IEventStoreData {
+    eventsList: EventListBase<any>;
+    timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
+    timelineData?: ITimelineData;
+    displayName : string;
+}
+
 @Component({
-  selector: 'app-event-store',
-  templateUrl: './event-store.component.html',
-  styleUrls: ['./event-store.component.scss']
+    selector: 'app-event-store',
+    templateUrl: './event-store.component.html',
+    styleUrls: ['./event-store.component.scss']
 })
 export class EventStoreComponent implements OnInit, OnDestroy {
 
-  constructor(public dataService: DataService) { }
+    constructor(public dataService: DataService) { }
 
-  public get showAllEvents() { return this.pshowAllEvents; }
-  public set showAllEvents(state: boolean) {
-      this.pshowAllEvents = state;
-      this.setTimelineData();
-  }
+    public get showAllEvents() { return this.pshowAllEvents; }
+    public set showAllEvents(state: boolean) {
+        this.pshowAllEvents = state;
+        this.setTimelineData();
+    }
 
-  public static MaxWindowInDays = 7;
+    public static MaxWindowInDays = 7;
 
-  private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
-  private debouncerHandlerSubscription: Subscription;
+    private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
+    private debouncerHandlerSubscription: Subscription;
 
-  public quickDates = [
-    { display: '1 hours', hours: 1},
-    { display: '3 hours', hours: 3},
-    { display: '6 hours', hours: 6},
-    { display: '1 day', hours: 24},
-    { display: '7 days', hours: 168 }
-  ];
+    public quickDates = [
+        { display: '1 hours', hours: 1 },
+        { display: '3 hours', hours: 3 },
+        { display: '6 hours', hours: 6 },
+        { display: '1 day', hours: 24 },
+        { display: '7 days', hours: 168 }
+    ];
 
-  @Input() eventsList: EventListBase<any>;
-  @Input() timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
-  public startDateMin: Date;
-  public endDateMin: Date;
-  public startDateMax: Date;
-  public endDateMax: Date;
-  public endDateInit: Date;
-  public isResetEnabled = false;
-  public timeLineEventsData: ITimelineData;
+    @Input() listEventStoreData: IEventStoreData[];
+    @Input() eventsList: EventListBase<any>;
+    @Input() timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
+    public startDateMin: Date;
+    public endDateMin: Date;
+    public startDateMax: Date;
+    public endDateMax: Date;
+    public endDateInit: Date;
+    public isResetEnabled = false;
+    public timeLineEventsData: ITimelineData;
 
-  public transformText = 'Category,Kind';
+    public transformText = 'Category,Kind';
 
-  private pshowAllEvents = false;
+    private pshowAllEvents = false;
 
-  public startDate: Date;
-  public endDate: Date;
+    public startDate: Date;
+    public endDate: Date;
 
-  ngOnInit() {
-    this.pshowAllEvents = !this.timelineGenerator;
-    this.resetSelectionProperties();
-    this.setTimelineData();
-    this.debouncerHandlerSubscription = this.debounceHandler
-    .pipe(debounceTime(400), distinctUntilChanged())
-    .subscribe(dates => {
-        this.startDate = dates.startDate;
-        this.endDate = dates.endDate;
-        this.setNewDateWindow();
-     });
-  }
+    ngOnInit() {
+        this.pshowAllEvents = !this.listEventStoreData;
+        this.resetSelectionProperties(this.listEventStoreData[0]);
+        this.setTimelineData();
+        this.debouncerHandlerSubscription = this.debounceHandler
+            .pipe(debounceTime(400), distinctUntilChanged())
+            .subscribe(dates => {
+                this.startDate = dates.startDate;
+                this.endDate = dates.endDate;
+                this.setNewDateWindow();
+            });
+    }
 
-  ngOnDestroy() {
-      this.debouncerHandlerSubscription.unsubscribe();
-  }
+    ngOnDestroy() {
+        this.debouncerHandlerSubscription.unsubscribe();
+    }
 
-  public reset(): void {
-      this.isResetEnabled = false;
-      if (this.eventsList.resetDateWindow()) {
-          this.resetSelectionProperties();
-          this.eventsList.reload().subscribe( data => {
-              this.setTimelineData();
-          });
-      } else {
-          this.resetSelectionProperties();
-      }
-  }
-
-  private resetSelectionProperties(): void {
-      this.startDate = this.eventsList.startDate;
-      this.endDate = this.eventsList.endDate;
-      this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
-      this.startDateMax = this.endDateMax = new Date(); // Today
-  }
-
-  public setDate(date: IQuickDates) {
-      this.setNewDates({
-        endDate: new Date(this.eventsList.endDate),
-        startDate: TimeUtils.AddHours(this.endDate, -1 * date.hours)
-      });
-  }
-
-  private setNewDateWindow(): void {
-      if (this.eventsList.setDateWindow(this.startDate, this.endDate)) {
-          this.resetSelectionProperties();
-          this.isResetEnabled = true;
-          this.eventsList.reload().subscribe( data => {
-              this.setTimelineData();
-          });
-      } else {
-          this.resetSelectionProperties();
-      }
-  }
-
-  public setTimelineData(): void {
-    this.eventsList.ensureInitialized().subscribe( () => {
-        try {
-            if (this.pshowAllEvents) {
-                const d = parseEventsGenerically(this.eventsList.collection.map(event => event.raw), this.transformText);
-
-                this.timeLineEventsData = {
-                    groups: d.groups,
-                    items: d.items,
-                    start: this.startDate,
-                    end: this.endDate,
-                    potentiallyMissingEvents: d.potentiallyMissingEvents
-                };
-
-            }else if (this.timelineGenerator) {
-                const d = this.timelineGenerator.generateTimeLineData(this.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
-
-                this.timeLineEventsData = {
-                    groups: d.groups,
-                    items: d.items,
-                    start: this.startDate,
-                    end: this.endDate,
-                    potentiallyMissingEvents: d.potentiallyMissingEvents
-                };
-            }
-        }catch (e) {
-            console.error(e);
+    /*
+    public reset(): void {
+        this.isResetEnabled = false;
+        if (this.eventsList.resetDateWindow()) {
+            this.resetSelectionProperties();
+            this.eventsList.reload().subscribe( data => {
+                this.setTimelineData();
+            });
+        } else {
+            this.resetSelectionProperties();
         }
-    });
+    }
+    */
+
+    private resetSelectionProperties(data : IEventStoreData): void {
+        this.startDate = data.eventsList.startDate;
+        this.endDate = data.eventsList.endDate;
+        this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
+        this.startDateMax = this.endDateMax = new Date(); // Today
+    }
+
+    public setDate(date: IQuickDates) {
+        this.setNewDates({
+            endDate: new Date(this.listEventStoreData[0].eventsList.endDate),
+            startDate: TimeUtils.AddHours(this.endDate, -1 * date.hours)
+        });
+    }
+
+    private setNewDateWindow(): void {
+        let eventListChange = false;
+
+        for (let eventStoreData of this.listEventStoreData) {
+            if (eventStoreData.eventsList.setDateWindow(this.startDate, this.endDate)) {
+                this.resetSelectionProperties(eventStoreData);
+                this.isResetEnabled = true;
+                eventStoreData.eventsList.reload().subscribe(data => {
+                    eventListChange = true;
+                });
+            } else {
+                this.resetSelectionProperties(eventStoreData);
+            }
+        }
+
+        if (eventListChange) {
+            this.setTimelineData();
+        }
+    }
+
+    public mergeTimelineData(data: ITimelineData): void {
+        data.items.forEach(item => {
+            this.timeLineEventsData.items.add(item);
+        });
+
+        data.groups.forEach(group => {
+            this.timeLineEventsData.groups.add(group);
+        });
+
+        this.timeLineEventsData.potentiallyMissingEvents = 
+        this.timeLineEventsData.potentiallyMissingEvents || data.potentiallyMissingEvents;
+    }
+
+    public clearCurrentData() : void{
+        this.timeLineEventsData = {
+            start : this.startDate,
+            end : this.endDate,
+            groups : new DataSet<DataGroup>(),
+            items : new DataSet<DataGroup>()
+        }
+    }
+
+    public setTimelineData() : void{
+        this.clearCurrentData();
+        let listRawEvents = [];
+        let completedSubscriptions = 0;
+
+        for (let data of this.listEventStoreData) {
+            data.eventsList.ensureInitialized().subscribe(() => {
+                try {
+                    if (this.pshowAllEvents) {
+                        listRawEvents = listRawEvents.concat(data.eventsList.collection);
+                        completedSubscriptions++;
+
+                        let receivedAllSubscriptions = (completedSubscriptions === this.listEventStoreData.length);
+
+                        if (receivedAllSubscriptions) {
+                            listRawEvents = listRawEvents.map(event => event.raw);
+                            const d = parseEventsGenerically(listRawEvents, this.transformText);
+
+                            this.timeLineEventsData = {
+                                start: this.startDate,
+                                end: this.endDate,
+                                items: d.items,
+                                groups: d.groups
+                            }
+                        }
+                    } else if (data.timelineGenerator) {
+                        const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
+
+                        data.timelineData = {
+                            groups: d.groups,
+                            items: d.items,
+                            start: this.startDate,
+                            end: this.endDate,
+                            potentiallyMissingEvents: d.potentiallyMissingEvents
+                        };
+
+                        this.mergeTimelineData(data.timelineData);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            });
+        }
     }
 
     setNewDates(dates: IOnDateChange) {

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -29,174 +29,174 @@ export interface IEventStoreData {
 })
 export class EventStoreComponent implements OnInit, OnDestroy {
 
-    constructor(public dataService: DataService) { }
+  constructor(public dataService: DataService) { }
 
-    public get showAllEvents() { return this.pshowAllEvents; }
-    public set showAllEvents(state: boolean) {
-        this.pshowAllEvents = state;
-        this.setTimelineData();
-    }
+  public get showAllEvents() { return this.pshowAllEvents; }
+  public set showAllEvents(state: boolean) {
+      this.pshowAllEvents = state;
+      this.setTimelineData();
+  }
 
-    public static MaxWindowInDays = 7;
+  public static MaxWindowInDays = 7;
 
-    private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
-    private debouncerHandlerSubscription: Subscription;
+  private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
+  private debouncerHandlerSubscription: Subscription;
 
-    public quickDates = [
-        { display: '1 hours', hours: 1 },
-        { display: '3 hours', hours: 3 },
-        { display: '6 hours', hours: 6 },
-        { display: '1 day', hours: 24 },
-        { display: '7 days', hours: 168 }
-    ];
+  public quickDates = [
+      { display: '1 hours', hours: 1 },
+      { display: '3 hours', hours: 3 },
+      { display: '6 hours', hours: 6 },
+      { display: '1 day', hours: 24 },
+      { display: '7 days', hours: 168 }
+  ];
 
-    @Input() listEventStoreData: IEventStoreData[];
-    public startDateMin: Date;
-    public endDateMin: Date;
-    public startDateMax: Date;
-    public endDateMax: Date;
-    public endDateInit: Date;
-    public isResetEnabled = false;
-    public timeLineEventsData: ITimelineData;
+  @Input() listEventStoreData: IEventStoreData[];
+  public startDateMin: Date;
+  public endDateMin: Date;
+  public startDateMax: Date;
+  public endDateMax: Date;
+  public endDateInit: Date;
+  public isResetEnabled = false;
+  public timeLineEventsData: ITimelineData;
 
-    public transformText = 'Category,Kind';
+  public transformText = 'Category,Kind';
 
-    private pshowAllEvents = false;
+  private pshowAllEvents = false;
 
-    public startDate: Date;
-    public endDate: Date;
+  public startDate: Date;
+  public endDate: Date;
 
-    ngOnInit() {
-        this.pshowAllEvents = this.checkAllOption();
-        this.resetSelectionProperties();
-        this.setTimelineData();
-        this.debouncerHandlerSubscription = this.debounceHandler
-            .pipe(debounceTime(400), distinctUntilChanged())
-            .subscribe(dates => {
-                this.startDate = dates.startDate;
-                this.endDate = dates.endDate;
-                this.setNewDateWindow();
-            });
-    }
+  ngOnInit() {
+      this.pshowAllEvents = this.checkAllOption();
+      this.resetSelectionProperties();
+      this.setTimelineData();
+      this.debouncerHandlerSubscription = this.debounceHandler
+          .pipe(debounceTime(400), distinctUntilChanged())
+          .subscribe(dates => {
+              this.startDate = dates.startDate;
+              this.endDate = dates.endDate;
+              this.setNewDateWindow();
+          });
+  }
 
-    ngOnDestroy() {
-        this.debouncerHandlerSubscription.unsubscribe();
-    }
+  ngOnDestroy() {
+      this.debouncerHandlerSubscription.unsubscribe();
+  }
 
-    public checkAllOption(): boolean {
-        let onlyShowAll = false;
-        for (const data of this.listEventStoreData) {
-            if (!data.timelineGenerator) {
-                onlyShowAll = true;
-            }
-        }
-        return onlyShowAll;
-    }
+  public checkAllOption(): boolean {
+      let onlyShowAll = false;
+      for (const data of this.listEventStoreData) {
+          if (!data.timelineGenerator) {
+              onlyShowAll = true;
+          }
+      }
+      return onlyShowAll;
+  }
 
-    private resetSelectionProperties(): void {
-        this.startDate = this.listEventStoreData[0].eventsList.startDate;
-        this.endDate = this.listEventStoreData[0].eventsList.endDate;
-        this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
-        this.startDateMax = this.endDateMax = new Date(); // Today
-    }
+  private resetSelectionProperties(): void {
+      this.startDate = this.listEventStoreData[0].eventsList.startDate;
+      this.endDate = this.listEventStoreData[0].eventsList.endDate;
+      this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
+      this.startDateMax = this.endDateMax = new Date(); // Today
+  }
 
-    public setDate(date: IQuickDates) {
-        this.setNewDates({
-            endDate: new Date(this.listEventStoreData[0].eventsList.endDate),
-            startDate: TimeUtils.AddHours(this.endDate, -1 * date.hours)
-        });
-    }
+  public setDate(date: IQuickDates) {
+      this.setNewDates({
+          endDate: new Date(this.listEventStoreData[0].eventsList.endDate),
+          startDate: TimeUtils.AddHours(this.endDate, -1 * date.hours)
+      });
+  }
 
-    private setNewDateWindow(): void {
-        let eventListChange = false;
+  private setNewDateWindow(): void {
+      let eventListChange = false;
 
-        for (const data of this.listEventStoreData) {
-            if (data.eventsList.setDateWindow(this.startDate, this.endDate)) {
-                this.resetSelectionProperties();
-                this.isResetEnabled = true;
-                data.eventsList.reload().subscribe(d => {
-                    eventListChange = true;
-                });
-            } else {
-                this.resetSelectionProperties();
-            }
-        }
+      for (const data of this.listEventStoreData) {
+          if (data.eventsList.setDateWindow(this.startDate, this.endDate)) {
+              this.resetSelectionProperties();
+              this.isResetEnabled = true;
+              data.eventsList.reload().subscribe(d => {
+                  eventListChange = true;
+              });
+          } else {
+              this.resetSelectionProperties();
+          }
+      }
 
-        if (eventListChange) {
-            this.setTimelineData();
-        }
-    }
+      if (eventListChange) {
+          this.setTimelineData();
+      }
+  }
 
-    public mergeTimelineData(combinedData: ITimelineData, data: ITimelineData): void {
-        data.items.forEach(item => {
-            combinedData.items.add(item);
-        });
+  public mergeTimelineData(combinedData: ITimelineData, data: ITimelineData): void {
+      data.items.forEach(item => {
+          combinedData.items.add(item);
+      });
 
-        data.groups.forEach(group => {
-            combinedData.groups.add(group);
-        });
+      data.groups.forEach(group => {
+          combinedData.groups.add(group);
+      });
 
-        combinedData.potentiallyMissingEvents =
-            combinedData.potentiallyMissingEvents || data.potentiallyMissingEvents;
-    }
+      combinedData.potentiallyMissingEvents =
+          combinedData.potentiallyMissingEvents || data.potentiallyMissingEvents;
+  }
 
-    private initializeTimelineData(): ITimelineData {
-        return {
-            start: this.startDate,
-            end: this.endDate,
-            groups: new DataSet<DataGroup>(),
-            items: new DataSet<DataItem>()
-        };
-    }
+  private initializeTimelineData(): ITimelineData {
+      return {
+          start: this.startDate,
+          end: this.endDate,
+          groups: new DataSet<DataGroup>(),
+          items: new DataSet<DataItem>()
+      };
+  }
 
-    public setTimelineData(): void {
-        let rawEventlist = [];
-        const combinedTimelineData = this.initializeTimelineData();
+  public setTimelineData(): void {
+      let rawEventlist = [];
+      const combinedTimelineData = this.initializeTimelineData();
 
-        const subs = this.listEventStoreData.map((data) => {
-            return data.eventsList.ensureInitialized();
-        });
+      const subs = this.listEventStoreData.map((data) => {
+          return data.eventsList.ensureInitialized();
+      });
 
-        forkJoin(subs).pipe(finalize(() => {
-            for (const data of this.listEventStoreData) {
-                try {
-                    if (this.pshowAllEvents) {
-                        rawEventlist = rawEventlist.concat(data.eventsList.collection.map(event => event.raw));
+      forkJoin(subs).pipe(finalize(() => {
+          for (const data of this.listEventStoreData) {
+              try {
+                  if (this.pshowAllEvents) {
+                      rawEventlist = rawEventlist.concat(data.eventsList.collection.map(event => event.raw));
 
-                    } else if (data.timelineGenerator) {
-                        const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
+                  } else if (data.timelineGenerator) {
+                      const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
 
-                        data.timelineData = {
-                            groups: d.groups,
-                            items: d.items,
-                            start: this.startDate,
-                            end: this.endDate,
-                            potentiallyMissingEvents: d.potentiallyMissingEvents
-                        };
-                        this.mergeTimelineData(combinedTimelineData, data.timelineData);
-                    }
-                } catch (e) {
-                    console.error(e);
-                }
-            }
+                      data.timelineData = {
+                          groups: d.groups,
+                          items: d.items,
+                          start: this.startDate,
+                          end: this.endDate,
+                          potentiallyMissingEvents: d.potentiallyMissingEvents
+                      };
+                      this.mergeTimelineData(combinedTimelineData, data.timelineData);
+                  }
+              } catch (e) {
+                  console.error(e);
+              }
+          }
 
-            if (this.pshowAllEvents) {
-                const d = parseEventsGenerically(rawEventlist, this.transformText);
+          if (this.pshowAllEvents) {
+              const d = parseEventsGenerically(rawEventlist, this.transformText);
 
-                this.timeLineEventsData = {
-                    start: this.startDate,
-                    end: this.endDate,
-                    items: d.items,
-                    groups: d.groups
-                };
-            }
-            else {
-                this.timeLineEventsData = combinedTimelineData;
-            }
-        })).subscribe();
-    }
+              this.timeLineEventsData = {
+                  start: this.startDate,
+                  end: this.endDate,
+                  items: d.items,
+                  groups: d.groups
+              };
+          }
+          else {
+              this.timeLineEventsData = combinedTimelineData;
+          }
+      })).subscribe();
+  }
 
-    setNewDates(dates: IOnDateChange) {
-        this.debounceHandler.next(dates);
-    }
+  setNewDates(dates: IOnDateChange) {
+      this.debounceHandler.next(dates);
+  }
 }

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -4,8 +4,8 @@ import { EventListBase } from 'src/app/Models/DataModels/collections/Collections
 import { FabricEventBase } from 'src/app/Models/eventstore/Events';
 import { TimeUtils } from 'src/app/Utils/TimeUtils';
 import { IOnDateChange } from '../double-slider/double-slider.component';
-import { Subject, Subscription } from 'rxjs';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { Subject, Subscription, forkJoin } from 'rxjs';
+import { debounceTime, distinctUntilChanged, finalize } from 'rxjs/operators';
 import { DataService } from 'src/app/services/data.service';
 import { hostViewClassName } from '@angular/compiler';
 import { DataGroup, DataItem, DataSet } from 'vis-timeline/standalone/esm';
@@ -17,7 +17,7 @@ export interface IQuickDates {
 
 export interface IEventStoreData {
     eventsList: EventListBase<any>;
-    timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
+    timelineGenerator?: TimeLineGeneratorBase<FabricEventBase>;
     timelineData?: ITimelineData;
     displayName: string;
 }
@@ -51,8 +51,6 @@ export class EventStoreComponent implements OnInit, OnDestroy {
     ];
 
     @Input() listEventStoreData: IEventStoreData[];
-    @Input() eventsList: EventListBase<any>;
-    @Input() timelineGenerator: TimeLineGeneratorBase<FabricEventBase>;
     public startDateMin: Date;
     public endDateMin: Date;
     public startDateMax: Date;
@@ -69,8 +67,8 @@ export class EventStoreComponent implements OnInit, OnDestroy {
     public endDate: Date;
 
     ngOnInit() {
-        this.pshowAllEvents = !this.listEventStoreData;
-        this.resetSelectionProperties(this.listEventStoreData[0]);
+        this.pshowAllEvents = this.checkAllOption();
+        this.resetSelectionProperties();
         this.setTimelineData();
         this.debouncerHandlerSubscription = this.debounceHandler
             .pipe(debounceTime(400), distinctUntilChanged())
@@ -85,23 +83,19 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         this.debouncerHandlerSubscription.unsubscribe();
     }
 
-    /* TODO: Find out what does this function does
-    public reset(): void {
-        this.isResetEnabled = false;
-        if (this.eventsList.resetDateWindow()) {
-            this.resetSelectionProperties();
-            this.eventsList.reload().subscribe( data => {
-                this.setTimelineData();
-            });
-        } else {
-            this.resetSelectionProperties();
+    public checkAllOption(): boolean {
+        let onlyShowAll = false;
+        for (const data of this.listEventStoreData) {
+            if (!data.timelineGenerator) {
+                onlyShowAll = true;
+            }
         }
+        return onlyShowAll;
     }
-    */
 
-    private resetSelectionProperties(data: IEventStoreData): void {
-        this.startDate = data.eventsList.startDate;
-        this.endDate = data.eventsList.endDate;
+    private resetSelectionProperties(): void {
+        this.startDate = this.listEventStoreData[0].eventsList.startDate;
+        this.endDate = this.listEventStoreData[0].eventsList.endDate;
         this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
         this.startDateMax = this.endDateMax = new Date(); // Today
     }
@@ -118,13 +112,13 @@ export class EventStoreComponent implements OnInit, OnDestroy {
 
         for (const data of this.listEventStoreData) {
             if (data.eventsList.setDateWindow(this.startDate, this.endDate)) {
-                this.resetSelectionProperties(data);
+                this.resetSelectionProperties();
                 this.isResetEnabled = true;
                 data.eventsList.reload().subscribe(d => {
                     eventListChange = true;
                 });
             } else {
-                this.resetSelectionProperties(data);
+                this.resetSelectionProperties();
             }
         }
 
@@ -133,53 +127,42 @@ export class EventStoreComponent implements OnInit, OnDestroy {
         }
     }
 
-    public mergeTimelineData(data: ITimelineData): void {
+    public mergeTimelineData(combinedData: ITimelineData, data: ITimelineData): void {
         data.items.forEach(item => {
-            this.timeLineEventsData.items.add(item);
+            combinedData.items.add(item);
         });
 
         data.groups.forEach(group => {
-            this.timeLineEventsData.groups.add(group);
+            combinedData.groups.add(group);
         });
 
-        this.timeLineEventsData.potentiallyMissingEvents =
-        this.timeLineEventsData.potentiallyMissingEvents || data.potentiallyMissingEvents;
+        combinedData.potentiallyMissingEvents =
+            combinedData.potentiallyMissingEvents || data.potentiallyMissingEvents;
     }
 
-    public clearCurrentData(): void{
-        this.timeLineEventsData = {
-            start : this.startDate,
-            end : this.endDate,
-            groups : new DataSet<DataGroup>(),
-            items : new DataSet<DataGroup>()
+    private initializeTimelineData(): ITimelineData {
+        return {
+            start: this.startDate,
+            end: this.endDate,
+            groups: new DataSet<DataGroup>(),
+            items: new DataSet<DataItem>()
         };
     }
 
-    public setTimelineData(): void{
-        this.clearCurrentData();
-        let listRawEvents = [];
-        let completedSubscriptions = 0;
+    public setTimelineData(): void {
+        let rawEventlist = [];
+        const combinedTimelineData = this.initializeTimelineData();
 
-        for (const data of this.listEventStoreData) {
-            data.eventsList.ensureInitialized().subscribe(() => {
+        const subs = this.listEventStoreData.map((data) => {
+            return data.eventsList.ensureInitialized();
+        });
+
+        forkJoin(subs).pipe(finalize(() => {
+            for (const data of this.listEventStoreData) {
                 try {
                     if (this.pshowAllEvents) {
-                        listRawEvents = listRawEvents.concat(data.eventsList.collection);
-                        completedSubscriptions++;
+                        rawEventlist = rawEventlist.concat(data.eventsList.collection.map(event => event.raw));
 
-                        const receivedAllSubscriptions = (completedSubscriptions === this.listEventStoreData.length);
-
-                        if (receivedAllSubscriptions) {
-                            listRawEvents = listRawEvents.map(event => event.raw);
-                            const d = parseEventsGenerically(listRawEvents, this.transformText);
-
-                            this.timeLineEventsData = {
-                                start: this.startDate,
-                                end: this.endDate,
-                                items: d.items,
-                                groups: d.groups
-                            };
-                        }
                     } else if (data.timelineGenerator) {
                         const d = data.timelineGenerator.generateTimeLineData(data.eventsList.collection.map(event => event.raw), this.startDate, this.endDate);
 
@@ -190,14 +173,27 @@ export class EventStoreComponent implements OnInit, OnDestroy {
                             end: this.endDate,
                             potentiallyMissingEvents: d.potentiallyMissingEvents
                         };
-
-                        this.mergeTimelineData(data.timelineData);
+                        this.mergeTimelineData(combinedTimelineData, data.timelineData);
                     }
                 } catch (e) {
                     console.error(e);
                 }
-            });
-        }
+            }
+
+            if (this.pshowAllEvents) {
+                const d = parseEventsGenerically(rawEventlist, this.transformText);
+
+                this.timeLineEventsData = {
+                    start: this.startDate,
+                    end: this.endDate,
+                    items: d.items,
+                    groups: d.groups
+                };
+            }
+            else {
+                this.timeLineEventsData = combinedTimelineData;
+            }
+        })).subscribe();
     }
 
     setNewDates(dates: IOnDateChange) {

--- a/src/SfxWeb/src/app/views/application/events/events.component.html
+++ b/src/SfxWeb/src/app/views/application/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="appEvents" [timelineGenerator]="timelineGenerator"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/application/events/events.component.html
+++ b/src/SfxWeb/src/app/views/application/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/application/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/application/events/events.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ApplicationBaseControllerDirective } from '../applicationBase';
 import { DataService } from 'src/app/services/data.service';
-import { ApplicationEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { ApplicationTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -11,17 +11,19 @@ import { ApplicationTimelineGenerator } from 'src/app/Models/eventstore/timeline
 })
 export class EventsComponent extends ApplicationBaseControllerDirective {
 
-  timelineGenerator: ApplicationTimelineGenerator;
-  appEvents: ApplicationEventList;
+  listEventStoreData: IEventStoreData [];
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);
   }
 
   setup() {
-    this.appEvents = this.data.createApplicationEventList(this.appId);
-    this.timelineGenerator = new ApplicationTimelineGenerator();
+    this.listEventStoreData = [
+      { eventsList : this.data.createApplicationEventList(this.appId),
+        timelineGenerator: new ApplicationTimelineGenerator(),
+        displayName : 'Application: ' + this.appId
+      }
+    ];
   }
-
 
 }

--- a/src/SfxWeb/src/app/views/applications/events/events.component.html
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="appEvents"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/applications/events/events.component.html
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/applications/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { ApplicationEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { DataService } from 'src/app/services/data.service';
 import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 import { IResponseMessageHandler, EventsStoreResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
 import { Observable } from 'rxjs';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -12,17 +12,20 @@ import { Observable } from 'rxjs';
 })
 export class EventsComponent extends BaseControllerDirective {
 
-  appEvents: ApplicationEventList;
+  listEventStoreData: IEventStoreData [];
 
   constructor(private data: DataService, injector: Injector) {
     super(injector);
    }
 
    setup() {
-    this.appEvents = this.data.createApplicationEventList(null);
+    this.listEventStoreData = [{
+      eventsList: this.data.createApplicationEventList(null),
+      displayName: 'Applications'
+    }];
    }
 
    refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
-    return this.appEvents.refresh(new EventsStoreResponseMessageHandler(messageHandler));
+    return this.listEventStoreData[0].eventsList.refresh(new EventsStoreResponseMessageHandler(messageHandler));
   }
 }

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.html
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.html
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="clusterEvents" [timelineGenerator]="clusterTimelineGenerator"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { ClusterEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { ClusterTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
 import { DataService } from 'src/app/services/data.service';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,14 +10,16 @@ import { DataService } from 'src/app/services/data.service';
 })
 export class EventsComponent implements OnInit {
 
-  clusterEvents: ClusterEventList;
-  clusterTimelineGenerator: ClusterTimelineGenerator;
+  listEventStoreData: IEventStoreData [];
 
   constructor(public data: DataService) { }
 
   ngOnInit() {
-    this.clusterEvents = this.data.createClusterEventList();
-    this.clusterTimelineGenerator = new ClusterTimelineGenerator();
+    this.listEventStoreData = [{
+      eventsList: this.data.createClusterEventList(),
+      timelineGenerator: new ClusterTimelineGenerator(),
+      displayName: 'Nodes'
+    }];
   }
 
 }

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -18,7 +18,7 @@ export class EventsComponent implements OnInit {
     this.listEventStoreData = [{
       eventsList: this.data.createClusterEventList(),
       timelineGenerator: new ClusterTimelineGenerator(),
-      displayName: 'Nodes'
+      displayName: 'Cluster'
     }];
   }
 

--- a/src/SfxWeb/src/app/views/combined-events/combined-events.module.ts
+++ b/src/SfxWeb/src/app/views/combined-events/combined-events.module.ts
@@ -5,13 +5,19 @@ import { CombinedEventsRoutingModule } from './combined-events-routing.module';
 import { BaseComponent } from './base/base.component';
 import { EventsComponent } from './events/events.component';
 import { SharedModule } from 'src/app/shared/shared.module';
+import { DetailListTemplatesModule } from 'src/app/modules/detail-list-templates/detail-list-templates.module';
+import { EventStoreModule } from 'src/app/modules/event-store/event-store.module';
+import { ChartsModule } from 'src/app/modules/charts/charts.module';
 
 @NgModule({
   declarations: [BaseComponent, EventsComponent],
   imports: [
     CommonModule,
     CombinedEventsRoutingModule,
-    SharedModule
+    SharedModule,
+    DetailListTemplatesModule,
+    EventStoreModule,
+    ChartsModule
   ]
 })
 export class CombinedEventsModule { }

--- a/src/SfxWeb/src/app/views/combined-events/events/events.component.html
+++ b/src/SfxWeb/src/app/views/combined-events/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/combined-events/events/events.component.html
+++ b/src/SfxWeb/src/app/views/combined-events/events/events.component.html
@@ -1,1 +1,3 @@
-<p>events works!</p>
+<div>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+</div>

--- a/src/SfxWeb/src/app/views/combined-events/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/combined-events/events/events.component.ts
@@ -10,19 +10,19 @@ import { DataService } from 'src/app/services/data.service';
 })
 export class EventsComponent implements OnInit {
 
-  listEventStoreData : IEventStoreData [];
+  listEventStoreData: IEventStoreData [];
 
-  constructor(public data : DataService) { }
+  constructor(public data: DataService) { }
 
   ngOnInit(): void {
     this.listEventStoreData = [
-      { eventsList : this.data.createClusterEventList(), 
+      { eventsList : this.data.createClusterEventList(),
         timelineGenerator: new ClusterTimelineGenerator(),
-        displayName : "Clusters"
+        displayName : 'Clusters'
       },
-      { eventsList : this.data.createNodeEventList(null), 
+      { eventsList : this.data.createNodeEventList(null),
         timelineGenerator : new NodeTimelineGenerator(),
-        displayName : "Nodes"
+        displayName : 'Nodes'
       }
     ];
   }

--- a/src/SfxWeb/src/app/views/combined-events/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/combined-events/events/events.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { ClusterTimelineGenerator, NodeTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
+import { DataService } from 'src/app/services/data.service';
 
 @Component({
   selector: 'app-events',
@@ -7,9 +10,21 @@ import { Component, OnInit } from '@angular/core';
 })
 export class EventsComponent implements OnInit {
 
-  constructor() { }
+  listEventStoreData : IEventStoreData [];
+
+  constructor(public data : DataService) { }
 
   ngOnInit(): void {
+    this.listEventStoreData = [
+      { eventsList : this.data.createClusterEventList(), 
+        timelineGenerator: new ClusterTimelineGenerator(),
+        displayName : "Clusters"
+      },
+      { eventsList : this.data.createNodeEventList(null), 
+        timelineGenerator : new NodeTimelineGenerator(),
+        displayName : "Nodes"
+      }
+    ];
   }
 
 }

--- a/src/SfxWeb/src/app/views/node/events/events.component.html
+++ b/src/SfxWeb/src/app/views/node/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/node/events/events.component.html
+++ b/src/SfxWeb/src/app/views/node/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="nodeEvents" [timelineGenerator]="nodeEventTimelineGenerator"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/node/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/node/events/events.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Injector } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { NodeBaseControllerDirective } from '../NodeBase';
 import { NodeTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
-import { NodeEventList } from 'src/app/Models/DataModels/collections/Collections';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,16 +10,19 @@ import { NodeEventList } from 'src/app/Models/DataModels/collections/Collections
   styleUrls: ['./events.component.scss']
 })
 export class EventsComponent extends NodeBaseControllerDirective {
-  nodeEvents: NodeEventList;
-  nodeEventTimelineGenerator: NodeTimelineGenerator;
+
+  listEventStoreData: IEventStoreData [];
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);
   }
 
   setup() {
-    this.nodeEvents = this.data.createNodeEventList(this.nodeName);
-    this.nodeEventTimelineGenerator = new NodeTimelineGenerator();
+    this.listEventStoreData = [{
+      eventsList: this.data.createNodeEventList(this.nodeName),
+      timelineGenerator: new NodeTimelineGenerator(),
+      displayName: 'Node: ' + this.nodeName
+    }];
   }
 
 }

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.html
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.html
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="nodeEvents" [timelineGenerator]="nodeEventTimelineGenerator"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NodeTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
-import { NodeEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { DataService } from 'src/app/services/data.service';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,14 +10,16 @@ import { DataService } from 'src/app/services/data.service';
 })
 export class EventsComponent implements OnInit {
 
-  nodeEvents: NodeEventList;
-  nodeEventTimelineGenerator: NodeTimelineGenerator;
+  listEventStoreData: IEventStoreData [];
 
   constructor(public data: DataService) { }
 
   ngOnInit() {
-      this.nodeEvents = this.data.createNodeEventList(null);
-      this.nodeEventTimelineGenerator = new NodeTimelineGenerator();
+    this.listEventStoreData = [{
+      eventsList: this.data.createNodeEventList(null),
+      timelineGenerator: new NodeTimelineGenerator(),
+      displayName: 'Nodes'
+    }];
   }
 
 }

--- a/src/SfxWeb/src/app/views/partition/events/events.component.html
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/partition/events/events.component.html
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="partitionEvents" [timelineGenerator]="partitionTimeLineGenerator"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/partition/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { PartitionBaseControllerDirective } from '../PartitionBase';
 import { DataService } from 'src/app/services/data.service';
-import { PartitionEventList } from 'src/app/Models/DataModels/collections/Collections';
 import { PartitionTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,15 +10,19 @@ import { PartitionTimelineGenerator } from 'src/app/Models/eventstore/timelineGe
   styleUrls: ['./events.component.scss']
 })
 export class EventsComponent extends PartitionBaseControllerDirective {
-  partitionEvents: PartitionEventList;
-  partitionTimeLineGenerator: PartitionTimelineGenerator;
+
+  listEventStoreData: IEventStoreData [];
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);
   }
 
   setup() {
-    this.partitionEvents = this.data.createPartitionEventList(this.partitionId);
-    this.partitionTimeLineGenerator = new PartitionTimelineGenerator();
+    this.listEventStoreData = [{
+      eventsList: this.data.createPartitionEventList(this.partitionId),
+      timelineGenerator: new PartitionTimelineGenerator(),
+      displayName: 'Partition: ' + this.partitionId
+    }];
   }
+
 }

--- a/src/SfxWeb/src/app/views/replica/events/events.component.html
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/replica/events/events.component.html
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="replicaEvents" ></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/replica/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { DataService } from 'src/app/services/data.service';
-import { ReplicaEventList } from 'src/app/Models/DataModels/collections/Collections';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,14 +10,17 @@ import { ReplicaEventList } from 'src/app/Models/DataModels/collections/Collecti
 })
 export class EventsComponent extends ReplicaBaseControllerDirective {
 
-  replicaEvents: ReplicaEventList;
+  listEventStoreData: IEventStoreData [];
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);
   }
 
   setup() {
-    this.replicaEvents = this.data.createReplicaEventList(this.partitionId, this.replicaId);
+    this.listEventStoreData = [{
+      eventsList: this.data.createReplicaEventList(this.partitionId, this.replicaId),
+      displayName: 'Replica: ' + this.replicaId
+    }];
   }
 
 }

--- a/src/SfxWeb/src/app/views/service/events/events.component.html
+++ b/src/SfxWeb/src/app/views/service/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/service/events/events.component.html
+++ b/src/SfxWeb/src/app/views/service/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [eventsList]="serviceEvents"></app-event-store>
+    <app-event-store [listEventStoreData] = "listEventStoreData"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/service/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/service/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Injector } from '@angular/core';
 import { ServiceBaseControllerDirective } from '../ServiceBase';
 import { DataService } from 'src/app/services/data.service';
-import { ServiceEventList } from 'src/app/Models/DataModels/collections/Collections';
+import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
 
 @Component({
   selector: 'app-events',
@@ -10,14 +10,17 @@ import { ServiceEventList } from 'src/app/Models/DataModels/collections/Collecti
 })
 export class EventsComponent extends ServiceBaseControllerDirective {
 
-  serviceEvents: ServiceEventList;
+  listEventStoreData: IEventStoreData [];
 
   constructor(protected data: DataService, injector: Injector) {
     super(data, injector);
   }
 
   setup() {
-    this.serviceEvents = this.data.createServiceEventList(this.serviceId);
+    this.listEventStoreData = [{
+      eventsList: this.data.createServiceEventList(this.serviceId),
+      displayName: 'Service: ' + this.serviceId
+    }];
   }
 
 }


### PR DESCRIPTION
# Event Store modification to use it with multiple elements of SFX
(NOTE) Currently this version of combined-events only works for Cluster and Nodes events.

The main objective of this PR is to add the necessary changes to make the event-store component compatible with working with a collection of elements, instead of the current approach that is fixed for just one element.

The IEventStoreData interface is introduced to collect all the necessary information for each element to be displayed in the event-store. Each instance of the interface contains:
- The EventList associated to its type (Node, Cluster, etc).
- Its own TimelineGenerator.
- An ITimeLineData object to save its information for the timeline.
- A displayName (string) that is used to show its name on the template.

The main changes were applied to the logic of the event-store component. The biggest change was that, since we are working with a collection of elements, we would be working with a collection of ITimeLineData to display and a collection of Observables.
The collection of the timeline data is fixed by creating a merging function to join all of the events and groups in a single instance that is later bound to display. While the Observables issue is solved by using a RxJS operator ( forkJoin ).

For each component of every element in SFX (Application, Node, Replica, etc) the applied changes were the same. What was done is the following:
- The IEventStoreData interface is imported.
- All of the references for the current TimelineGenerator and EventList aredeleted.
- The previously mentioned are replaced by an instance of IEventStoreData.
- This instance is placed in an array that is bound to the event-store component in the template.

## Photos:

![sfx1](https://user-images.githubusercontent.com/26049483/121265022-bd759900-c87d-11eb-8959-dff5b3071847.PNG)

![sfx2](https://user-images.githubusercontent.com/26049483/121265101-dc742b00-c87d-11eb-9ba0-54ea4b622c92.PNG)



