### PR TITLE
improved failed upgrade view and manual upgrade banner

### DIFF
--- a/src/SfxWeb/cypress/fixtures/cluster-page/upgrade/failed-upgrade.json
+++ b/src/SfxWeb/cypress/fixtures/cluster-page/upgrade/failed-upgrade.json
@@ -1,0 +1,105 @@
+{
+  "CodeVersion": "8.2.1571.9590",
+  "ConfigVersion": "4",
+  "UpgradeDomains": [
+      {
+          "Name": "0",
+          "State": "Completed"
+      },
+      {
+          "Name": "1",
+          "State": "Completed"
+      },
+      {
+          "Name": "2",
+          "State": "Completed"
+      },
+      {
+          "Name": "3",
+          "State": "Completed"
+      },
+      {
+          "Name": "4",
+          "State": "Completed"
+      }
+  ],
+  "UpgradeUnits": [
+      {
+          "Name": "0",
+          "State": "Completed"
+      },
+      {
+          "Name": "1",
+          "State": "Completed"
+      },
+      {
+          "Name": "2",
+          "State": "Completed"
+      },
+      {
+          "Name": "3",
+          "State": "Completed"
+      },
+      {
+          "Name": "4",
+          "State": "Completed"
+      }
+  ],
+  "UpgradeState": "RollingForwardCompleted",
+  "NextUpgradeDomain": "",
+  "RollingUpgradeMode": "Monitored",
+  "UpgradeDescription": {
+      "CodeVersion": "8.2.1571.9590",
+      "ConfigVersion": "3",
+      "UpgradeKind": "Rolling",
+      "RollingUpgradeMode": "Monitored",
+      "UpgradeReplicaSetCheckTimeoutInSeconds": 4294967295,
+      "InstanceCloseDelayDurationInSeconds": 4294967295,
+      "ForceRestart": false,
+      "MonitoringPolicy": {
+          "FailureAction": "Rollback",
+          "HealthCheckWaitDurationInMilliseconds": "PT0H5M0S",
+          "HealthCheckStableDurationInMilliseconds": "PT0H5M0S",
+          "HealthCheckRetryTimeoutInMilliseconds": "PT0H40M0S",
+          "UpgradeTimeoutInMilliseconds": "PT16H0M0S",
+          "UpgradeDomainTimeoutInMilliseconds": "PT3H0M0S"
+      },
+      "ClusterHealthPolicy": {
+          "ConsiderWarningAsError": false,
+          "MaxPercentUnhealthyNodes": 100,
+          "MaxPercentUnhealthyApplications": 0,
+          "NodeTypeHealthPolicyMap": []
+      },
+      "EnableDeltaHealthEvaluation": true,
+      "ClusterUpgradeHealthPolicy": {
+          "MaxPercentDeltaUnhealthyNodes": 0,
+          "MaxPercentUpgradeDomainDeltaUnhealthyNodes": 0
+      },
+      "SortOrder": "Default"
+  },
+  "UpgradeDurationInMilliseconds": "PT0H55M4.65033S",
+  "UpgradeDomainDurationInMilliseconds": "PT0H0M0.0804175S",
+  "UnhealthyEvaluations": [],
+  "CurrentUpgradeDomainProgress": {
+      "NodeUpgradeProgressList": []
+  },
+  "CurrentUpgradeUnitsProgress": {
+      "NodeUpgradeProgressList": []
+  },
+  "StartTimestampUtc": "2022-03-10T16:13:59.906Z",
+  "FailureTimestampUtc": "2022-03-10T16:13:59.906Z",
+  "FailureReason": "UpgradeDomainTimeout",
+  "UpgradeDomainProgressAtFailure": {
+      "DomainName": "2",
+      "NodeUpgradeProgressList": [
+        {
+          "NodeName": "_b-hrs-1_2",
+          "UpgradePhase": "Upgrading",
+          "PendingSafetyChecks": [
+
+          ]
+        }
+      ]
+    },
+  "IsNodeByNode": false
+}

--- a/src/SfxWeb/cypress/fixtures/cluster-page/upgrade/manual-mode-upgrade.json
+++ b/src/SfxWeb/cypress/fixtures/cluster-page/upgrade/manual-mode-upgrade.json
@@ -1,0 +1,71 @@
+{
+  "CodeVersion": "7.1.456.9590",
+  "ConfigVersion": "10",
+  "UpgradeDomains": [
+      {
+          "Name": "0",
+          "State": "Completed"
+      },
+      {
+          "Name": "1",
+          "State": "Completed"
+      },
+      {
+          "Name": "2",
+          "State": "Completed"
+      },
+      {
+          "Name": "3",
+          "State": "Completed"
+      },
+      {
+          "Name": "4",
+          "State": "Completed"
+      }
+  ],
+  "UpgradeState": "RollingForwardCompleted",
+  "NextUpgradeDomain": "",
+  "RollingUpgradeMode": "UnmonitoredManual",
+  "UpgradeDescription": {
+      "CodeVersion": "7.1.456.9590",
+      "ConfigVersion": "10",
+      "UpgradeKind": "Rolling",
+      "RollingUpgradeMode": "UnmonitoredManual",
+      "UpgradeReplicaSetCheckTimeoutInSeconds": 4294967295,
+      "InstanceCloseDelayDurationInSeconds": 4294967295,
+      "ForceRestart": false,
+      "MonitoringPolicy": {
+          "FailureAction": "Rollback",
+          "HealthCheckWaitDurationInMilliseconds": "PT0H5M0S",
+          "HealthCheckStableDurationInMilliseconds": "PT0H5M0S",
+          "HealthCheckRetryTimeoutInMilliseconds": "PT0H40M0S",
+          "UpgradeTimeoutInMilliseconds": "PT16H0M0S",
+          "UpgradeDomainTimeoutInMilliseconds": "PT3H0M0S"
+      },
+      "ClusterHealthPolicy": {
+          "ConsiderWarningAsError": false,
+          "MaxPercentUnhealthyNodes": 100,
+          "MaxPercentUnhealthyApplications": 0
+      },
+      "EnableDeltaHealthEvaluation": true,
+      "ClusterUpgradeHealthPolicy": {
+          "MaxPercentDeltaUnhealthyNodes": 0,
+          "MaxPercentUpgradeDomainDeltaUnhealthyNodes": 0
+      },
+      "SortOrder": "Default"
+  },
+  "UpgradeDurationInMilliseconds": "PT0H55M4.49738S",
+  "UpgradeDomainDurationInMilliseconds": "PT0H0M0.0741611S",
+  "UnhealthyEvaluations": [],
+  "CurrentUpgradeDomainProgress": {
+      "DomainName": "",
+      "NodeUpgradeProgressList": []
+  },
+  "StartTimestampUtc": "2020-08-25T18:09:10.960Z",
+  "FailureTimestampUtc": "0001-01-01T00:00:00.000Z",
+  "FailureReason": "None",
+  "UpgradeDomainProgressAtFailure": {
+      "DomainName": "",
+      "NodeUpgradeProgressList": []
+  }
+}

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -86,9 +86,21 @@ context('Cluster page', () => {
       cy.get('[data-cy=upgrade-bar-domain]').within(() => {
         cy.contains('74 milliseconds')
       })
+
+      cy.get('[data-cy=manualmode]').should('not.exist')
+
     })
 
-    it('upgrade in progress - Node by Node', () => {
+    it('upgrade in progress - manual mode', () => {
+      cy.intercept('GET', upgradeProgress_route, { fixture: 'cluster-page/upgrade/manual-mode-upgrade.json' }).as("upgrade");
+      cy.visit('/#/details')
+
+      cy.wait("@upgrade")
+
+      cy.get('[data-cy=manualmode]').should('exist')
+    })
+
+    it.only('upgrade in progress - Node by Node', () => {
       cy.intercept('GET', upgradeProgress_route, { fixture: 'cluster-page/upgrade/upgrade-in-progress-node-by-node.json' }).as("inprogres");
 
       cy.visit('/#/details')
@@ -128,6 +140,27 @@ context('Cluster page', () => {
         cy.wait('@appinfo');
         cy.contains(serviceName)
 
+      })
+    })
+
+    it('failed upgrade', () => {
+      cy.intercept('GET', upgradeProgress_route, { fixture: 'cluster-page/upgrade/failed-upgrade.json' }).as("inprogres");
+
+      cy.visit('/#/details')
+
+      cy.wait("@inprogres")
+
+      cy.get('[data-cy=failedupgrade]').within(() => {
+
+        cy.get('[data-cy=failureoverview]').within(() => {
+          cy.contains('UpgradeDomainTimeout');
+          cy.contains('2022-03-10T16:13:59.906Z');
+        })
+
+        cy.get('[data-cy=failedud]').within(() => {
+          cy.contains('b-hrs-1_2');
+          cy.get('[data-cy=failedphase]')
+        })
       })
     })
 

--- a/src/SfxWeb/cypress/integration/cluster.spec.js
+++ b/src/SfxWeb/cypress/integration/cluster.spec.js
@@ -100,7 +100,7 @@ context('Cluster page', () => {
       cy.get('[data-cy=manualmode]').should('exist')
     })
 
-    it.only('upgrade in progress - Node by Node', () => {
+    it('upgrade in progress - Node by Node', () => {
       cy.intercept('GET', upgradeProgress_route, { fixture: 'cluster-page/upgrade/upgrade-in-progress-node-by-node.json' }).as("inprogres");
 
       cy.visit('/#/details')

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -166,16 +166,21 @@ export interface IRawClusterUpgradeDescription {
         SortOrder: string;
     }
 
+export interface IRawApplicationHealthPolicy {
+  ConsiderWarningAsError: boolean;
+  MaxPercentUnhealthyDeployedApplications: number;
+}
 export interface IRawUpgradeDescription {
-        Name: string;
-        TargetApplicationTypeVersion: string;
-        Parameters: IRawParameter[];
-        UpgradeKind: string;
-        RollingUpgradeMode: string;
-        UpgradeReplicaSetCheckTimeoutInSeconds: string;
-        ForceRestart: boolean;
-        MonitoringPolicy: IRawMonitoringPolicy;
-    }
+  Name: string;
+  TargetApplicationTypeVersion: string;
+  Parameters: IRawParameter[];
+  UpgradeKind: string;
+  RollingUpgradeMode: string;
+  UpgradeReplicaSetCheckTimeoutInSeconds: string;
+  ForceRestart: boolean;
+  MonitoringPolicy: IRawMonitoringPolicy;
+  ApplicationHealthPolicy: IRawApplicationHealthPolicy
+}
 
 export interface IRawUnhealthyEvaluation {
         HealthEvaluation: IRawHealthEvaluation;

--- a/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.html
@@ -9,5 +9,5 @@
 
 <div class="flex-center" style="margin-left: 10px; margin-bottom: 5px;">
   Phase :
-  <app-phase-diagram [items]="progress" [currentIndex]="index"></app-phase-diagram>
+  <app-phase-diagram [items]="progress" [currentIndex]="index" [failed]="failed"></app-phase-diagram>
 </div>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
@@ -13,8 +13,8 @@ import { IProgressStatus } from 'src/app/shared/component/phase-diagram/phase-di
   styleUrls: ['./node-progress.component.scss']
 })
 export class NodeProgressComponent implements OnChanges {
-
-  @Input()node: IRawNodeUpgradeProgress;
+  @Input() failed = false;
+  @Input() node: IRawNodeUpgradeProgress;
 
   public progress: IProgressStatus[] = [];
   public index = -1;
@@ -32,7 +32,7 @@ export class NodeProgressComponent implements OnChanges {
 
     // given the upgrading and post upgrade safety check phases refer to completed state
     // set the index 1 further to consider them completed effectively
-    if (this.index > 1) {
+    if (this.index > 1 && !this.failed) {
       this.index ++;
     }
 

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let node of upgradeDomain.NodeUpgradeProgressList;trackBy: nodeTrackBy" style="border-bottom: 1px solid gray; ">
     <app-collapse-container collapsed="true" [sectionName]="node.NodeName + ' Progress '">
         <div collapse-header>
-            <app-node-progress [node]="node"></app-node-progress>
+            <app-node-progress [node]="node" [failed]="failed"></app-node-progress>
         </div>
         <div collapse-body class="table-responsive" >
             <app-safety-checks [safetyChecks]="node.PendingSafetyChecks"></app-safety-checks>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
@@ -11,7 +11,7 @@ import { IPartitionData } from '../safety-checks/safety-checks.component';
 export class UpgradeDomainProgressComponent{
 
   partitions: Record<string, IPartitionData> = {};
-
+  @Input() failed = false;
   @Input() upgradeDomain: IRawUpgradeDomainProgress | ICurrentUpgradeUnitsProgressInfo;
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
@@ -1,16 +1,22 @@
 <div class="detail-pane">
-  <div *ngIf="upgradeProgress.raw.FailureReason !== 'None'">
-    <h5>Upgrade Failure</h5>
+  <div *ngIf="failed">
+    <div class="layout-container failed">
+      <div class="overview-container">
+        <h5>Upgrade Failure Overview</h5>
+        <app-essential-item *ngFor="let item of failedUpgradeItems; let l = last" [item]="item" [underline]="false">
+        </app-essential-item>
+      </div>
 
-    <!-- {{}} -->
+      <div *ngIf="upgradeProgress.raw.UpgradeDomainProgressAtFailure?.NodeUpgradeProgressList.length > 0"
+        data-cy="failedud" class="node-list">
+        <h5 style="text-align: center;">Nodes Upgrading Status at Failure</h5>
+        <app-upgrade-domain-progress [failed]="true"
+          [upgradeDomain]="upgradeProgress.raw.UpgradeDomainProgressAtFailure">
+        </app-upgrade-domain-progress>
+      </div>
 
-    <div *ngIf="upgradeProgress.raw.UpgradeDomainProgressAtFailure?.NodeUpgradeProgressList.length > 0"
-      data-cy="failedud" style="flex: 2; min-width: 500px;">
-      <h5 style="text-align: center;">Nodes status</h5>
-      <app-upgrade-domain-progress
-        [upgradeDomain]="upgradeProgress.raw.UpgradeDomainProgressAtFailure">
-      </app-upgrade-domain-progress>
     </div>
+
 
     <div class="detail-pane" *ngIf="upgradeProgress.unhealthyEvaluations.length > 0">
       <h4>Unhealthy Evaluations (Upgrade)</h4>
@@ -19,7 +25,10 @@
     </div>
   </div>
 
-  <div style="display: flex; width: 100%; flex-wrap: wrap; justify-content: space-around;">
+  <div class="layout-container">
+    <app-warning *ngIf="manual" description="Unmonitored manual mode needs manual intervention after every upgrade on an update domain,
+                              to kick off the upgrade on the next update domain. No Service Fabric health checks are performed.
+                              The administrator performs the health or status checks before starting the upgrade in the next update domain."></app-warning>
     <div class="domain-container" *ngIf="upgradeProgress.upgradeDomains.length > 0">
       <h5>{{upgradeProgress.isUDUpgrade ? 'Upgrade Domain' : 'Node'}} Progress</h5>
       <app-upgrade-progress style="align-self: center;" [upgradeDomains]="upgradeProgress.upgradeDomains"
@@ -62,8 +71,14 @@
       </div>
     </div>
 
+    <div *ngIf="healthPolicy.length > 0">
+      <h5>Monitoring Policy</h5>
+      <app-essential-item *ngFor="let item of healthPolicy; let l = last" [item]="item" [underline]="false">
+      </app-essential-item>
+    </div>
+
     <div *ngIf="upgradeProgress.isUpgrading && upgradeProgress.nodesInProgress?.NodeUpgradeProgressList.length > 0"
-      data-cy="currentud" style="flex: 2; min-width: 500px;">
+      data-cy="currentud" class="node-list">
       <h5 style="text-align: center;">Nodes status</h5>
       <app-upgrade-domain-progress [upgradeDomain]="upgradeProgress.nodesInProgress">
       </app-upgrade-domain-progress>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
@@ -1,4 +1,24 @@
 <div class="detail-pane">
+  <div *ngIf="upgradeProgress.raw.FailureReason !== 'None'">
+    <h5>Upgrade Failure</h5>
+
+    <!-- {{}} -->
+
+    <div *ngIf="upgradeProgress.raw.UpgradeDomainProgressAtFailure?.NodeUpgradeProgressList.length > 0"
+      data-cy="failedud" style="flex: 2; min-width: 500px;">
+      <h5 style="text-align: center;">Nodes status</h5>
+      <app-upgrade-domain-progress
+        [upgradeDomain]="upgradeProgress.raw.UpgradeDomainProgressAtFailure">
+      </app-upgrade-domain-progress>
+    </div>
+
+    <div class="detail-pane" *ngIf="upgradeProgress.unhealthyEvaluations.length > 0">
+      <h4>Unhealthy Evaluations (Upgrade)</h4>
+      <app-detail-list [list]="upgradeProgress.unhealthyEvaluations"
+        [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></app-detail-list>
+    </div>
+  </div>
+
   <div style="display: flex; width: 100%; flex-wrap: wrap; justify-content: space-around;">
     <div class="domain-container" *ngIf="upgradeProgress.upgradeDomains.length > 0">
       <h5>{{upgradeProgress.isUDUpgrade ? 'Upgrade Domain' : 'Node'}} Progress</h5>
@@ -42,7 +62,8 @@
       </div>
     </div>
 
-    <div *ngIf="upgradeProgress.isUpgrading && upgradeProgress.nodesInProgress?.NodeUpgradeProgressList.length > 0" data-cy="currentud" style="flex: 2; min-width: 500px;">
+    <div *ngIf="upgradeProgress.isUpgrading && upgradeProgress.nodesInProgress?.NodeUpgradeProgressList.length > 0"
+      data-cy="currentud" style="flex: 2; min-width: 500px;">
       <h5 style="text-align: center;">Nodes status</h5>
       <app-upgrade-domain-progress [upgradeDomain]="upgradeProgress.nodesInProgress">
       </app-upgrade-domain-progress>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.html
@@ -1,7 +1,7 @@
 <div class="detail-pane">
-  <div *ngIf="failed">
+  <div *ngIf="failed" data-cy="failedupgrade">
     <div class="layout-container failed">
-      <div class="overview-container">
+      <div class="overview-container" data-cy="failureoverview">
         <h5>Upgrade Failure Overview</h5>
         <app-essential-item *ngFor="let item of failedUpgradeItems; let l = last" [item]="item" [underline]="false">
         </app-essential-item>
@@ -26,9 +26,11 @@
   </div>
 
   <div class="layout-container">
-    <app-warning *ngIf="manual" description="Unmonitored manual mode needs manual intervention after every upgrade on an update domain,
-                              to kick off the upgrade on the next update domain. No Service Fabric health checks are performed.
-                              The administrator performs the health or status checks before starting the upgrade in the next update domain."></app-warning>
+    <app-warning *ngIf="manual" data-cy="manualmode"
+      description="Unmonitored manual mode needs manual intervention after every upgrade on an update domain,
+                                  to kick off the upgrade on the next update domain. No Service Fabric health checks are performed.
+                                  The administrator performs the health or status checks before starting the upgrade in the next update domain.">
+    </app-warning>
     <div class="domain-container" *ngIf="upgradeProgress.upgradeDomains.length > 0">
       <h5>{{upgradeProgress.isUDUpgrade ? 'Upgrade Domain' : 'Node'}} Progress</h5>
       <app-upgrade-progress style="align-self: center;" [upgradeDomains]="upgradeProgress.upgradeDomains"
@@ -72,7 +74,7 @@
     </div>
 
     <div *ngIf="healthPolicy.length > 0">
-      <h5>Monitoring Policy</h5>
+      <h5>Monitoring And Health Policies</h5>
       <app-essential-item *ngFor="let item of healthPolicy; let l = last" [item]="item" [underline]="false">
       </app-essential-item>
     </div>

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.scss
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.scss
@@ -17,8 +17,30 @@ h5 {
 
 .overview-container {
   flex: 1;
-  min-width: 400px;
-  max-width: 600px;
+  min-width: 350px;
+  max-width: 400px;
   margin-right: 10px;
   margin-left: 10px;
+}
+
+
+.layout-container {
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-around;
+
+  &.failed {
+    border: 2px solid var(--badge-error);
+    padding: 10px;
+    border-left: 10px solid var(--badge-error);
+    border-radius: 5px;
+    margin-bottom: 10px;
+  }
+}
+
+
+.node-list {
+  flex: 2;
+  min-width: 500px;
 }

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
@@ -4,6 +4,7 @@ import { ClusterUpgradeProgress } from 'src/app/Models/DataModels/Cluster';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile/essential-health-tile.component';
 import { SettingsService } from 'src/app/services/settings.service';
+import { TimeUtils } from 'src/app/Utils/TimeUtils';
 
 @Component({
   selector: 'app-upgrade-info',
@@ -19,6 +20,10 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
   essentialItems: IEssentialListItem[] = [];
   essentialItems2: IEssentialListItem[] = [];
 
+  failedUpgradeItems: IEssentialListItem[] = [];
+
+  healthPolicy: IEssentialListItem[] = [];
+
   startTimeEssentialItem: IEssentialListItem;
 
   helpText = '';
@@ -28,6 +33,9 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
   // this is to avoid confusion
   upgradeDuration: IEssentialListItem;
 
+  failed: boolean = false;
+  manual: boolean = false;
+
   constructor(private settings: SettingsService) { }
 
   ngOnInit() {
@@ -35,8 +43,62 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
   }
 
   ngOnChanges(): void {
+    this.manual = this.upgradeProgress.raw.RollingUpgradeMode === "UnmonitoredManual ";
+    this.failed = this.upgradeProgress.raw.FailureReason !== 'None';
+
+    if(this.failed) {
+      this.failedUpgradeItems = [
+        {
+          descriptionName: 'Failure Reason',
+          copyTextValue: this.upgradeProgress.raw.FailureReason,
+          displayText: this.upgradeProgress.raw.FailureReason,
+        },
+        {
+          descriptionName: 'Failure Timestamp',
+          copyTextValue: this.upgradeProgress.raw.FailureTimestampUtc,
+          displayText: this.upgradeProgress.raw.FailureTimestampUtc,
+        },
+      ]
+
+      const domainName = this.upgradeProgress.raw.UpgradeDomainProgressAtFailure.DomainName;
+      if(domainName) {
+        this.failedUpgradeItems.push({
+          descriptionName: 'Failure Domain',
+          copyTextValue: domainName,
+          displayText: domainName,
+        })
+      }
+    }
+
+    const monitoringPolicy = this.upgradeProgress.raw?.UpgradeDescription?.MonitoringPolicy;
+
+    if(monitoringPolicy) {
+      const healthCheckRetryTimeout = TimeUtils.getDuration(monitoringPolicy.HealthCheckRetryTimeoutInMilliseconds);
+      const healthCheckStableDuration = TimeUtils.getDuration(monitoringPolicy.HealthCheckStableDurationInMilliseconds);
+      const healthCheckWaitDuration = TimeUtils.getDuration(monitoringPolicy.HealthCheckWaitDurationInMilliseconds);
+
+      this.healthPolicy = [
+        {
+          descriptionName: 'Health Check Wait Duration',
+          copyTextValue: healthCheckWaitDuration,
+          displayText: healthCheckWaitDuration
+        },
+        {
+          descriptionName: 'Health Check Stable Duration',
+          copyTextValue: healthCheckStableDuration,
+          displayText: healthCheckStableDuration
+        },
+        {
+          descriptionName: 'Health Check Retry Time Out',
+          copyTextValue: healthCheckRetryTimeout,
+          displayText: healthCheckRetryTimeout
+        },
+      ]
+    }
+
+
     let entitySpecificInformation = [];
-    if (this.upgradeProgress instanceof  ClusterUpgradeProgress) {
+    if (this.upgradeProgress instanceof ClusterUpgradeProgress) {
       entitySpecificInformation = [
         {
           descriptionName: 'Code Version',
@@ -49,6 +111,30 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
           displayText: this.upgradeProgress.raw.ConfigVersion,
         }
       ];
+
+      const clusterHealthPolicy = this.upgradeProgress.raw.UpgradeDescription.ClusterHealthPolicy;
+
+      const considerWarningAsError = clusterHealthPolicy.ConsiderWarningAsError;
+      const maxPercentUnhealthyNodes = `${clusterHealthPolicy.MaxPercentUnhealthyNodes}%`;
+      const maxPercentUnhealthyApps = `${clusterHealthPolicy.MaxPercentUnhealthyApplications}%`;
+
+      this.healthPolicy = this.healthPolicy.concat([
+        {
+          descriptionName: 'Treat Warnings As Errors',
+          copyTextValue: considerWarningAsError.toString(),
+          displayText: considerWarningAsError.toString()
+        },
+        {
+          descriptionName: 'Max Unhealthy Nodes %',
+          copyTextValue: maxPercentUnhealthyNodes,
+          displayText: maxPercentUnhealthyNodes
+        },
+        {
+          descriptionName: 'Max Unhealthy Applications %',
+          copyTextValue: maxPercentUnhealthyApps,
+          displayText: maxPercentUnhealthyApps
+        },
+      ])
     }else if (this.upgradeProgress instanceof ApplicationUpgradeProgress) {
       entitySpecificInformation = [
         {
@@ -57,6 +143,26 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
           displayText: this.upgradeProgress.raw.TargetApplicationTypeVersion,
         }
       ];
+
+      const applicationHealthPolicy = this.upgradeProgress.raw?.UpgradeDescription?.ApplicationHealthPolicy;
+
+      if(applicationHealthPolicy) {
+        const considerWarningAsError = applicationHealthPolicy.ConsiderWarningAsError;
+        const maxPercentUnhealthyApps = `${applicationHealthPolicy.MaxPercentUnhealthyDeployedApplications}%`;
+
+        this.healthPolicy = this.healthPolicy.concat([
+          {
+            descriptionName: 'Treat Warnings As Errors',
+            copyTextValue: considerWarningAsError.toString(),
+            displayText: considerWarningAsError.toString()
+          },
+          {
+            descriptionName: 'Max Unhealthy Deployed Applications %',
+            copyTextValue: maxPercentUnhealthyApps,
+            displayText: maxPercentUnhealthyApps
+          },
+        ])
+      }
     }
 
     this.essentialItems = entitySpecificInformation.concat([
@@ -104,5 +210,7 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
         displayText: this.upgradeProgress.upgradeDuration
       };
     }
+
+    console.log(this)
   }
 }

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
@@ -1,16 +1,20 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { ApplicationUpgradeProgress } from 'src/app/Models/DataModels/Application';
 import { ClusterUpgradeProgress } from 'src/app/Models/DataModels/Cluster';
+import { ListSettings } from 'src/app/Models/ListSettings';
 import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile/essential-health-tile.component';
+import { SettingsService } from 'src/app/services/settings.service';
 
 @Component({
   selector: 'app-upgrade-info',
   templateUrl: './upgrade-info.component.html',
   styleUrls: ['./upgrade-info.component.scss']
 })
-export class UpgradeInfoComponent implements OnChanges {
+export class UpgradeInfoComponent implements OnChanges, OnInit {
 
   @Input() upgradeProgress: ClusterUpgradeProgress | ApplicationUpgradeProgress;
+
+  upgradeProgressUnhealthyEvaluationsListSettings: ListSettings;
 
   essentialItems: IEssentialListItem[] = [];
   essentialItems2: IEssentialListItem[] = [];
@@ -24,7 +28,12 @@ export class UpgradeInfoComponent implements OnChanges {
   // this is to avoid confusion
   upgradeDuration: IEssentialListItem;
 
-  constructor() { }
+  constructor(private settings: SettingsService) { }
+
+  ngOnInit() {
+    this.upgradeProgressUnhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings('clusterUpgradeProgressUnhealthyEvaluations');
+  }
+
   ngOnChanges(): void {
     let entitySpecificInformation = [];
     if (this.upgradeProgress instanceof  ClusterUpgradeProgress) {

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
@@ -43,7 +43,7 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
   }
 
   ngOnChanges(): void {
-    this.manual = this.upgradeProgress.raw.RollingUpgradeMode === "UnmonitoredManual ";
+    this.manual = this.upgradeProgress.raw.RollingUpgradeMode === "UnmonitoredManual";
     this.failed = this.upgradeProgress.raw.FailureReason !== 'None';
 
     if(this.failed) {
@@ -112,29 +112,31 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
         }
       ];
 
-      const clusterHealthPolicy = this.upgradeProgress.raw.UpgradeDescription.ClusterHealthPolicy;
+      const clusterHealthPolicy = this.upgradeProgress.raw?.UpgradeDescription?.ClusterHealthPolicy;
 
-      const considerWarningAsError = clusterHealthPolicy.ConsiderWarningAsError;
-      const maxPercentUnhealthyNodes = `${clusterHealthPolicy.MaxPercentUnhealthyNodes}%`;
-      const maxPercentUnhealthyApps = `${clusterHealthPolicy.MaxPercentUnhealthyApplications}%`;
+      if(clusterHealthPolicy) {
+        const considerWarningAsError = clusterHealthPolicy.ConsiderWarningAsError;
+        const maxPercentUnhealthyNodes = `${clusterHealthPolicy.MaxPercentUnhealthyNodes}%`;
+        const maxPercentUnhealthyApps = `${clusterHealthPolicy.MaxPercentUnhealthyApplications}%`;
 
-      this.healthPolicy = this.healthPolicy.concat([
-        {
-          descriptionName: 'Treat Warnings As Errors',
-          copyTextValue: considerWarningAsError.toString(),
-          displayText: considerWarningAsError.toString()
-        },
-        {
-          descriptionName: 'Max Unhealthy Nodes %',
-          copyTextValue: maxPercentUnhealthyNodes,
-          displayText: maxPercentUnhealthyNodes
-        },
-        {
-          descriptionName: 'Max Unhealthy Applications %',
-          copyTextValue: maxPercentUnhealthyApps,
-          displayText: maxPercentUnhealthyApps
-        },
-      ])
+        this.healthPolicy = this.healthPolicy.concat([
+          {
+            descriptionName: 'Treat Warnings As Errors',
+            copyTextValue: considerWarningAsError.toString(),
+            displayText: considerWarningAsError.toString()
+          },
+          {
+            descriptionName: 'Max Unhealthy Nodes %',
+            copyTextValue: maxPercentUnhealthyNodes,
+            displayText: maxPercentUnhealthyNodes
+          },
+          {
+            descriptionName: 'Max Unhealthy Applications %',
+            copyTextValue: maxPercentUnhealthyApps,
+            displayText: maxPercentUnhealthyApps
+          },
+        ])
+      }
     }else if (this.upgradeProgress instanceof ApplicationUpgradeProgress) {
       entitySpecificInformation = [
         {

--- a/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.html
+++ b/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.html
@@ -1,7 +1,7 @@
 
 <div class="flex-center" [ngClass]="wrapperClass">
   <ng-container  *ngFor="let phase of progress; let l = last;">
-    <div class="progress-item hover-row" [ngClass]="cssClass[phase.state]" >
+    <div class="progress-item hover-row" [ngClass]="cssClass[phase.state]" [attr.data-cy]="cssClass[phase.state] + 'phase'" >
       <div class="text-description" >{{phase.name}}
       </div>
       <div>

--- a/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.scss
+++ b/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.scss
@@ -27,11 +27,15 @@
 }
 
 .in-progress {
-  border-color: #0075c9;
+  border-color: var(--accent-darkblue);
 }
 
 .done {
   border-color: green;
+}
+
+.failed {
+  border-color: var(--badge-error);
 }
 
 .arrow {

--- a/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.ts
+++ b/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.ts
@@ -11,7 +11,7 @@ export class PhaseDiagramComponent implements OnChanges {
   @Input() items: IProgressStatus[];
   @Input() currentIndex = 0;
   @Input() vertical = false;
-
+  @Input() failed: boolean = false; //treat in progress phases as failed
   public progress: IProgressStatusWithIndex[] = [];
   public wrapperClass = '';
 
@@ -27,6 +27,7 @@ export class PhaseDiagramComponent implements OnChanges {
   public cssClass = {
     '-1': 'done',
     0: 'in-progress',
+    '-2': 'failed',
     1: 'pending'
   };
 
@@ -53,7 +54,7 @@ export class PhaseDiagramComponent implements OnChanges {
     }else if (diff <= -1) {
       return -1;
     }else{
-      return 0;
+      return this.failed ? -2 : 0;
     }
   }
 

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.html
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.html
@@ -6,28 +6,6 @@
         </div>
         <div collapse-body>
             <app-upgrade-info [upgradeProgress]="clusterUpgradeProgress"></app-upgrade-info>
-
-            <!-- <div *ngIf="clusterUpgradeProgress.raw.FailureReason !== 'None'">
-                <h4>Upgrade Failure</h4>
-                <div class="table-responsive">
-                    <table class="table detail-table">
-                        <tbody>
-                            <tr>
-                                <th>Failure Timestamp UTC</th>
-                                <td>{{clusterUpgradeProgress.failureTimestampUtc}}</td>
-                            </tr>
-                            <tr>
-                                <th>Failure Reason</th>
-                                <td><img class="badge-icon" src="images/badge-error.svg"><span> {{clusterUpgradeProgress.raw.FailureReason}}</span></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-            <div class="detail-pane" *ngIf="clusterUpgradeProgress.unhealthyEvaluations.length > 0">
-                <h4>Unhealthy Evaluations (Upgrade)</h4>
-                <app-detail-list [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></app-detail-list>
-            </div> -->
         </div>
     </app-collapse-container>
 </div>

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.html
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.html
@@ -7,7 +7,7 @@
         <div collapse-body>
             <app-upgrade-info [upgradeProgress]="clusterUpgradeProgress"></app-upgrade-info>
 
-            <div *ngIf="clusterUpgradeProgress.raw.FailureReason !== 'None'">
+            <!-- <div *ngIf="clusterUpgradeProgress.raw.FailureReason !== 'None'">
                 <h4>Upgrade Failure</h4>
                 <div class="table-responsive">
                     <table class="table detail-table">
@@ -27,7 +27,7 @@
             <div class="detail-pane" *ngIf="clusterUpgradeProgress.unhealthyEvaluations.length > 0">
                 <h4>Unhealthy Evaluations (Upgrade)</h4>
                 <app-detail-list [list]="clusterUpgradeProgress.unhealthyEvaluations" [listSettings]="upgradeProgressUnhealthyEvaluationsListSettings"></app-detail-list>
-            </div>
+            </div> -->
         </div>
     </app-collapse-container>
 </div>


### PR DESCRIPTION
Currently the failed upgrade view is below the latest upgrade and does not match the layout for the overall upgrade scenario.

![improved-failed-upgrade-view](https://user-images.githubusercontent.com/15344718/161650104-aceca63a-b7e9-4a92-aa81-94a1834bda69.PNG)

Add a banner for when an upgrade is in manual mode to make it more clear that intervention is required.
![manual-mode-banner](https://user-images.githubusercontent.com/15344718/161651288-661954b5-61b6-4505-925f-c4a35aeff038.PNG)

