### PR TITLE
Fix for scaling validation issue #777

### DIFF
--- a/src/SfxWeb/src/app/views/service/scale-service/scale-service.component.ts
+++ b/src/SfxWeb/src/app/views/service/scale-service/scale-service.component.ts
@@ -33,7 +33,7 @@ export class ScaleServiceComponent implements OnInit {
     };
 
     this.form = this.formBuilder.group({
-      count: [(this.service.description.raw as IRawStatelessServiceDescription).InstanceCount, [Validators.required, Validators.pattern('^(?:-1|[1-9]\d*)$')]],
+      count: [(this.service.description.raw as IRawStatelessServiceDescription).InstanceCount, [Validators.required, Validators.pattern('^(?:-1|[1-9]\\d*)$')]],
     });
   }
 


### PR DESCRIPTION
Unable to scale beyond 9 services because of validation pattern error. Because the pattern is passed as a string literal to Angular and the regex query engine required literal backslash characters when escaping, double backslashes are required in order to support characters like ```\d```.

Fix for #777 