### PR TITLE
Adding remaining stuff to the Event Store

### DIFF
--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -1,6 +1,6 @@
 
 
-import { FabricEventBase, ClusterEvent, NodeEvent, ApplicationEvent, FabricEvent } from './Events';
+import { FabricEventBase, ClusterEvent, NodeEvent, ApplicationEvent, FabricEvent, PartitionEvent } from './Events';
 import { DataGroup, DataItem, DataSet } from 'vis-timeline/standalone/esm';
 import padStart from 'lodash/padStart';
 import findIndex from 'lodash/findIndex';
@@ -475,11 +475,11 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
     }
 }
 
-export class PartitionTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
+export class PartitionTimelineGenerator extends TimeLineGeneratorBase<PartitionEvent> {
     static readonly swapPrimaryLabel = 'Primary Swap';
     static readonly swapPrimaryDurations = 'Swap Primary phases';
 
-    consume(events: NodeEvent[], startOfRange: Date, endOfRange: Date): ITimelineData {
+    consume(events: PartitionEvent[], startOfRange: Date, endOfRange: Date): ITimelineData {
         const items = new DataSet<DataItem>();
 
         events.forEach( event => {

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -33,11 +33,11 @@ import { IDataModelCollection } from '../Models/DataModels/collections/Collectio
 import { DeployedApplicationCollection } from '../Models/DataModels/collections/DeployedApplicationCollection';
 import { MatDialog } from '@angular/material/dialog';
 import { RepairTaskCollection } from '../Models/DataModels/collections/RepairTaskCollection';
-import { ClusterEvent, FabricEventBase, NodeEvent, ServiceEvent } from '../Models/eventstore/Events';
+import { ApplicationEvent, ClusterEvent, FabricEventBase, NodeEvent, PartitionEvent, ReplicaEvent, ServiceEvent } from '../Models/eventstore/Events';
 import { IEventStoreData } from '../modules/event-store/event-store/event-store.component';
 import { SettingsService } from './settings.service';
 import { RepairTask } from '../Models/DataModels/repairTask';
-import { ClusterTimelineGenerator, NodeTimelineGenerator, RepairTaskTimelineGenerator } from '../Models/eventstore/timelineGenerators';
+import { ApplicationTimelineGenerator, ClusterTimelineGenerator, NodeTimelineGenerator, PartitionTimelineGenerator, RepairTaskTimelineGenerator } from '../Models/eventstore/timelineGenerators';
 
 @Injectable({
   providedIn: 'root'
@@ -322,24 +322,62 @@ export class DataService {
         return d;
     }
 
-    public createNodeEventList(nodeName?: string): NodeEventList {
-        return new NodeEventList(this, nodeName);
+    public getNodeEventData(nodeName?: string): IEventStoreData<NodeEventList, NodeEvent>{
+        const list = new NodeEventList(this, nodeName);
+        const d = {
+            eventsList: list,
+            timelineGenerator: new NodeTimelineGenerator(),
+            displayName: nodeName? nodeName : 'Nodes',
+        };
+
+        this.addFabricEventData<NodeEventList, NodeEvent>(d);
+        return d;
     }
 
-    public createApplicationEventList(applicationId?: string): ApplicationEventList {
-        return new ApplicationEventList(this, applicationId);
+    public getApplicationEventData(applicationId?: string): IEventStoreData<ApplicationEventList,ApplicationEvent> {
+        const list = new ApplicationEventList(this, applicationId);
+        const d = {
+            eventsList : list,
+            timelineGenerator : applicationId? new ApplicationTimelineGenerator() : null,
+            displayName : applicationId? applicationId : 'Apps',
+        };
+
+        this.addFabricEventData<ApplicationEventList, ApplicationEvent>(d);
+        return d;
     }
 
-    public createServiceEventList(serviceId?: string): ServiceEventList {
-        return new ServiceEventList(this, serviceId);
+    public getServiceEventData(serviceId?: string): IEventStoreData<ServiceEventList,ServiceEvent> {
+        const list = new ServiceEventList(this, serviceId);
+        const d = {
+            eventsList : list,
+            displayName : serviceId
+        };
+
+        this.addFabricEventData<ServiceEventList, ServiceEvent>(d);
+        return d;
     }
 
-    public createPartitionEventList(partitionId?: string): PartitionEventList {
-        return new PartitionEventList(this, partitionId);
+    public getPartitionEventData(partitionId?: string): IEventStoreData<PartitionEventList,PartitionEvent> {
+        const list = new PartitionEventList(this, partitionId);
+        const d = {
+            eventsList : list,
+            timelineGenerator : new PartitionTimelineGenerator(),
+            displayName : partitionId
+        };
+
+        this.addFabricEventData<PartitionEventList, PartitionEvent>(d);
+        return d;
     }
 
-    public createReplicaEventList(partitionId: string, replicaId?: string): ReplicaEventList {
-        return new ReplicaEventList(this, partitionId, replicaId);
+    public getReplicaEventData(partitionId: string, replicaId?: string): IEventStoreData<ReplicaEventList,ReplicaEvent> {
+        const list = new ReplicaEventList(this, partitionId, replicaId);
+        const d = {
+            eventsList : list,
+            displayName : replicaId
+        };
+
+        this.addFabricEventData<ReplicaEventList, ReplicaEvent>(d);
+        return d;
     }
 
     public createCorrelatedEventList(eventInstanceId: string) {

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -327,26 +327,26 @@ export class DataService {
         const d = {
             eventsList: list,
             timelineGenerator: new NodeTimelineGenerator(),
-            displayName: nodeName? nodeName : 'Nodes',
+            displayName: nodeName ? nodeName : 'Nodes',
         };
 
         this.addFabricEventData<NodeEventList, NodeEvent>(d);
         return d;
     }
 
-    public getApplicationEventData(applicationId?: string): IEventStoreData<ApplicationEventList,ApplicationEvent> {
+    public getApplicationEventData(applicationId?: string): IEventStoreData<ApplicationEventList, ApplicationEvent> {
         const list = new ApplicationEventList(this, applicationId);
         const d = {
             eventsList : list,
-            timelineGenerator : applicationId? new ApplicationTimelineGenerator() : null,
-            displayName : applicationId? applicationId : 'Apps',
+            timelineGenerator : applicationId ? new ApplicationTimelineGenerator() : null,
+            displayName : applicationId ? applicationId : 'Apps',
         };
 
         this.addFabricEventData<ApplicationEventList, ApplicationEvent>(d);
         return d;
     }
 
-    public getServiceEventData(serviceId?: string): IEventStoreData<ServiceEventList,ServiceEvent> {
+    public getServiceEventData(serviceId?: string): IEventStoreData<ServiceEventList, ServiceEvent> {
         const list = new ServiceEventList(this, serviceId);
         const d = {
             eventsList : list,
@@ -357,7 +357,7 @@ export class DataService {
         return d;
     }
 
-    public getPartitionEventData(partitionId?: string): IEventStoreData<PartitionEventList,PartitionEvent> {
+    public getPartitionEventData(partitionId?: string): IEventStoreData<PartitionEventList, PartitionEvent> {
         const list = new PartitionEventList(this, partitionId);
         const d = {
             eventsList : list,
@@ -369,7 +369,7 @@ export class DataService {
         return d;
     }
 
-    public getReplicaEventData(partitionId: string, replicaId?: string): IEventStoreData<ReplicaEventList,ReplicaEvent> {
+    public getReplicaEventData(partitionId: string, replicaId?: string): IEventStoreData<ReplicaEventList, ReplicaEvent> {
         const list = new ReplicaEventList(this, partitionId, replicaId);
         const d = {
             eventsList : list,

--- a/src/SfxWeb/src/app/views/application/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/application/events/events.component.ts
@@ -19,10 +19,7 @@ export class EventsComponent extends ApplicationBaseControllerDirective {
 
   setup() {
     this.listEventStoreData = [
-      { eventsList : this.data.createApplicationEventList(this.appId),
-        timelineGenerator: new ApplicationTimelineGenerator(),
-        displayName : 'Application: ' + this.appId
-      }
+      this.data.getApplicationEventData(this.appId)
     ];
   }
 

--- a/src/SfxWeb/src/app/views/applications/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.ts
@@ -20,7 +20,7 @@ export class EventsComponent extends BaseControllerDirective {
 
    setup() {
     this.listEventStoreData = [
-      this.data.getApplicationEventData(null)
+      this.data.getApplicationEventData()
     ];
    }
 

--- a/src/SfxWeb/src/app/views/applications/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.ts
@@ -19,10 +19,9 @@ export class EventsComponent extends BaseControllerDirective {
    }
 
    setup() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createApplicationEventList(null),
-      displayName: 'Applications'
-    }];
+    this.listEventStoreData = [
+      this.data.getApplicationEventData(null)
+    ];
    }
 
    refresh(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -20,7 +20,7 @@ export class EventsComponent implements OnInit {
       this.data.getNodeEventData()
     ];
 
-    if(this.data.clusterManifest.isRepairManagerEnabled){
+    if (this.data.clusterManifest.isRepairManagerEnabled){
       this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
     }
   }

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -17,8 +17,12 @@ export class EventsComponent implements OnInit {
   ngOnInit() {
     this.listEventStoreData = [
       this.data.getClusterEventData(),
-      this.data.getRepairTasksData(this.settings)
+      this.data.getNodeEventData()
     ];
+
+    if(this.data.clusterManifest.isRepairManagerEnabled){
+      this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
+    }
   }
 
 }

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -20,9 +20,13 @@ export class EventsComponent implements OnInit {
       this.data.getNodeEventData()
     ];
 
-    if (this.data.clusterManifest.isRepairManagerEnabled){
-      this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
-    }
+    this.data.clusterManifest.ensureInitialized().subscribe(() => {
+      if (this.data.clusterManifest.isRepairManagerEnabled) {
+        this.data.repairCollection.ensureInitialized().subscribe(() => {
+          this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
+        });
+      }
+    });
   }
 
 }

--- a/src/SfxWeb/src/app/views/node/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/node/events/events.component.ts
@@ -18,11 +18,9 @@ export class EventsComponent extends NodeBaseControllerDirective {
   }
 
   setup() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createNodeEventList(this.nodeName),
-      timelineGenerator: new NodeTimelineGenerator(),
-      displayName: 'Node: ' + this.nodeName
-    }];
+    this.listEventStoreData = [
+      this.data.getNodeEventData(this.nodeName)
+    ];
   }
 
 }

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -19,9 +19,13 @@ export class EventsComponent implements OnInit {
       this.data.getNodeEventData(null)
     ];
 
-    if (this.data.clusterManifest.isRepairManagerEnabled){
-      this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
-    }
+    this.data.clusterManifest.ensureInitialized().subscribe(() => {
+      if (this.data.clusterManifest.isRepairManagerEnabled) {
+        this.data.repairCollection.ensureInitialized().subscribe(() => {
+          this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
+        });
+      }
+    });
   }
 
 }

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { NodeTimelineGenerator } from 'src/app/Models/eventstore/timelineGenerators';
 import { DataService } from 'src/app/services/data.service';
 import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
+import { SettingsService } from 'src/app/services/settings.service';
 
 @Component({
   selector: 'app-events',
@@ -12,14 +12,16 @@ export class EventsComponent implements OnInit {
 
   listEventStoreData: IEventStoreData<any, any> [];
 
-  constructor(public data: DataService) { }
+  constructor(public data: DataService, public settings: SettingsService) { }
 
   ngOnInit() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createNodeEventList(null),
-      timelineGenerator: new NodeTimelineGenerator(),
-      displayName: 'Nodes'
-    }];
+    this.listEventStoreData = [
+      this.data.getNodeEventData(null)
+    ];
+
+    if(this.data.clusterManifest.isRepairManagerEnabled){
+      this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
+    }
   }
 
 }

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -19,7 +19,7 @@ export class EventsComponent implements OnInit {
       this.data.getNodeEventData(null)
     ];
 
-    if(this.data.clusterManifest.isRepairManagerEnabled){
+    if (this.data.clusterManifest.isRepairManagerEnabled){
       this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
     }
   }

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -16,7 +16,7 @@ export class EventsComponent implements OnInit {
 
   ngOnInit() {
     this.listEventStoreData = [
-      this.data.getNodeEventData(null)
+      this.data.getNodeEventData()
     ];
 
     this.data.clusterManifest.ensureInitialized().subscribe(() => {

--- a/src/SfxWeb/src/app/views/partition/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.ts
@@ -18,11 +18,9 @@ export class EventsComponent extends PartitionBaseControllerDirective {
   }
 
   setup() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createPartitionEventList(this.partitionId),
-      timelineGenerator: new PartitionTimelineGenerator(),
-      displayName: 'Partition: ' + this.partitionId
-    }];
+    this.listEventStoreData = [
+      this.data.getPartitionEventData(this.partitionId)
+    ];
   }
 
 }

--- a/src/SfxWeb/src/app/views/replica/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.ts
@@ -17,10 +17,9 @@ export class EventsComponent extends ReplicaBaseControllerDirective {
   }
 
   setup() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createReplicaEventList(this.partitionId, this.replicaId),
-      displayName: 'Replica: ' + this.replicaId
-    }];
+    this.listEventStoreData = [
+      this.data.getReplicaEventData(this.partitionId, this.replicaId)
+    ];
   }
 
 }

--- a/src/SfxWeb/src/app/views/service/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/service/events/events.component.ts
@@ -17,10 +17,9 @@ export class EventsComponent extends ServiceBaseControllerDirective {
   }
 
   setup() {
-    this.listEventStoreData = [{
-      eventsList: this.data.createServiceEventList(this.serviceId),
-      displayName: 'Service: ' + this.serviceId
-    }];
+    this.listEventStoreData = [
+      this.data.getServiceEventData(this.serviceId)
+    ];
   }
 
 }


### PR DESCRIPTION
This PR contains the latest changes to the events components + some fixes. The previous accepted changes are now replicated in the remaining modules of SFX, for each of the elements that contains an event store component.

Also a check has been added to make sure that we only add the repair tasks if the repair manager is enabled in the cluster, this is done by checking the cluster's manifest.