### PR TITLE
It appears that is not safe to assume the ordering of events for node ES queries

### DIFF
--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerator.spec.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerator.spec.ts
@@ -211,7 +211,7 @@ describe('TimelineGenerators', () => {
             const data = [deactivate, down];
 
             const events = generator.consume(data, startDate, endDateRange);
-            expect(events.items.length).toBe(2);
+            expect(events.items.length).toBe(1);
             expect(events.potentiallyMissingEvents).toBeFalse();
         });
     });

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -331,7 +331,7 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
   };
 
   generateNodeDisablingEvent(event: NodeEvent) {
-    const label = `Node ${event.nodeName} Disabling`;
+    const label = `Node ${event.nodeName} Disabling with intent ${event.eventProperties.EffectiveDeactivateIntent}`;
     const start = event.eventProperties.StartTime;
     const end = event.timeStamp;
     const item = {
@@ -349,6 +349,7 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
   };
 
     consume(events: NodeEvent[], startOfRange: Date, endOfRange: Date): ITimelineData {
+        events = events.sort((a,b) => Date.parse(b.timeStamp) - Date.parse(a.timeStamp))
 
         const nodeEventMap: Record<string, NodeEvent[]> = {};
 


### PR DESCRIPTION
They can be either newest to oldest or oldest to newest.