### PR TITLE
Refresh logic improvements

### DIFF
--- a/src/SfxWeb/src/app/Utils/CollectionUtils.ts
+++ b/src/SfxWeb/src/app/Utils/CollectionUtils.ts
@@ -1,6 +1,6 @@
 import { IDataModel } from '../Models/DataModels/Base';
 import { Utils } from './Utils';
-
+import KeyBy from 'lodash/KeyBy';
 // -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
@@ -21,11 +21,11 @@ export class CollectionUtils {
                                          appendOnly: boolean = false): T[] {
 
         // create dictionary for old id => element
-        const oldCollectionMap = Utils.keyByFromFunction(collection, keySelector);
+        const oldCollectionMap = KeyBy(collection, keySelector);
         // remove deleted items first
         if (!appendOnly) {
             // create dictionary for new id => element
-            const newCollectionMap = Utils.keyByFromFunction(newCollection, newKeySelector);
+            const newCollectionMap = KeyBy(newCollection, newKeySelector);
             collection = collection.filter((item) => newCollectionMap[keySelector(item)]);
         }
 
@@ -53,7 +53,7 @@ export class CollectionUtils {
             return false;
         }
 
-        const oldCollectionMap = Utils.keyByFromFunction(collection, keySelector);
+        const oldCollectionMap = KeyBy(collection, keySelector);
 
         return newCollection.every(item => {
             const id = newKeySelector(item);

--- a/src/SfxWeb/src/app/Utils/CollectionUtils.ts
+++ b/src/SfxWeb/src/app/Utils/CollectionUtils.ts
@@ -1,6 +1,6 @@
 import { IDataModel } from '../Models/DataModels/Base';
 import { Utils } from './Utils';
-import KeyBy from 'lodash/KeyBy';
+import keyBy from 'lodash/keyBy';
 // -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
@@ -21,11 +21,11 @@ export class CollectionUtils {
                                          appendOnly: boolean = false): T[] {
 
         // create dictionary for old id => element
-        const oldCollectionMap = KeyBy(collection, keySelector);
+        const oldCollectionMap = keyBy(collection, keySelector);
         // remove deleted items first
         if (!appendOnly) {
             // create dictionary for new id => element
-            const newCollectionMap = KeyBy(newCollection, newKeySelector);
+            const newCollectionMap = keyBy(newCollection, newKeySelector);
             collection = collection.filter((item) => newCollectionMap[keySelector(item)]);
         }
 
@@ -53,7 +53,7 @@ export class CollectionUtils {
             return false;
         }
 
-        const oldCollectionMap = KeyBy(collection, keySelector);
+        const oldCollectionMap = keyBy(collection, keySelector);
 
         return newCollection.every(item => {
             const id = newKeySelector(item);

--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -30,7 +30,7 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
              this.setup();
 
-             this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => this.refresh(this.messageService))));
+             this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => {console.log("refresh",this); return this.refresh(this.messageService)})));
 
              this.subscriptions.add(this.common().pipe(mergeMap(() => this.refresh(this.messageService))).subscribe());
         }));
@@ -68,6 +68,7 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
     }
 
     common(messageHandler?: IResponseMessageHandler): Observable<any>{
+      console.log("test")
         return of(null);
     }
 }

--- a/src/SfxWeb/src/app/ViewModels/BaseController.ts
+++ b/src/SfxWeb/src/app/ViewModels/BaseController.ts
@@ -30,9 +30,9 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
              this.setup();
 
-             this.refreshService.insertRefreshSubject('current controller' + this.getClassName(), () => this.common().pipe(mergeMap(() => {console.log("refresh",this); return this.refresh(this.messageService)})));
+             this.subscriptions.add(this.refreshService.refreshSubject.subscribe(() => this.fullRefresh().subscribe()));
 
-             this.subscriptions.add(this.common().pipe(mergeMap(() => this.refresh(this.messageService))).subscribe());
+             this.subscriptions.add(this.fullRefresh().subscribe());
         }));
 
          console.log(this);
@@ -52,9 +52,11 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
 
     ngOnDestroy(){
         this.subscriptions.unsubscribe();
-        this.refreshService.removeRefreshSubject('current controller' + this.getClassName());
     }
 
+    fullRefresh(): Observable<any> {
+      return this.common().pipe(mergeMap(() => this.refresh(this.messageService)));
+    }
 
     /*
      Optional to get and set params from URL. called before common
@@ -68,7 +70,6 @@ export abstract class BaseControllerDirective implements  OnInit, OnDestroy {
     }
 
     common(messageHandler?: IResponseMessageHandler): Observable<any>{
-      console.log("test")
         return of(null);
     }
 }

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -123,9 +123,8 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         return (this.node && this.node.mergeClusterHealthStateChunk ?
         this.node.mergeClusterHealthStateChunk(clusterHealthChunk)
         : of([])).pipe(mergeMap(() => {
-          const updateChildrenPromises = this.children.map(child => {
-            return child.updateDataModelFromHealthChunkRecursively(clusterHealthChunk);
-          });
+          const updateChildrenPromises = this.children.map(child => child.updateDataModelFromHealthChunkRecursively(clusterHealthChunk));
+
           if (updateChildrenPromises.length > 0) {
             return forkJoin(updateChildrenPromises);
           } else {

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -55,7 +55,7 @@ export class TreeNodeGroupViewModel {
     }
 
     public get isExpanded(): boolean {
-        return  this.internalIsExpanded && !!this.node.childrenQuery;
+        return  this.internalIsExpanded && this.hasChildren;
     }
 
     public get isCollapsed(): boolean {
@@ -122,11 +122,15 @@ export class TreeNodeGroupViewModel {
 
         return of(this.node && this.node.mergeClusterHealthStateChunk
             ? this.node.mergeClusterHealthStateChunk(clusterHealthChunk)
-            : true).pipe(map( () => {
+            : true).pipe(mergeMap( () => {
                 const updateChildrenPromises = this.children.map(child => {
                     return child.updateDataModelFromHealthChunkRecursively(clusterHealthChunk);
                 });
-                return forkJoin(updateChildrenPromises);
+                if (updateChildrenPromises.length > 0) {
+                  return forkJoin(updateChildrenPromises);
+                }else{
+                  return of(true);
+                }
             } ));
     }
 

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -14,7 +14,7 @@ import orderBy from 'lodash/orderBy';
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
 // -----------------------------------------------------------------------------
-export class TreeNodeGroupViewModel {
+export class TreeNodeGroupViewModel implements ITreeNode {
     public parent: TreeNodeGroupViewModel;
     public sortBy: () => any[];
     public selected = false;
@@ -115,23 +115,23 @@ export class TreeNodeGroupViewModel {
         });
     }
 
-    public updateDataModelFromHealthChunkRecursively(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
+    public updateDataModelFromHealthChunkRecursively(clusterHealthChunk: IClusterHealthChunk): Observable<any[]> {
         if (!this.internalIsExpanded) {
-            return of(true);
+            return of([]);
         }
 
-        return of(this.node && this.node.mergeClusterHealthStateChunk
-            ? this.node.mergeClusterHealthStateChunk(clusterHealthChunk)
-            : true).pipe(mergeMap( () => {
-                const updateChildrenPromises = this.children.map(child => {
-                    return child.updateDataModelFromHealthChunkRecursively(clusterHealthChunk);
-                });
-                if (updateChildrenPromises.length > 0) {
-                  return forkJoin(updateChildrenPromises);
-                }else{
-                  return of(true);
-                }
-            } ));
+        return (this.node && this.node.mergeClusterHealthStateChunk ?
+        this.node.mergeClusterHealthStateChunk(clusterHealthChunk)
+        : of([])).pipe(mergeMap(() => {
+          const updateChildrenPromises = this.children.map(child => {
+            return child.updateDataModelFromHealthChunkRecursively(clusterHealthChunk);
+          });
+          if (updateChildrenPromises.length > 0) {
+            return forkJoin(updateChildrenPromises);
+          } else {
+            return of([]);
+          }
+        }));
     }
 
     public refreshExpandedChildrenRecursively(): Observable<any> {

--- a/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
@@ -107,7 +107,7 @@ export class TreeViewModel {
         return clusterHealthQueryDescription;
     }
 
-    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
+    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any[]> {
         return this.childGroupViewModel.updateDataModelFromHealthChunkRecursively(clusterHealthChunk);
     }
 

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -344,15 +344,6 @@ export class DataService {
             deployedApps.push(deployedApp);
         }));
 
-    // // Assign deployed apps under their belonging nodes
-    // const nodeDeployedAppsGroups = deployedApps.reduce( (previous, current) => {
-    //     if ( current.NodeName in previous){
-    //         previous[current.NodeName].push(current);
-    //     }else{
-    //         previous[current.NodeName] = [current];
-    //     }
-    //     return previous; }, {});
-
     // TODO
     const nodeDeployedAppsGroups = groupBy(deployedApps, deployedApp => deployedApp.NodeName);
     Object.keys(nodeDeployedAppsGroups).forEach(key => {

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -33,7 +33,7 @@ import { IDataModelCollection } from '../Models/DataModels/collections/Collectio
 import { DeployedApplicationCollection } from '../Models/DataModels/collections/DeployedApplicationCollection';
 import { MatDialog } from '@angular/material/dialog';
 import { RepairTaskCollection } from '../Models/DataModels/collections/RepairTaskCollection';
-
+import groupBy from 'lodash/groupBy';
 @Injectable({
   providedIn: 'root'
 })
@@ -326,7 +326,7 @@ export class DataService {
     if (item) {
         return item.ensureInitialized(forceRefresh, messageHandler);
     } else {
-        return throwError(null);
+        return throwError('This item could not be found');
     }
   }
 
@@ -344,17 +344,17 @@ export class DataService {
             deployedApps.push(deployedApp);
         }));
 
-    // Assign deployed apps under their belonging nodes
-    const nodeDeployedAppsGroups = deployedApps.reduce( (previous, current) => {
-        if ( current.NodeName in previous){
-            previous[current.NodeName].push(current);
-        }else{
-            previous[current.NodeName] = [current];
-        }
-        return previous; }, {});
+    // // Assign deployed apps under their belonging nodes
+    // const nodeDeployedAppsGroups = deployedApps.reduce( (previous, current) => {
+    //     if ( current.NodeName in previous){
+    //         previous[current.NodeName].push(current);
+    //     }else{
+    //         previous[current.NodeName] = [current];
+    //     }
+    //     return previous; }, {});
 
     // TODO
-    // let nodeDeployedAppsGroups = _.groupBy(deployedApps, deployedApp => deployedApp.NodeName);
+    const nodeDeployedAppsGroups = groupBy(deployedApps, deployedApp => deployedApp.NodeName);
     Object.keys(nodeDeployedAppsGroups).forEach(key => {
         const group = nodeDeployedAppsGroups[key];
 

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -72,10 +72,12 @@ export class TreeService {
             // Merge the health chunk result back to the shared data models, during refresh, all tree nodes will
             // retrieve data from the cached data model which already has latest health state.
             const clusterHealthQueryDescription = this.tree.addHealthChunkFiltersRecursively(this.data.getInitialClusterHealthChunkQueryDescription());
+            console.log(clusterHealthQueryDescription);
             return this.data.getClusterHealthChunk(clusterHealthQueryDescription)
                 .pipe(mergeMap(healthChunk => {
-                    return forkJoin([
-                        // cluster health needs to be refreshed even when the root node is collapsed
+                  console.log(healthChunk);
+                  return forkJoin([
+                        // cluster health needs to be refreshed even when the rooddt node is collapsed
                         this.clusterHealth.mergeHealthStateChunk(healthChunk),
                         this.tree.mergeClusterHealthStateChunk(healthChunk)
                     ]).pipe(mergeMap(() => this.tree.refresh()) );

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -43,7 +43,7 @@ export class TreeService {
 
             this.cm = new ClusterManifest(this.data);
 
-            this.refreshService.refreshSubject.subscribe( () => this.refresh().subscribe());
+            this.refreshService.refreshSubject.subscribe( () => {console.log(this); this.refresh().subscribe(); });
         }
 
         public selectTreeNode(path: string[], skipSelectAction?: boolean): Observable<any> {
@@ -78,7 +78,7 @@ export class TreeService {
                         // cluster health needs to be refreshed even when the root node is collapsed
                         this.clusterHealth.mergeHealthStateChunk(healthChunk),
                         this.tree.mergeClusterHealthStateChunk(healthChunk)
-                    ]).pipe(mergeMap( () => this.tree.refresh()) );
+                    ]).pipe(mergeMap(() => this.tree.refresh()) );
                 }));
         }
 

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -42,7 +42,8 @@ export class TreeService {
             }
 
             this.cm = new ClusterManifest(this.data);
-            this.refreshService.insertRefreshSubject('tree', () => this.refresh() );
+
+            this.refreshService.refreshSubject.subscribe( () => this.refresh().subscribe());
         }
 
         public selectTreeNode(path: string[], skipSelectAction?: boolean): Observable<any> {

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -43,7 +43,7 @@ export class TreeService {
 
             this.cm = new ClusterManifest(this.data);
 
-            this.refreshService.refreshSubject.subscribe( () => {console.log(this); this.refresh().subscribe(); });
+            this.refreshService.refreshSubject.subscribe( () => this.refresh().subscribe());
         }
 
         public selectTreeNode(path: string[], skipSelectAction?: boolean): Observable<any> {
@@ -72,10 +72,8 @@ export class TreeService {
             // Merge the health chunk result back to the shared data models, during refresh, all tree nodes will
             // retrieve data from the cached data model which already has latest health state.
             const clusterHealthQueryDescription = this.tree.addHealthChunkFiltersRecursively(this.data.getInitialClusterHealthChunkQueryDescription());
-            console.log(clusterHealthQueryDescription);
             return this.data.getClusterHealthChunk(clusterHealthQueryDescription)
                 .pipe(mergeMap(healthChunk => {
-                  console.log(healthChunk);
                   return forkJoin([
                         // cluster health needs to be refreshed even when the rooddt node is collapsed
                         this.clusterHealth.mergeHealthStateChunk(healthChunk),

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -75,7 +75,7 @@ export class TreeService {
             return this.data.getClusterHealthChunk(clusterHealthQueryDescription)
                 .pipe(mergeMap(healthChunk => {
                   return forkJoin([
-                        // cluster health needs to be refreshed even when the rooddt node is collapsed
+                        // cluster health needs to be refreshed even when the root node is collapsed
                         this.clusterHealth.mergeHealthStateChunk(healthChunk),
                         this.tree.mergeClusterHealthStateChunk(healthChunk)
                     ]).pipe(mergeMap(() => this.tree.refresh()) );

--- a/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
+++ b/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, HostListener, OnInit } from '@angular/core';
 import { ClusterUpgradeProgress } from 'src/app/Models/DataModels/Cluster';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { RefreshService } from 'src/app/services/refresh.service';
 
 @Component({
@@ -20,7 +20,7 @@ export class ClusterUpgradeBannerComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.refreshService.insertRefreshSubject('upgradeBanner', () => this.refresh());
+    this.refreshService.refreshSubject.subscribe(() => this.refresh().subscribe());
     this.checkWidth(window.innerWidth);
   }
 

--- a/src/SfxWeb/src/app/views/application/applicationBase.ts
+++ b/src/SfxWeb/src/app/views/application/applicationBase.ts
@@ -20,9 +20,14 @@ export class ApplicationBaseControllerDirective extends BaseControllerDirective 
     }
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
+      try {
         return this.data.getApp(this.appId, true, messageHandler).pipe(map(data => {
-            this.app = data;
+          console.log(data);
+          this.app = data;
         }));
+      }  catch(e) {
+        console.log(e)
+      }
     }
 
     getParams(route: ActivatedRouteSnapshot): void {

--- a/src/SfxWeb/src/app/views/application/applicationBase.ts
+++ b/src/SfxWeb/src/app/views/application/applicationBase.ts
@@ -20,14 +20,9 @@ export class ApplicationBaseControllerDirective extends BaseControllerDirective 
     }
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
-      try {
         return this.data.getApp(this.appId, true, messageHandler).pipe(map(data => {
-          console.log(data);
           this.app = data;
         }));
-      }  catch(e) {
-        console.log(e)
-      }
     }
 
     getParams(route: ActivatedRouteSnapshot): void {

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -54,7 +54,6 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
   }
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
-    console.log(this)
     this.data.clusterManifest.ensureInitialized().subscribe(() => {
       if (this.data.clusterManifest.isBackupRestoreEnabled) {
         this.data.refreshBackupPolicies(messageHandler);
@@ -77,7 +76,7 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
         const replicasHealthStateCount = HealthUtils.getHealthStateCount(appHealth.raw, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount('Replicas', 'Replica', false, replicasHealthStateCount);
       }))
-    ])
+    ]);
   }
 
 }

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -23,19 +23,16 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
   unhealthyEvaluationsListSettings: ListSettings;
   upgradeProgressUnhealthyEvaluationsListSettings: ListSettings;
   serviceTypesListSettings: ListSettings;
-  clusterManifest: ClusterManifest;
 
   servicesDashboard: IDashboardViewModel;
   partitionsDashboard: IDashboardViewModel;
   replicasDashboard: IDashboardViewModel;
 
-  constructor(protected data: DataService, injector: Injector, private settings: SettingsService, private cdr: ChangeDetectorRef) {
+  constructor(protected data: DataService, injector: Injector, private settings: SettingsService) {
     super(data, injector);
   }
 
   setup() {
-    this.clusterManifest = new ClusterManifest(this.data);
-
     this.listSettings = this.settings.getNewOrExistingListSettings('services', ['name'], [
       new ListColumnSettingForLink('name', 'Name', item => item.viewPath),
       new ListColumnSetting('raw.TypeName', 'Service Type'),
@@ -54,11 +51,10 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
 
     this.unhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings();
     this.upgradeProgressUnhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings('upgradeProgressUnhealthyEvaluations');
-    this.cdr.detectChanges();
-
   }
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
+    console.log(this)
     this.data.clusterManifest.ensureInitialized().subscribe(() => {
       if (this.data.clusterManifest.isBackupRestoreEnabled) {
         this.data.refreshBackupPolicies(messageHandler);
@@ -66,7 +62,6 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
     });
 
     return forkJoin([
-      this.clusterManifest.ensureInitialized(false),
       this.app.upgradeProgress.refresh(messageHandler).pipe(map(upgradeProgress => {
         this.upgradeProgress = upgradeProgress;
       })),
@@ -82,9 +77,7 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
         const replicasHealthStateCount = HealthUtils.getHealthStateCount(appHealth.raw, HealthStatisticsEntityKind.Replica);
         this.replicasDashboard = DashboardViewModel.fromHealthStateCount('Replicas', 'Replica', false, replicasHealthStateCount);
       }))
-    ]).pipe(map( () => {
-      this.cdr.detectChanges();
-    }));
+    ])
   }
 
 }

--- a/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-task-view/repair-task-view.component.ts
@@ -3,7 +3,7 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 import { ListColumnSetting } from 'src/app/Models/ListSettings';
 import { IRepairTaskPhase, RepairTask } from 'src/app/Models/DataModels/repairTask';
 import { DataService } from 'src/app/services/data.service';
-import { forkJoin } from 'rxjs';
+import { forkJoin, Subscription } from 'rxjs';
 import { RefreshService } from 'src/app/services/refresh.service';
 import { catchError, map } from 'rxjs/operators';
 
@@ -18,18 +18,19 @@ export class RepairTaskViewComponent implements OnInit, DetailBaseComponent, OnD
   copyText = '';
   history: any;
   nodes = [];
+  subs: Subscription = new Subscription();
   constructor(public dataService: DataService, private refreshService: RefreshService) { }
 
   ngOnInit(): void {
     this.copyText = JSON.stringify(this.item.raw, null, '\t');
 
-    this.updateNodesList().subscribe();
+    this.subs.add(this.updateNodesList().subscribe());
 
-    this.refreshService.insertRefreshSubject(this.item.id, () => this.updateNodesList());
+    this.subs.add(this.refreshService.refreshSubject.subscribe(() => this.updateNodesList().subscribe()));
   }
 
   ngOnDestroy() {
-    this.refreshService.removeRefreshSubject(this.item.id);
+    this.subs.unsubscribe();
   }
 
   asIsOrder(a: any, b: any): number {


### PR DESCRIPTION
Change the direction for how the refresh service works. Instead of other components giving callback functions, emit an observable that things can subscribe to . This should reduce the issues with proto inheritance and passing callbacks that has cause some pages to not update correctly and simplify the refresh service.
It appears that something during the typescript compile for a production build is causing the overridden functions to not correctly map to what should be called causing some pages to incorrectly not update.