### PR TITLE
Display Description field for Node Deactivation Info (10.0)

### DIFF
--- a/src/SfxWeb/cypress/e2e/node.cy.js
+++ b/src/SfxWeb/cypress/e2e/node.cy.js
@@ -96,10 +96,24 @@ context('node page', () => {
 
         cy.get('[data-cy=deactivated]').within(() => {
           cy.contains("86fa6852ad467a903afbbc67edc16b66");
+          cy.contains("This is a description").should('have.length', 1);
           cy.get(seedNodeQuoromRef).should('not.exist');
         })
       })
 
+      it('deactivated - no description', () => {
+        addRoute("deactivatedNode", "node-page/deactivated-node-seed-node-quorom.json", apiUrl(`/Nodes/${nodeName}/?*`));
+        addRoute(FIXTURE_NODES, "node-page/node-list-seed-node-quorom.json", nodes_route);
+
+        cy.visit(`/#/node/${nodeName}`);
+
+        cy.wait("@getdeactivatedNode");
+
+        cy.get('[data-cy=deactivated]').within(() => {
+          cy.contains("This is a description").should('not.exist');
+        })
+      })
+      
       it('deactivated - show seed node quorom warning', () => {
         addRoute("deactivatedNode", "node-page/deactivated-node-seed-node-quorom.json", apiUrl(`/Nodes/${nodeName}/?*`));
         addRoute(FIXTURE_NODES, "node-page/node-list-seed-node-quorom.json", nodes_route);

--- a/src/SfxWeb/cypress/fixtures/node-page/deactivated-node.json
+++ b/src/SfxWeb/cypress/fixtures/node-page/deactivated-node.json
@@ -23,7 +23,8 @@
                     "Id": "86fa6852ad467a903afbbc67edc16b66",
                     "NodeDeactivationTaskType": "Client"
                 },
-                "NodeDeactivationIntent": "Pause"
+                "NodeDeactivationIntent": "Pause",
+                "NodeDeactivationDescription": "This is a description"
             }
         ],
         "PendingSafetyChecks": []

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -83,7 +83,7 @@ export class Node extends DataModelBase<IRawNode> {
 
     public get hasDeactivatingDescription(): boolean {
         return this.isDeactivating && (
-            this.raw.NodeDeactivationInfo.NodeDeactivationTask.some(task => task.NodeDeactivationDescription.length)
+            this.raw.NodeDeactivationInfo.NodeDeactivationTask.some(task => task.NodeDeactivationDescription?.length)
         );
     }
     

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -1,4 +1,4 @@
-import { IRawNode, IRawNodeLoadInformation, IRawNodeLoadMetricInformation, IRawNodeHealth, NodeStatus } from '../RawDataTypes';
+import { IRawNode, IRawNodeLoadInformation, IRawNodeLoadMetricInformation, IRawNodeHealth, NodeStatus, IRawNodeDeactivationTask } from '../RawDataTypes';
 import { IDecorators, DataModelBase } from './Base';
 import { DataService } from 'src/app/services/data.service';
 import { HealthStateFilterFlags, IClusterHealthChunkQueryDescription, IHealthStateFilter } from '../HealthChunkRawDataTypes';
@@ -81,6 +81,12 @@ export class Node extends DataModelBase<IRawNode> {
         return this.raw.NodeDeactivationInfo.NodeDeactivationStatus !== 'None';
     }
 
+    public get hasDeactivatingDescription(): boolean {
+        return this.isDeactivating && (
+            this.raw.NodeDeactivationInfo.NodeDeactivationTask.some(task => task.NodeDeactivationDescription.length)
+        );
+    }
+    
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IHealthStateFilter {
         // To get all deployed applications on this node, we need to add deployed application filters in all existing application filters.
         // (There will be at least one application filter there by default which is returned by DataService.getInitialClusterHealthChunkQueryDescription)

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -448,7 +448,7 @@ export interface IRawNodeDeactivationInfo {
 export interface IRawNodeDeactivationTask {
         NodeDeactivationTaskId: IRawNodeDeactivationTaskId;
         NodeDeactivationIntent: string;
-        NodeDeactivationDescription: string;
+        NodeDeactivationDescription?: string;
     }
 export interface IRawSchedule {
         ScheduleKind: string;

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -448,6 +448,7 @@ export interface IRawNodeDeactivationInfo {
 export interface IRawNodeDeactivationTask {
         NodeDeactivationTaskId: IRawNodeDeactivationTaskId;
         NodeDeactivationIntent: string;
+        NodeDeactivationDescription: string;
     }
 export interface IRawSchedule {
         ScheduleKind: string;

--- a/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.html
+++ b/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.html
@@ -12,7 +12,7 @@
   </div>
 
   <div *ngIf="deactivationInfo.NodeDeactivationTask.length > 0" style="flex-grow: 1;
-    margin-left: 15px; min-width: 400px;">
+    margin-left: 15px; min-width: 400px; max-width: 1120px">
     <h5 class="underline title" >Deactivation Tasks</h5>
     <app-detail-list [list]="deactivationInfo.NodeDeactivationTask" [listSettings]="settings" [showTopOptions]="false"></app-detail-list>
   </div>

--- a/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
+++ b/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
@@ -15,7 +15,7 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
 
   public readonly seedNodeQuorumMessage = "This node deactivation is waiting on a Seed Node Quorom safety check. If this deactivation is going for an irregular amount of time, consider referring to the following TSG to potentially continue progress for this deactivation."
 
-  @Input() node: Node;
+  @Input() hasDescription: boolean = false;
   @Input() deactivationInfo: IRawNodeDeactivationInfo;
 
   public progress: IProgressStatus[] = [];
@@ -33,7 +33,11 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
       new ListColumnSetting('NodeDeactivationIntent', 'Intent'),
       new ListColumnSetting('NodeDeactivationTaskId.Id', 'Id'),
       new ListColumnSetting('NodeDeactivationTaskId.NodeDeactivationTaskType', 'Task Type'),
-    ]);
+      ]);
+    
+    if (this.hasDescription && this.settings.columnSettings.length < 4) {
+      this.settings.columnSettings.push(new ListColumnSetting('NodeDeactivationDescription', 'Description', { cssClasses: "wrap-overflow" }));
+    }
   }
 
   ngOnChanges(): void {

--- a/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
+++ b/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
@@ -28,16 +28,16 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
   constructor(public settingsService: SettingsService) { }
 
   ngOnInit(): void {
-    this.settings = this.settingsService.getNewOrExistingListSettings('tasks', null,
-    [
+
+    let columnSettings = [
       new ListColumnSetting('NodeDeactivationIntent', 'Intent'),
       new ListColumnSetting('NodeDeactivationTaskId.Id', 'Id'),
       new ListColumnSetting('NodeDeactivationTaskId.NodeDeactivationTaskType', 'Task Type'),
-      ]);
-    
-    if (this.hasDescription && this.settings.columnSettings.length < 4) {
-      this.settings.columnSettings.push(new ListColumnSetting('NodeDeactivationDescription', 'Description', { cssClasses: "wrap-overflow" }));
+    ]
+    if (this.hasDescription) {
+      columnSettings.push(new ListColumnSetting('NodeDeactivationDescription', 'Description', { cssClasses: "wrap-overflow" }));
     }
+    this.settings = this.settingsService.getNewOrExistingListSettings('tasks', null, columnSettings);
   }
 
   ngOnChanges(): void {

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.html
@@ -75,7 +75,7 @@
         </div>
         <div collapse-body class="table-responsive" style="padding: 10px;">
           <a [routerLink]="node.viewPath">View Node</a>
-          <app-node-deactivation-info [deactivationInfo]="node.raw.NodeDeactivationInfo"></app-node-deactivation-info>
+          <app-node-deactivation-info [deactivationInfo]="node.raw.NodeDeactivationInfo" [hasDescription]="node.hasDeactivatingDescription"></app-node-deactivation-info>
         </div>
       </app-collapse-container>
     </div>

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.html
@@ -40,7 +40,7 @@
         <h4>Deactivation Info</h4>
       </div>
       <div collapse-body>
-        <app-node-deactivation-info [deactivationInfo]="node.raw.NodeDeactivationInfo"></app-node-deactivation-info>
+        <app-node-deactivation-info [deactivationInfo]="node.raw.NodeDeactivationInfo" [hasDescription]="node.hasDeactivatingDescription"></app-node-deactivation-info>
       </div>
     </app-collapse-container>
   </div>

--- a/src/SfxWeb/src/styles.scss
+++ b/src/SfxWeb/src/styles.scss
@@ -740,3 +740,6 @@ table.detail-list {
 
 }
 
+.wrap-overflow {
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
Added optional description field to node deactivation info per API changes listed in [PR](https://msazure.visualstudio.com/One/_git/WindowsFabric/pullrequest/8091988).

![MicrosoftTeams-image](https://github.com/microsoft/service-fabric-explorer/assets/32966177/363ea6b3-c91b-49dd-aefa-054704960dcd)
