### PR TITLE
Fixing instructions for installing nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Service Fabric Explorer consists of two main components, an AngularJS based appl
 To develop Service Fabric Explorer, the following components are required.
 
 * Git: https://git-scm.com/
-* Node.js (Latest is preferred): https://nodejs.org/
+* Node.js (use LTS version): https://nodejs.org/
 
 The recommended IDE for Service Fabric Explorer development is VSCode because VSCode is a cross-platform editor, which supports Windows, Linux and macOS. But you can use whatever editor to develop. 
 


### PR DESCRIPTION
As the title says. 
While onboarding on the SFX repo I got an error similar to this one: https://stackoverflow.com/questions/68042264/upgrade-from-angular-11-to-12-causes-peer-dependency-conflict

The problem is solved by downgrading version of nodejs to be LTS (long term support).