### PR TITLE
Change rotation of the arrow symbol

### DIFF
--- a/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.html
+++ b/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.html
@@ -19,7 +19,7 @@
         <div class="self hide-nested hover-row flex-center" [ngClass]="{ 'raised-z-index': i === higherZIndex}">
             <span  [ngStyle]="{ 'paddingLeft': child.paddingLeftPx }"></span>
             <div class="expander" *ngIf="!child.hasExpander"></div>
-            <button tabindex="0" class="expander icon mif-chevron-thin-down" aria-hidden="false" role="button"
+            <button tabindex="0" class="expander icon mif-chevron-thin-right" aria-hidden="false" role="button"
                     (click)="child.toggle(); $event.stopPropagation()" *ngIf="child.hasExpander"
                     [ngClass]="{ 'rotated': child.isExpanded }"
                     style="display: inline-block;" [title]="child.isCollapsed ? 'Expand Children' : 'Collapse Children'">

--- a/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.scss
+++ b/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.scss
@@ -38,7 +38,7 @@ button {
       transition: 0.25s transform;
 
       &.rotated {
-        transform: rotate(-90deg);
+        transform: rotate(90deg);
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/microsoft/service-fabric-explorer/issues/732

This PR will make the right arrow when the tree item is collapsed and rotate down when expanded