### PR TITLE
Updates to Repair Tasks, refresh function and deleting unused variables

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -81,6 +81,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
                 return this.update(collection);
             }),
             catchError( err => {
+                this.collection = [];
                 success = false;
                 return of(err);
             })

--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -87,8 +87,8 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
                 return of(err);
             })
             ).subscribe( () => {
-                if(this.clearOnFailureToUpdate && this.lastRefreshWasSuccessful){
-                    this.collection = [];   
+                if (this.clearOnFailureToUpdate && this.lastRefreshWasSuccessful){
+                    this.collection = [];
                 }
                 this.lastRefreshWasSuccessful = success;
                 this.refreshingPromise.next(success);

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -1,6 +1,6 @@
 import { IClusterHealthChunk, IDeployedServicePackageHealthStateChunk } from '../../HealthChunkRawDataTypes';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { ValueResolver, ITextAndBadge } from 'src/app/Utils/ValueResolver';
 import { IRawDeployedServicePackage } from '../../RawDataTypes';
 import { IdGenerator } from 'src/app/Utils/IdGenerator';
@@ -316,16 +316,12 @@ export class DeployedReplicaCollection extends DataModelCollectionBase<DeployedR
 export abstract class EventListBase<T extends FabricEventBase> extends DataModelCollectionBase<FabricEventInstanceModel<T>> {
     public readonly settings: ListSettings;
     public readonly detailsSettings: ListSettings;
-    // This will skip refreshing if period is set to be too quick by user, as currently events
-    // requests take ~3 secs, and so we shouldn't be delaying every global refresh.
-    public readonly minimumRefreshTimeInSecs: number = 10;
     public readonly pageSize: number = 15;
     public readonly defaultDateWindowInDays: number = 7;
     public readonly latestRefreshPeriodInSecs: number = 60 * 60;
 
     protected readonly optionalColsStartIndex: number = 2;
 
-    private lastRefreshTime?: Date;
     private iStartDate: Date;
     private iEndDate: Date;
 
@@ -374,20 +370,12 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
     }
 
     public reload(messageHandler?: IResponseMessageHandler): Observable<any> {
-        this.lastRefreshTime = null;
         return this.clear().pipe(map(() => {
             return this.refresh(messageHandler);
         }));
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
-        // Use existing collection if a refresh is called in less than minimumRefreshTimeInSecs.
-        if (this.lastRefreshTime &&
-            (new Date().getTime() - this.lastRefreshTime.getTime()) < (this.minimumRefreshTimeInSecs * 1000)) {
-            return of(this.collection);
-        }
-
-        this.lastRefreshTime = new Date();
         return this.retrieveEvents(messageHandler);
     }
 

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -7,7 +7,6 @@ import { debounceTime, distinctUntilChanged, finalize, subscribeOn } from 'rxjs/
 import { DataService } from 'src/app/services/data.service';
 import { hostViewClassName } from '@angular/compiler';
 import { DataGroup, DataItem, DataSet } from 'vis-timeline/standalone/esm';
-import { Observable } from 'rxjs';
 import { DataModelCollectionBase } from 'src/app/Models/DataModels/collections/CollectionBase';
 import { ListSettings } from 'src/app/Models/ListSettings';
 
@@ -16,19 +15,14 @@ export interface IQuickDates {
     hours: number;
 }
 
-export interface IEventStoreDataUtils{
-    setDateWindow(startDate: Date, endDate: Date): boolean;
-    reload(): Observable<any>;
-}
-
 export interface IEventStoreData<T extends DataModelCollectionBase<any>, S> {
     eventsList: T;
     timelineGenerator?: TimeLineGeneratorBase<S>;
     timelineData?: ITimelineData;
     displayName: string;
     listSettings?: ListSettings;
-    utils?: IEventStoreDataUtils;
-    getEvents?(): S [];
+    getEvents?(): S[];
+    setDateWindow?(startDate: Date, endDate: Date): boolean;
 }
 
 @Component({
@@ -46,8 +40,6 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       this.timeLineEventsData = this.getTimelineData();
   }
 
-  public static MaxWindowInDays = 7;
-
   private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
   private debouncerHandlerSubscription: Subscription;
 
@@ -61,11 +53,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
 
   @Input() listEventStoreData: IEventStoreData<any, any>[];
   public startDateMin: Date;
-  public endDateMin: Date;
   public startDateMax: Date;
-  public endDateMax: Date;
-  public endDateInit: Date;
-  public isResetEnabled = false;
   public failedRefresh = false;
   public timeLineEventsData: ITimelineData;
 
@@ -100,29 +88,25 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   }
 
   private resetSelectionProperties(): void {
-      this.startDate = this.listEventStoreData[0].eventsList.startDate;
-      this.endDate = this.listEventStoreData[0].eventsList.endDate;
-      this.startDateMin = this.endDateMin = TimeUtils.AddDays(new Date(), -30);
-      this.startDateMax = this.endDateMax = new Date(); // Today
+      const todaysDate = new Date();
+      this.startDate = TimeUtils.AddDays(todaysDate, -7);
+      this.endDate = this.startDateMax = todaysDate;
+      this.startDateMin = TimeUtils.AddDays(todaysDate, -30);
   }
 
   public setDate(date: IQuickDates) {
       this.setNewDates({
-          endDate: new Date(this.listEventStoreData[0].eventsList.endDate),
+          endDate: new Date(this.endDate),
           startDate: TimeUtils.AddHours(this.endDate, -1 * date.hours)
       });
   }
 
   private setNewDateWindow(): void {
-      const subs = this.listEventStoreData.filter(data => data.utils?.setDateWindow(this.startDate, this.endDate) ?? false)
-      .map((data) => {
-          this.resetSelectionProperties();
-          this.isResetEnabled = true;
-          return data.utils?.reload() ?? of(false);
-      });
+      // If the date window changed for some collection, we should refresh its data to get the new one.
+      const refreshData = this.listEventStoreData.some(data => data.setDateWindow ? data.setDateWindow(this.startDate, this.endDate) : false);
 
-      if (subs.length > 0) {
-          forkJoin(subs).subscribe(() => this.setTimelineData());
+      if (refreshData) {
+          this.setTimelineData();
       }
   }
 
@@ -153,7 +137,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
           if (data.eventsList.lastRefreshWasSuccessful){
               try {
                   if (this.pshowAllEvents) {
-                      if (data.utils){
+                      if (data.setDateWindow){
                           rawEventlist = rawEventlist.concat(data.getEvents());
                       }
 
@@ -186,7 +170,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   }
 
   public setTimelineData(): void {
-      const subs = this.listEventStoreData.map(data => data.eventsList.ensureInitialized());
+      const subs = this.listEventStoreData.map(data => data.eventsList.refresh());
 
       forkJoin(subs).subscribe(() => {
           this.timeLineEventsData = this.getTimelineData();

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -102,7 +102,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   }
 
   private setNewDateWindow(): void {
-      // If the date window changed for some collection, we should refresh its data to get the new one.
+      // If the data interface has that function implemented, we call it. If it doesn't we discard it by returning false.
       const refreshData = this.listEventStoreData.some(data => data.setDateWindow ? data.setDateWindow(this.startDate, this.endDate) : false);
 
       if (refreshData) {

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -297,10 +297,7 @@ export class DataService {
     private addFabricEventData<T extends EventListBase<any>, S extends FabricEventBase>(data: IEventStoreData<T, S>){
         data.listSettings = data.eventsList.settings;
         data.getEvents = () => data.eventsList.collection.map(event => event.raw);
-        data.utils = {
-            setDateWindow: (startDate: Date, endDate: Date) => data.eventsList.setDateWindow(startDate, endDate),
-            reload: () => data.eventsList.reload(),
-        };
+        data.setDateWindow = (startDate: Date, endDate: Date) => data.eventsList.setDateWindow(startDate, endDate);
     }
 
     public getRepairTasksData(settings: SettingsService): IEventStoreData<RepairTaskCollection, RepairTask>{


### PR DESCRIPTION
### Changes

We update the IEventStoreData interface to its final version, by replacing the utils interface inside it for just the needed function to set the date window.

There are some other minor updates to the event-store component where we try to avoid the usage of the reload function. Also, we change the way we setup initial dates to avoid arbitrarily accessing the first element of the list.

Also we get rid of unused variables in some files, mainly on the Event Store. Some of this changes are due to deleting the timeframe for refreshing the collection, but the majority are unused variables in the event-store component that serve no purpose in this version of SfxWeb.

### Issue

One issue that still is present is the fact that by using the ensureInitialized function. we may receive true values even though we shouldn't (due to a failure in the request to the API). The issue is:

If we get to the event store page without a failure in a request to the API, every collection would have a successful refresh and would be initialized. But, if later on the cluster fails and we can't get info through the API (errors in the requests) we wouldn't be able to catch those errors and show that something has failed. This happens due to the current loginc in the ensureInitialized function, because we would have a previous successful refresh to the collection that is initialized and that would lead to us not refreshing the data and just using  our current collection.

The possible fixes are:

1.  Instead of the ensureInitialized function just use the refresh function. This would mean that we always ask for the updated collection without looking at what happen to the previous requests.
2. Always force a refresh on the ensureInitialized function. This would also fix the issue but this function at the end would behave the exact same as the refresh function
3. Add a period for a forced refresh on the event store. We can set some variables so that every X amount of seconds a flag is raised so that the next call for ensureInitialized on the collections is a forced one. This way we can maintain a combined functionality.