### PR TITLE
Set events timeline to reflect isUTC flag at initialization

### DIFF
--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -67,6 +67,10 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
       }
     });
 
+    this.timeline.setOptions({
+      moment: this.isUTC ? moment.utc : moment
+    });
+
     this.timeline.on('click', data => {
       this.itemClicked.emit(data.item)
     })

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -73,7 +73,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
 
     this.timeline.on('click', data => {
       this.itemClicked.emit(data.item)
-    })
+    });
 
     this.updateList(this.events);
   }


### PR DESCRIPTION
`viz-timeline` package seems to default to UTC if otherwise unspecified, but `event-store-timeline.component.ts` defaults to `isUTC 
 = false`. While these eventually align after the user toggles the UTC checkbox (`isUTC = true` now), it means the timeline shifts back to UTC when the box is again unchecked, which is how it should have started initially before the toggling.

This simply sets the timezone option explicitly at after-view initialization instead of waiting for the user to set it via the checkbox toggle fixing #810 