### PR TITLE
Handling failed load

### DIFF
--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -88,11 +88,14 @@
                     </ng-container>
 
                     </ng-container>
-                    <tr *ngIf="isLoading">
+                    <tr *ngIf="isLoading && successfulLoad">
                         <td [attr.colspan]="listSettings.columnSettings.length">Loading...</td>
                     </tr>
-                    <tr *ngIf="sortedFilteredList.length === 0 && !list && !isLoading">
+                    <tr *ngIf="sortedFilteredList.length === 0 && !list && !isLoading && successfulLoad">
                         <td [attr.colspan]="listSettings.columnSettings.length">No items to display.</td>
+                    </tr>
+                    <tr *ngIf="!successfulLoad">
+                        <td [attr.colspan]="listSettings.columnSettings.length">Error: The list of events has failed to load.</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.html
@@ -95,7 +95,7 @@
                         <td [attr.colspan]="listSettings.columnSettings.length">No items to display.</td>
                     </tr>
                     <tr *ngIf="!successfulLoad">
-                        <td [attr.colspan]="listSettings.columnSettings.length">Error: The list of events has failed to load.</td>
+                        <td [attr.colspan]="listSettings.columnSettings.length">Items failed to load.</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -34,7 +34,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   @Input() listSettings: ListSettings;
   @Input() searchText = 'Search list';
   @Input() isLoading = false;
-  @Input() successfulLoad = false;
+  @Input() successfulLoad = true;
   @Output() sorted = new EventEmitter<any[]>();
   @Output() sortOrdering = new EventEmitter<ISortOrdering>();
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -34,6 +34,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   @Input() listSettings: ListSettings;
   @Input() searchText = 'Search list';
   @Input() isLoading = false;
+  @Input() successfulLoad = false;
   @Output() sorted = new EventEmitter<any[]>();
   @Output() sortOrdering = new EventEmitter<ISortOrdering>();
 

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -44,12 +44,16 @@
         </div>
         <br>
 
+        <app-health-badge *ngIf="failedRefresh" [text]="' Some items failed to load.'" [showText]="true" badgeClass="badge-warning"></app-health-badge>
+        
         <div *ngIf="listEventStoreData.length > 1; then showTabs else showSingle"></div>
 
         <ng-template #showTabs>
             <div ngbNav #nav="ngbNav">
                 <div ngbNavItem *ngFor="let data of listEventStoreData">
                     <a ngbNavLink class="bar-name">
+                        <app-health-badge *ngIf="!data.eventsList.lastRefreshWasSuccessful" 
+                        [text]="'Error'" [showText]="false" badgeClass="badge-error"></app-health-badge>
                         {{data.displayName}}
                     </a>
                     <ng-template ngbNavContent>

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -44,7 +44,7 @@
         </div>
         <br>
 
-        <app-health-badge *ngIf="failedRefresh" [text]="' Some items failed to load.'" [showText]="true" badgeClass="badge-warning"></app-health-badge>
+        <app-health-badge *ngIf="failedRefresh" text=" Some items failed to load."  badgeClass="badge-warning"></app-health-badge>
         
         <div *ngIf="listEventStoreData.length > 1; then showTabs else showSingle"></div>
 
@@ -53,7 +53,7 @@
                 <div ngbNavItem *ngFor="let data of listEventStoreData">
                     <a ngbNavLink class="bar-name">
                         <app-health-badge *ngIf="!data.eventsList.lastRefreshWasSuccessful" 
-                        [text]="'Error'" [showText]="false" badgeClass="badge-error"></app-health-badge>
+                        text="Error" [showText]="false"  badgeClass="badge-error"></app-health-badge>
                         {{data.displayName}}
                     </a>
                     <ng-template ngbNavContent>

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -55,7 +55,8 @@
                     <ng-template ngbNavContent>
                         <app-detail-list [list]="data.eventsList.collection" 
                         [listSettings]="data.eventsList.settings" 
-                        [isLoading]="!data.eventsList.isInitialized"></app-detail-list>
+                        [isLoading]="!data.eventsList.isInitialized"
+                        [successfulLoad]="data.eventsList.lastRefreshWasSuccessful"></app-detail-list>
                     </ng-template>
                 </div>
             </div>
@@ -65,7 +66,8 @@
         <ng-template #showSingle>
             <app-detail-list [list]="listEventStoreData[0].eventsList.collection" 
                 [listSettings]="listEventStoreData[0].eventsList.settings" 
-                [isLoading]="!listEventStoreData[0].eventsList.isInitialized"></app-detail-list>
+                [isLoading]="!listEventStoreData[0].eventsList.isInitialized"
+                [successfulLoad]="listEventStoreData[0].eventsList.lastRefreshWasSuccessful"></app-detail-list>
         </ng-template>
 
         <div>

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -57,6 +57,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   public endDateMax: Date;
   public endDateInit: Date;
   public isResetEnabled = false;
+  public failedRefresh = false;
   public timeLineEventsData: ITimelineData;
 
   public transformText = 'Category,Kind';
@@ -137,6 +138,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   private getTimelineData(): ITimelineData{
       let rawEventlist = [];
       let combinedTimelineData = this.initializeTimelineData();
+      this.failedRefresh = false;
 
       for (const data of this.listEventStoreData) {
           if (data.eventsList.lastRefreshWasSuccessful){
@@ -152,6 +154,9 @@ export class EventStoreComponent implements OnInit, OnDestroy {
               } catch (e) {
                   console.error(e);
               }
+          }
+          else{
+              this.failedRefresh = true;
           }
       }
 

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -139,7 +139,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       let combinedTimelineData = this.initializeTimelineData();
 
       for (const data of this.listEventStoreData) {
-          if(data.eventsList.lastRefreshWasSuccessful){
+          if (data.eventsList.lastRefreshWasSuccessful){
               try {
                   if (this.pshowAllEvents) {
                       rawEventlist = rawEventlist.concat(data.eventsList.collection.map(event => event.raw));
@@ -173,7 +173,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       const subs = this.listEventStoreData.map(data => data.eventsList.ensureInitialized());
 
       forkJoin(subs).subscribe(() => {
-          this.timeLineEventsData = this.getTimelineData(); 
+          this.timeLineEventsData = this.getTimelineData();
       });
   }
 


### PR DESCRIPTION
## Error handling for loading an event list
Handling the cases where an elements data fails to load. We display the error in the detail-list and also do not show its groups or items in the timeline.

Fixed the issue where we load the data once again each time we switch the tabs Correlated and All. Now the same data is used once again and we only update it when the date range changes.