### PR TITLE
Timeline improvements

### DIFF
--- a/src/SfxWeb/src/Styles/_vis.scss
+++ b/src/SfxWeb/src/Styles/_vis.scss
@@ -220,7 +220,7 @@
 }
 //pregenerated css colors
 
-.vis-item, .vis-item-content {
+.vis-item, .vis-item-content, .rca-summary-key {
 
   &.color-FFB399 {
     background-color: #FFB399;

--- a/src/SfxWeb/src/Styles/_vis.scss
+++ b/src/SfxWeb/src/Styles/_vis.scss
@@ -143,7 +143,7 @@
   background-color: var(--primary-background-color) !important;;
   border-radius: var(--primary-border-radius) !important;;
   line-height: 1;
-
+  z-index: 100;
   table {
     word-break: break-all;
   }

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
 // -----------------------------------------------------------------------------

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -81,9 +81,9 @@ export class EventStoreUtils {
         const outline = EventStoreUtils.internalToolTipFormatterObject(data);
         return `<div class="inner-tooltip">
                   ${title.length > 0 ? title + '<br>' : ''}
-                  Start: ${start}
+                  Start (local time): ${start}
                   <br>
-                  ${ end ? 'End: ' + end + '<br>' : ''}
+                  ${ end ? 'End (local time): ' + end + '<br>' : ''}
                   <b>
                     Details
                   </b>

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.scss
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.scss
@@ -1,9 +1,11 @@
 table {
-  button {
-    border-radius: var(--primary-border-radius);
-    padding: 5px;
-    flex: 1;
-    text-align: left;
+  th {
+    button {
+      border-radius: var(--primary-border-radius);
+      padding: 5px;
+      flex: 1;
+      text-align: left;
+    }
   }
 }
 

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.html
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.html
@@ -6,8 +6,12 @@
     </div>
 
     <div class="button-container">
-        <ng-content select="[buttons]"></ng-content>
+      <ng-content select="[buttons]"></ng-content>
 
+      <label class="toggle-wrapper" [attr.aria-label]="(isUTC ? 'Untoggle' : 'Toggle') + ' to use ' + (isUTC ? 'Local Time' : 'UTC time') ">
+        UTC time
+        <app-toggle [(state)]="isUTC" (stateChange)="flipTimeZone($event)" ></app-toggle>
+      </label>
 
         <button class="simple-button flip-button" (click)="flipShowControls();">
             <span class="mif-arrow-drop-up mif-2x" style="transition: .5s;"
@@ -45,12 +49,6 @@
             ngbTooltip="Move to the newest event in the time range.">
                 Move To Newest Event
             </button>
-
-            <div class="margined">
-              <label style="width: 105px; display: flex; gap: 10px; align-items: center;" [attr.aria-label]="(isUTC ? 'Untoggle' : 'Toggle') + ' to use ' + (isUTC ? 'Local Time' : 'UTC time') ">
-                <input type="checkbox" [(ngModel)]="isUTC" (ngModelChange)="flipTimeZone()">
-                Use UTC time</label>
-            </div>
         </ng-container>
     </div>
 </div>

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -68,6 +68,9 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
       this.itemClicked.emit(data.item)
     })
 
+    this.timeline.setOptions({
+      moment: this.isUTC ? moment.utc : moment
+    });
     this.updateList(this.events);
   }
 
@@ -80,9 +83,9 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
     })
   }
 
-  public flipTimeZone() {
+  public flipTimeZone(utc: boolean) {
     this.timeline.setOptions({
-      moment: this.isUTC ? moment : moment.utc
+      moment: utc ? moment.utc : moment
     });
   }
 
@@ -162,6 +165,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
           }
         },
         tooltip: {
+          followMouse: true,
           template: (itemData) => {
             let content = itemData.title;
 

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -68,9 +68,8 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
       this.itemClicked.emit(data.item)
     })
 
-    this.timeline.setOptions({
-      moment: this.isUTC ? moment.utc : moment
-    });
+    this.flipTimeZone(this.isUTC);
+
     this.updateList(this.events);
   }
 


### PR DESCRIPTION
Fixing a couple timeline issues.
-added back the colors for RCA
-added a prefix to specify local time in tool tips
-fixed the expand button taking too much width
-tooltips follow the mouse now
-moved the toggle to use the component as other places for toggling
-moved the UTC toggle out
-fixed the initial state of the toggle

![timeline](https://user-images.githubusercontent.com/15344718/218583342-4491aa84-8a91-4321-bb6f-f9e7b82c0fe4.PNG)
