### PR TITLE
Changes to RepairTask component

### DIFF
--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
-import { ListColumnSetting, ListSettings, ListColumnSettingForBadge, ListColumnSettingForLink, ListColumnSettingWithCopyText, ListColumnSettingWithUtcTime } from '../Models/ListSettings';
+import { ListColumnSetting, ListSettings, ListColumnSettingForBadge, ListColumnSettingForLink, ListColumnSettingWithCopyText, ListColumnSettingWithUtcTime, ListColumnSettingWithCustomComponent } from '../Models/ListSettings';
 import { NodeStatusConstants, Constants } from '../Common/Constants';
 import { ClusterLoadInformation } from '../Models/DataModels/Cluster';
 import { NodeLoadInformation } from '../Models/DataModels/Node';
 import { MetricsViewModel } from '../ViewModels/MetricsViewModel';
 import { StorageService } from './storage.service';
+import { RepairTaskViewComponent } from '../views/cluster/repair-task-view/repair-task-view.component';
 
 @Injectable({
   providedIn: 'root'
@@ -151,6 +152,60 @@ export class SettingsService {
 
     return this.getNewOrExistingListSettings(listKey, [], settings);
 
+  }
+
+  public getNewOrExistingPendingRepairTaskListSettings(listKey: string = 'pendingRepair'){
+    return this.getNewOrExistingListSettings(listKey, ['raw.History.CreatedUtcTimestamp'],
+    [
+        new ListColumnSetting('raw.TaskId', 'Task Id'),
+        new ListColumnSetting('raw.Action', 'Action', {enableFilter: true}),
+        new ListColumnSetting('raw.Target.NodeNames', 'Target'),
+        new ListColumnSetting('impactedNodes', 'Impact'),
+        new ListColumnSetting('raw.State', 'State', {enableFilter: true}),
+        new ListColumnSettingWithUtcTime('raw.History.CreatedUtcTimestamp', 'Created At'),
+        new ListColumnSetting('displayDuration', 'Duration', {
+            sortPropertyPaths: ['duration']
+        }),
+    ],
+    [
+        new ListColumnSettingWithCustomComponent(RepairTaskViewComponent,
+        '',
+        '',
+        {
+            enableFilter: false,
+            colspan: -1
+        })
+    ],
+    true,
+    (item) => (Object.keys(item).length > 0),
+    true);
+  }
+
+  public getNewOrExistingCompletedRepairTaskListSettings(listKey: string = 'completedRepair'){
+    return this.getNewOrExistingListSettings(listKey, ['raw.History.CreatedUtcTimestamp'],
+    [
+        new ListColumnSetting('raw.TaskId', 'Task Id'),
+        new ListColumnSetting('raw.Action', 'Action', {enableFilter: true}),
+        new ListColumnSetting('raw.Target.NodeNames', 'Target'),
+        new ListColumnSetting('impactedNodes', 'Impact'),
+        new ListColumnSetting('raw.ResultStatus', 'Result Status', {enableFilter: true}),
+        new ListColumnSettingWithUtcTime('raw.History.CreatedUtcTimestamp', 'Created At'),
+        new ListColumnSetting('displayDuration', 'Duration', {
+            sortPropertyPaths: ['duration']
+        }),
+    ],
+    [
+        new ListColumnSettingWithCustomComponent(RepairTaskViewComponent,
+        '',
+        '',
+        {
+            enableFilter: false,
+            colspan: -1
+        })
+    ],
+    true,
+    (item) => true,
+    true);
   }
 
   // Update all existing list settings to use new limit

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.spec.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.spec.ts
@@ -18,7 +18,6 @@ describe('RepairTasksComponent', () => {
   let component: RepairTasksComponent;
   let fixture: ComponentFixture<RepairTasksComponent>;
 
-  let settingsStub: Partial<SettingsService>;
   let dataServiceStub: Partial<DataService>;
   const task = {
     Scope: {
@@ -65,20 +64,6 @@ describe('RepairTasksComponent', () => {
   };
 
   beforeEach(waitForAsync(() => {
-
-    settingsStub = {
-        getNewOrExistingListSettings(
-        listName: string,
-        defaultSortProperties: string[] = [],
-        columnSettings: ListColumnSetting[] = [],
-        secondRowColumnSettings: ListColumnSetting[] = [],
-        secondRowCollapsible: boolean = false,
-        showSecondRow: (item) => boolean = (item) => true,
-        searchable: boolean = true) {
-
-        return new ListSettings(this.paginationLimit, defaultSortProperties, columnSettings, secondRowColumnSettings, secondRowCollapsible, showSecondRow, searchable);
-      }
-    };
 
     dataServiceStub = { };
     dataServiceStub.restClient = ({
@@ -135,7 +120,7 @@ describe('RepairTasksComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [ RepairTasksComponent ],
-      providers: [{provide: SettingsService, useValue: settingsStub },
+      providers: [SettingsService,
                   {provide: DataService, useValue: dataServiceStub },
                   RefreshService],
       imports: [RouterTestingModule, NgbNavModule]


### PR DESCRIPTION
## Objective
The main goal of this update is to decouple some of the functionalities of the RepairTask component to make it easier to use RepairTasks on other timelines or detail lists.
## Previous version
On this version the necessary functions used to create TimelineData and the ListSettings were inside the RepairTask component. This made it harder to be portable to any other place in SFX, since it would require to copy the same code on each instance where we would need it.
## New version
On this newer version we decouple the TimelineData creation by introducing its own TimelineGenerator function so it resembles the structure used by other SF events that are used on specific timelines.

Also, the logic for creating each ListSetting for the tasks (Pending and Completed) was moved to the SettingsService so that any component that injects it can get this list settings without having to implement them itself.



