### PR TITLE
Add order option for tree view

### DIFF
--- a/src/SfxWeb/src/app/Utils/healthUtils.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.ts
@@ -4,6 +4,8 @@ import { IRawUnhealthyEvaluation, IRawHealthEvaluation, IRawNodeHealthEvluation,
 import { HealthEvaluation } from '../Models/DataModels/Shared';
 import { DataService } from '../services/data.service';
 import { RoutesService } from '../services/routes.service';
+import { ITextAndBadge } from './ValueResolver';
+import { BadgeConstants } from '../Common/Constants';
 
 export enum HealthStatisticsEntityKind {
     Node,
@@ -173,6 +175,25 @@ export class HealthUtils {
             ErrorCount: 0,
             WarningCount: 0
         };
+    }
+
+    public static resolveHealthStateToValue(badge: ITextAndBadge) {
+        let value = 0;
+        switch (badge.badgeClass) {
+            case BadgeConstants.BadgeUnknown:
+            case BadgeConstants.BadgeOK:
+                value = 0;
+                break;
+            case BadgeConstants.BadgeWarning:
+                value = 1;
+                break;
+            case BadgeConstants.BadgeError:
+                value = 2;
+                break;
+            default:
+                break;
+        }
+        return value;
     }
 }
 

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
@@ -5,7 +5,7 @@ import { ValueResolver } from '../Utils/ValueResolver';
 import { TreeNodeGroupViewModel } from './TreeNodeGroupViewModel';
 
 describe('Tree Node', () => {
-
+    let vr: ValueResolver;
 
     let testNode: TreeNodeGroupViewModel;
     let treeViewModel: TreeViewModel;
@@ -17,6 +17,8 @@ describe('Tree Node', () => {
     let childQuery: ITreeNode[];
 
     beforeEach((() => {
+        vr =  new ValueResolver();
+
         treeViewModel = new TreeViewModel( () => of([]));
 
         child = {
@@ -55,7 +57,6 @@ describe('Tree Node', () => {
     });
 
     describe('validate tree Node - IsVisibleBadge', () => {
-        let vr: ValueResolver;
 
         beforeEach(() => {
             node.alwaysVisible = false;
@@ -64,8 +65,7 @@ describe('Tree Node', () => {
             testNode.tree.showOkItems = false;
             testNode.tree.showWarningItems = false;
             testNode.tree.showErrorItems = false;
-
-            vr =  new ValueResolver();
+            testNode.tree.orderbyHealthState = false;
         });
 
         fit('always visible', () => {
@@ -157,7 +157,7 @@ describe('Tree Node', () => {
             const child2 = {
                 displayName: () => 'child2',
                 nodeId: 'child2',
-                sortBy: () => [-1]
+                sortBy: () => [-1],
             };
 
             const child3 = {
@@ -180,6 +180,42 @@ describe('Tree Node', () => {
             childQuery = [child3, child2, child4];
             testNode.refreshExpandedChildrenRecursively().subscribe();
             expect(testNode.displayedChildren[1].nodeId).toBe('child4');
+
+        });
+
+        fit('sort children by sort health order', () => {
+            const child2 = {
+                displayName: () => 'child2',
+                nodeId: 'child2',
+                sortBy: () => [1],
+                badge: () => vr.resolveHealthStatus('Ok')
+            };
+
+            const child3 = {
+                displayName: () => 'child3',
+                nodeId: 'child3',
+                sortBy: () => [2],
+                badge: () => vr.resolveHealthStatus('Warning')
+            };
+
+            const child4 = {
+                displayName: () => 'child4',
+                nodeId: 'child4',
+                sortBy: () => [3],
+                badge: () => vr.resolveHealthStatus('Error')
+            };
+
+            childQuery = [child2, child3, child4];
+            testNode.toggle();
+            expect(testNode.displayedChildren[0].nodeId).toBe('child2');
+            expect(testNode.displayedChildren[1].nodeId).toBe('child3');
+            expect(testNode.displayedChildren[2].nodeId).toBe('child4');
+
+            testNode.tree.orderbyHealthState = true;
+
+            expect(testNode.displayedChildren[0].nodeId).toBe('child4');
+            expect(testNode.displayedChildren[1].nodeId).toBe('child3');
+            expect(testNode.displayedChildren[2].nodeId).toBe('child2');
 
         });
 

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -9,6 +9,7 @@ import { ListSettings } from '../Models/ListSettings';
 import { ActionCollection } from '../Models/ActionCollection';
 import { ITextAndBadge } from '../Utils/ValueResolver';
 import orderBy from 'lodash/orderBy';
+import { HealthUtils } from '../Utils/healthUtils';
 
 // -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -33,9 +34,9 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         }
 
         if (this.tree.orderbyHealthState) {
-            result = result.sort( (a, b) => {
-                const badgeState1 = a.badge ? this.resolveHealthState(a.badge()) : 0;
-                const badgeState2 = b.badge ? this.resolveHealthState(b.badge()) : 0;
+            result = result.sort( (child1, child2) => {
+                const badgeState1 = child1.badge ? HealthUtils.resolveHealthStateToValue(child1.badge()) : 0;
+                const badgeState2 = child2.badge ? HealthUtils.resolveHealthStateToValue(child2.badge()) : 0;
                 return badgeState2 - badgeState1;
             });
         }
@@ -172,25 +173,6 @@ export class TreeNodeGroupViewModel implements ITreeNode {
     private keyboardSelectActionDelayInMilliseconds = 200;
     private internalIsExpanded = false;
     private currentGetChildrenPromise: Subject<any>;
-
-    private resolveHealthState(badge: ITextAndBadge) {
-        let value = 0;
-        switch (badge.badgeClass) {
-            case BadgeConstants.BadgeUnknown:
-            case BadgeConstants.BadgeOK:
-                value = 0;
-                break;
-            case BadgeConstants.BadgeWarning:
-                value = 1;
-                break;
-            case BadgeConstants.BadgeError:
-                value = 2;
-                break;
-            default:
-                break;
-        }
-        return value;
-    }
 
     public toggle(): Observable<any> {
         this.internalIsExpanded = !this.internalIsExpanded;

--- a/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
@@ -17,6 +17,7 @@ export class TreeViewModel {
     public showErrorItems = true;
 
     public searchTerm = '';
+    public orderbyHealthState = false;
 
     public firstTreeSelect = true;
 

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.html
@@ -8,16 +8,22 @@
                 <a href="https://aka.ms/sfxrepo" target="_blank" style="color: black;">You can report any issues you run into (Click here)</a>
             </div>
         </div>
-        <app-check-box [(state)]="treeService.tree.showOkItems">
-            <app-health-badge [badgeClass]="'badge-ok'" [text]="'OK'"></app-health-badge>
-        </app-check-box>
-        <app-check-box [(state)]="treeService.tree.showWarningItems">
-            <app-health-badge [badgeClass]="'badge-warning'" [text]="'Warning'"></app-health-badge>
-        </app-check-box>
-        <app-check-box [(state)]="treeService.tree.showErrorItems">
-            <app-health-badge [badgeClass]="'badge-error'" [text]="'Error'"></app-health-badge>
-        </app-check-box>
-        <div style="padding: 10px 10px 0px 0px; margin-left: -15px;">
+        <div class="filter-items-container">
+            <app-check-box [(state)]="treeService.tree.showOkItems" class="filter-item">
+                <app-health-badge [badgeClass]="'badge-ok'" [text]="'OK'"></app-health-badge>
+            </app-check-box>
+            <app-check-box [(state)]="treeService.tree.showWarningItems" class="filter-item">
+                <app-health-badge [badgeClass]="'badge-warning'" [text]="'Warning'"></app-health-badge>
+            </app-check-box>
+            <app-check-box [(state)]="treeService.tree.showErrorItems" class="filter-item">
+                <app-health-badge [badgeClass]="'badge-error'" [text]="'Error'"></app-health-badge>
+            </app-check-box>
+            <div class="filter-item" style="display: inline-block;">
+                <app-toggle [(state)]="treeService.tree.orderbyHealthState"></app-toggle>
+                Sort by Health
+            </div>
+        </div>
+        <div style="padding: 5px 10px 0px 0px; margin-left: -15px;">
             <app-input (changed)="setSearchText($event)"></app-input>
         </div>
     </div>

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.scss
@@ -87,3 +87,14 @@
     overflow: auto;
   }
 }
+
+.filter-items-container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.filter-item {
+    margin-top: 2.5px;
+    margin-bottom: 2.5px;
+}

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -21,7 +21,6 @@ export class TreeService {
         public containerRef: ElementRef;
         public tree: TreeViewModel;
         private clusterHealth: ClusterHealth;
-        private cm: ClusterManifest;
         // controller views can get instantiated before this service and so a request to set the tree location might
         // get requested before the init function is called and so it needs to be cached.
         private cachedTreeSelection: {path: string[], skipSelectAction?: boolean};
@@ -40,8 +39,6 @@ export class TreeService {
             if (this.cachedTreeSelection) {
                 this.tree.selectTreeNode(this.cachedTreeSelection.path, this.cachedTreeSelection.skipSelectAction);
             }
-
-            this.cm = new ClusterManifest(this.data);
 
             this.refreshService.refreshSubject.subscribe( () => this.refresh().subscribe());
         }


### PR DESCRIPTION
Add a toggle which would show things in the tree in the order of their significant health state, so show error, warning and then unknown/OK. This would be  very helpful in large lists of nodes to see which are the most serious ones first.
Before toggling
![beforeOrderByHealth](https://user-images.githubusercontent.com/15344718/125118272-5594b700-e0a4-11eb-8ee4-64f080b7be83.PNG)
After toggling
![afterOrderByHealth](https://user-images.githubusercontent.com/15344718/125118303-60e7e280-e0a4-11eb-8f3b-e1883da1bc40.PNG)
