### PR TITLE
more responsive image store viewer.

### DIFF
--- a/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
@@ -16,7 +16,7 @@ export class DisplayNameColumnComponent implements DetailBaseComponent {
   constructor() { }
 
     openFolder(): void {
-      this.listSetting.imagestore.expandFolder(this.item.path).subscribe();
+      this.listSetting.imagestore.expandFolder(this.item.path);
     }
 }
 

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.html
@@ -35,6 +35,10 @@
                         {{item.name}}
                     </button>
                 </span>
+                <br>
+                <div *ngIf="imagestoreRoot.isLoadingFolderContent">
+                  Loading folder: {{imagestoreRoot.currentDirectoryBeingLoaded || 'root'}}
+                </div>
             </div>
             <!-- search-text="'Search confined to current directory'" TODO add this input -->
             <app-detail-list [list]="imagestoreRoot.currentFolder.allChildren" [listSettings]="fileListSettings"></app-detail-list>

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
@@ -34,7 +34,7 @@ export class ImagestoreViewerComponent implements OnInit {
   }
 
   openFolder(relativePath: string): void {
-    this.imagestoreRoot.expandFolder(relativePath).subscribe();
+    this.imagestoreRoot.expandFolder(relativePath);
   }
 
 }


### PR DESCRIPTION
image store viewer will not show the current directory being loaded and allow the option to change the directory being loaded now. Previously it would get stuck on whichever directory is currently being opened, which if it is slow can feel unresponsive or broken.