### PR TITLE
Fix for #782

### DIFF
--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -429,7 +429,7 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
                     enableFilter: true,
                     getDisplayHtml: (item) => (!item.raw.category ? 'Operational' : item.raw.category)
                 }),
-            new ListColumnSetting('raw.timeStampString', 'Timestamp', {sortPropertyPaths: ['raw.timestamp']}),
+            new ListColumnSetting('raw.timeStampString', 'Timestamp', {sortPropertyPaths: ['raw.timeStamp']}),
             new ListColumnSetting('raw.timeStamp', 'Timestamp(UTC)')],
             [
                 new ListColumnSettingWithEventStoreFullDescription(),


### PR DESCRIPTION
I can't figure out how to run a debug build of SFX locally in a manner that allows it to also interact with an already-running SF dev box cluster so it can pull data, but I believe this to be a fix for the timestamp sorting issue in #782 - the string-based path to the property it sorts on had incorrect casing.