### PR TITLE
Changes to events page and tests

### DIFF
--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -188,19 +188,24 @@ context('Cluster page', () => {
 
       cy.get('[data-cy=eventtabs]').within(() => {
         cy.contains(CLUSTER_TAB_NAME)
-        cy.contains(REPAIR_TASK_TAB_NAME)
       })
     })
 
     it("repair manager disabled", () => {
+      addRoute('events', 'empty-list.json', apiUrl(`/EventsStore/Cluster/Events?*`))
       addRoute('repair-manager-manifest', 'manifestRepairManagerDisabled.json', manifest_route)
 
       cy.visit('/#/events')
-
-      cy.wait('@getrepair-manager-manifest')
+      cy.wait(['@getevents','@getrepair-manager-manifest'])
 
       cy.get('[data-cy=eventtabs]').within(() => {
         cy.contains(CLUSTER_TAB_NAME)
+      })
+      checkTableErrorMessage(EMPTY_LIST_TEXT);
+
+      cy.get('[sectionName=select-event-types]').click()
+
+      cy.get('[data-cy=option-picker]').within(() => {
         cy.get(REPAIR_TASK_TAB_NAME).should('not.exist')
       })
     })
@@ -212,12 +217,6 @@ context('Cluster page', () => {
         cy.contains(CLUSTER_TAB_NAME)
       })
       checkTableSize(15);
-
-      cy.get('[data-cy=eventtabs]').within(() => {
-        cy.contains(REPAIR_TASK_TAB_NAME).click();
-      })
-
-      checkTableErrorMessage(EMPTY_LIST_TEXT);
     })
 
     it("all events", () => {
@@ -228,6 +227,12 @@ context('Cluster page', () => {
       })
       checkTableSize(15);
 
+      cy.get('[sectionName=select-event-types]').click()
+
+      cy.get('[data-cy=option-picker]').within(() => {
+        cy.contains(REPAIR_TASK_TAB_NAME)
+        cy.get('[type=checkbox]').eq(1).check({force: true})
+      })
 
       cy.get('[data-cy=eventtabs]').within(() => {
         cy.contains(REPAIR_TASK_TAB_NAME).click();

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -6,6 +6,9 @@ import {
 } from './util';
 
 const LOAD_INFO = "getloadinfo"
+const EVENT_TABS='[data-cy=eventtabs]'
+const OPTION_PICKER='[data-cy=option-picker]'
+const SELECT_EVENT_TYPES='[sectionName=select-event-types]'
 
 context('Cluster page', () => {
 
@@ -186,7 +189,7 @@ context('Cluster page', () => {
       cy.wait('@getevents');
       cy.url().should('include', 'events');
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(CLUSTER_TAB_NAME)
       })
     })
@@ -198,14 +201,14 @@ context('Cluster page', () => {
       cy.visit('/#/events')
       cy.wait(['@getevents','@getrepair-manager-manifest'])
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(CLUSTER_TAB_NAME)
       })
       checkTableErrorMessage(EMPTY_LIST_TEXT);
 
-      cy.get('[sectionName=select-event-types]').click()
+      cy.get(SELECT_EVENT_TYPES).click()
 
-      cy.get('[data-cy=option-picker]').within(() => {
+      cy.get(OPTION_PICKER).within(() => {
         cy.get(REPAIR_TASK_TAB_NAME).should('not.exist')
       })
     })
@@ -213,7 +216,7 @@ context('Cluster page', () => {
     it("cluster events", () => {
       setup('cluster-page/eventstore/cluster-events.json', 'empty-list.json')
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(CLUSTER_TAB_NAME)
       })
       checkTableSize(15);
@@ -222,19 +225,19 @@ context('Cluster page', () => {
     it("all events", () => {
       setup('cluster-page/eventstore/cluster-events.json', 'cluster-page/repair-jobs/simple.json')
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(CLUSTER_TAB_NAME);
       })
       checkTableSize(15);
 
-      cy.get('[sectionName=select-event-types]').click()
+      cy.get(SELECT_EVENT_TYPES).click()
 
-      cy.get('[data-cy=option-picker]').within(() => {
+      cy.get(OPTION_PICKER).within(() => {
         cy.contains(REPAIR_TASK_TAB_NAME)
         cy.get('[type=checkbox]').eq(1).check({force: true})
       })
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(REPAIR_TASK_TAB_NAME).click();
       })
       checkTableSize(6);
@@ -243,7 +246,7 @@ context('Cluster page', () => {
     it("failed request",() => {
       setup('failed-events.json', 'empty-list.json')
 
-      cy.get('[data-cy=eventtabs]').within(() => {
+      cy.get(EVENT_TABS).within(() => {
         cy.contains(CLUSTER_TAB_NAME)
         cy.get('[text=Error]')
       })

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -189,6 +189,10 @@ export abstract class TimeLineGeneratorBase<T> {
     generateTimeLineData(events: T[], startOfRange?: Date, endOfRange?: Date, nestedGroupLabel?: string): ITimelineData {
         const data = this.consume(events, startOfRange, endOfRange);
         EventStoreUtils.addSubGroups(data.groups);
+        /*
+            When we have more than one event type on the timeline we should group them by type to make it easier to visualize.
+            If we set a nestedGroupLabel a group with the name of the event type will be created and gather all of its events.
+        */
         if (nestedGroupLabel){
             const nestedElementGroup: DataGroup = {
                 id: nestedGroupLabel,
@@ -205,7 +209,7 @@ export abstract class TimeLineGeneratorBase<T> {
                 }
             });
             // If the group is already nested, we remove it from the nested groups of the new one.
-            nestedElementGroup.nestedGroups = nestedElementGroup.nestedGroups.filter(group => groupsAlreadyNested.indexOf(group) === -1);
+            nestedElementGroup.nestedGroups = nestedElementGroup.nestedGroups.filter(group => !groupsAlreadyNested.includes(group));
 
             data.groups.add(nestedElementGroup);
         }

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.html
@@ -44,35 +44,28 @@
         </div>
         <br>
 
+        <div class="detail-pane essen-pane" *ngIf="optionsConfig">
+            <app-option-picker [optionsConfig]="optionsConfig" (selectedOption)="processData($event)"></app-option-picker>
+        </div>
+
         <app-health-badge *ngIf="failedRefresh" text=" Some items failed to load."  badgeClass="badge-warning"></app-health-badge>
-        
-        <div *ngIf="listEventStoreData.length > 1; then showTabs else showSingle"></div>
 
-        <ng-template #showTabs>
-            <div ngbNav #nav="ngbNav" data-cy="eventtabs">
-                <div ngbNavItem *ngFor="let data of listEventStoreData">
-                    <a ngbNavLink class="bar-name">
-                        <app-health-badge *ngIf="!data.eventsList.lastRefreshWasSuccessful" 
-                        text="Error" [showText]="false"  badgeClass="badge-error"></app-health-badge>
-                        {{data.displayName}}
-                    </a>
-                    <ng-template ngbNavContent>
-                        <app-detail-list [list]="data.eventsList.collection" 
-                        [listSettings]="data.listSettings" 
-                        [isLoading]="!data.eventsList.isInitialized"
-                        [successfulLoad]="data.eventsList.lastRefreshWasSuccessful"></app-detail-list>
-                    </ng-template>
-                </div>
+        <div ngbNav #nav="ngbNav" data-cy="eventtabs">
+            <div ngbNavItem *ngFor="let data of listEventStoreData">
+                <a ngbNavLink class="bar-name">
+                    <app-health-badge *ngIf="!data.eventsList.lastRefreshWasSuccessful" 
+                    text="Error" [showText]="false"  badgeClass="badge-error"></app-health-badge>
+                    {{data.displayName}}
+                </a>
+                <ng-template ngbNavContent>
+                    <app-detail-list [list]="data.eventsList.collection" 
+                    [listSettings]="data.listSettings" 
+                    [isLoading]="!data.eventsList.isInitialized"
+                    [successfulLoad]="data.eventsList.lastRefreshWasSuccessful"></app-detail-list>
+                </ng-template>
             </div>
-            <div [ngbNavOutlet]="nav"></div>
-        </ng-template>
-
-        <ng-template #showSingle>
-            <app-detail-list [list]="listEventStoreData[0].eventsList.collection" 
-                [listSettings]="listEventStoreData[0].listSettings" 
-                [isLoading]="!listEventStoreData[0].eventsList.isInitialized"
-                [successfulLoad]="listEventStoreData[0].eventsList.lastRefreshWasSuccessful"></app-detail-list>
-        </ng-template>
+        </div>
+        <div [ngbNavOutlet]="nav"></div>
 
         <div>
             <div style="float: right; padding: 15px 0 0 0; margin: 0px;">

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -186,8 +186,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       this.listEventStoreData.push(option.data);
     }
     else{
-      const index = this.listEventStoreData.indexOf(option.data);
-      this.listEventStoreData.splice(index, 1);
+      this.listEventStoreData = this.listEventStoreData.filter(item => item !== option.data);
     }
     this.setNewDateWindow(true);
   }

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -9,6 +9,7 @@ import { hostViewClassName } from '@angular/compiler';
 import { DataGroup, DataItem, DataSet } from 'vis-timeline/standalone/esm';
 import { DataModelCollectionBase } from 'src/app/Models/DataModels/collections/CollectionBase';
 import { ListSettings } from 'src/app/Models/ListSettings';
+import { IOptionConfig, IOptionData } from '../option-picker/option-picker.component';
 
 export interface IQuickDates {
     display: string;
@@ -52,6 +53,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
   ];
 
   @Input() listEventStoreData: IEventStoreData<any, any>[];
+  @Input() optionsConfig: IOptionConfig;
   public startDateMin: Date;
   public startDateMax: Date;
   public failedRefresh = false;
@@ -101,11 +103,11 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       });
   }
 
-  private setNewDateWindow(): void {
+  private setNewDateWindow(forceRefresh: boolean = false): void {
       // If the data interface has that function implemented, we call it. If it doesn't we discard it by returning false.
       const refreshData = this.listEventStoreData.some(data => data.setDateWindow ? data.setDateWindow(this.startDate, this.endDate) : false);
 
-      if (refreshData) {
+      if (refreshData || forceRefresh) {
           this.setTimelineData();
       }
   }
@@ -132,6 +134,7 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       let rawEventlist = [];
       let combinedTimelineData = this.initializeTimelineData();
       this.failedRefresh = false;
+      const addNestedGroups = this.listEventStoreData.length > 1;
 
       for (const data of this.listEventStoreData) {
           if (data.eventsList.lastRefreshWasSuccessful){
@@ -142,7 +145,8 @@ export class EventStoreComponent implements OnInit, OnDestroy {
                       }
 
                   } else if (data.timelineGenerator) {
-                      data.timelineData = data.timelineGenerator.generateTimeLineData(data.getEvents(), this.startDate, this.endDate);
+                      // If we have more than one element in the timeline the events get grouped by the displayName of the element.
+                      data.timelineData = data.timelineGenerator.generateTimeLineData(data.getEvents(), this.startDate, this.endDate, addNestedGroups ? data.displayName : null);
 
                       this.mergeTimelineData(combinedTimelineData, data.timelineData);
                   }
@@ -175,6 +179,17 @@ export class EventStoreComponent implements OnInit, OnDestroy {
       forkJoin(subs).subscribe(() => {
           this.timeLineEventsData = this.getTimelineData();
       });
+  }
+
+  processData(option: IOptionData){
+    if (option.addToList){
+      this.listEventStoreData.push(option.data);
+    }
+    else{
+      const index = this.listEventStoreData.indexOf(option.data);
+      this.listEventStoreData.splice(index, 1);
+    }
+    this.setNewDateWindow(true);
   }
 
   setNewDates(dates: IOnDateChange) {

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.html
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.html
@@ -1,3 +1,3 @@
 <div>
-    <app-event-store [listEventStoreData]="listEventStoreData"></app-event-store>
+    <app-event-store [listEventStoreData]="listEventStoreData" [optionsConfig]="optionsConfig"></app-event-store>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { DataService } from 'src/app/services/data.service';
 import { IEventStoreData } from 'src/app/modules/event-store/event-store/event-store.component';
-import { SettingsService } from 'src/app/services/settings.service';
+import { IOptionConfig } from 'src/app/modules/event-store/option-picker/option-picker.component';
 
 @Component({
   selector: 'app-events',
@@ -11,22 +11,19 @@ import { SettingsService } from 'src/app/services/settings.service';
 export class EventsComponent implements OnInit {
 
   listEventStoreData: IEventStoreData<any, any> [];
+  optionsConfig: IOptionConfig;
 
-  constructor(public data: DataService, private settings: SettingsService) { }
+  constructor(public data: DataService) { }
 
   ngOnInit() {
     this.listEventStoreData = [
-      this.data.getClusterEventData(),
-      this.data.getNodeEventData()
+      this.data.getClusterEventData()
     ];
 
-    this.data.clusterManifest.ensureInitialized().subscribe(() => {
-      if (this.data.clusterManifest.isRepairManagerEnabled) {
-        this.data.repairCollection.ensureInitialized().subscribe(() => {
-          this.listEventStoreData.push(this.data.getRepairTasksData(this.settings));
-        });
-      }
-    });
+    this.optionsConfig = {
+      enableNodes: true,
+      enableRepairTasks: true
+    };
   }
 
 }


### PR DESCRIPTION
The changes introduced in this PR are:

- A couple of tests were reorganized and modified to comply with the new functionality of the option-picker. This had to be done to prevent the PR to fail the E2E tests.
- On the timelineGenerator we add some changes to make it optional to group all of the events of one type by the name of the even type (Cluster, Nodes, Applications, etc.) making it useful when you add more events to one timeline. Also there were some changes to two labels to differentiate the names.
- Reorganization of the events page view by putting the option-picker between the timeline and the detail-list. Also leaving the tabs even if we have one element.
- Add a function to the event store component to correctly add or delete an event type.