### PR TITLE
Added ManagedIdenityClientId params for BRS operations

### DIFF
--- a/src/SfxWeb/cypress/e2e/cluster.cy.js
+++ b/src/SfxWeb/cypress/e2e/cluster.cy.js
@@ -486,6 +486,7 @@ context('Cluster page', () => {
               "ContainerName": "",
               "BlobServiceUri": "",
               "ManagedIdentityType": "",
+              "ManagedIdentityClientId": "",
               "PrimaryUserName": "",
               "PrimaryPassword": "",
               "SecondaryUserName": "",
@@ -500,6 +501,7 @@ context('Cluster page', () => {
 
         cy.get("[formcontrolname=BlobServiceUri]").type("BSUURI");
         cy.get("[formcontrolname=ContainerName]").type("sillycontainername");
+        cy.get("[formcontrolname=ManagedIdentityClientId]").type("sillyclientid");
         cy.get("[value=Cluster]").click();
 
         cy.get(submitButton).click();
@@ -526,6 +528,7 @@ context('Cluster page', () => {
               "ContainerName": "sillycontainername",
               "BlobServiceUri": "BSUURI",
               "ManagedIdentityType": "Cluster",
+              "ManagedIdentityClientId": "sillyclientid",
               "PrimaryUserName": "",
               "PrimaryPassword": "",
               "SecondaryUserName": "",
@@ -578,6 +581,7 @@ context('Cluster page', () => {
               "ContainerName": "",
               "BlobServiceUri": "",
               "ManagedIdentityType": "",
+              "ManagedIdentityClientId": "",
               "PrimaryUserName": "username",
               "PrimaryPassword": "password",
               "SecondaryUserName": "",

--- a/src/SfxWeb/src/Styles/_modal.scss
+++ b/src/SfxWeb/src/Styles/_modal.scss
@@ -1,6 +1,6 @@
 @import "vars.scss";
 
-$modal-dt-width: 160px;
+$modal-dt-width: 180px;
 $modal-short-dt-width: 100px;
 $dialog-input-bg-color: #242424;
 
@@ -63,7 +63,7 @@ $dialog-input-bg-color: #242424;
 
             dd {
                 padding: 5px 0px;
-
+                width: calc(100% - $modal-dt-width);
                 dl {
                     margin-top: 5px;
                 }

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.html
@@ -58,6 +58,12 @@
                     VMSS
                 </label><br />
             </dd>
+            <dt>ManagedIdentityClientId
+                <span tabindex="0" class="mif-info" title="Client-id of the user-assigned managed identity (in the case of the system-assigned managed identity, please keep ManagedIdentityClientId Empty)"></span>
+            </dt>
+            <dd>
+                <input type="text" class="input-flat" formControlName="ManagedIdentityClientId" name="ManagedIdentityClientId">
+            </dd>
         </dl>
         <dl class="dl-horizontal" *ngIf="localForm.value.StorageKind === 'FileShare'">
             <dt>FriendlyName</dt>

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -24,6 +24,7 @@ export class StorageFormComponent implements OnInit {
       ContainerName: [''],
       BlobServiceUri: [''],
       ManagedIdentityType: [''],
+      ManagedIdentityClientId: [''],
       IsEmptyPrimaryCredential: [true],
       PrimaryUserName: [''],
       PrimaryPassword: [''],
@@ -58,6 +59,7 @@ export class StorageFormComponent implements OnInit {
       ContainerName: '',
       BlobServiceUri: '',
       ManagedIdentityType: '',
+      ManagedIdentityClientId: '',
       IsEmptyPrimaryCredential: true,
       PrimaryUserName: '',
       PrimaryPassword: '',
@@ -88,6 +90,7 @@ export class StorageFormComponent implements OnInit {
 
       storage.get('BlobServiceUri').setValidators(null);
       storage.get('ManagedIdentityType').setValidators(null);
+      storage.get('ManagedIdentityClientId').setValidators(null);
     }
 
     if (storageKind === 'FileShare') {
@@ -102,6 +105,7 @@ export class StorageFormComponent implements OnInit {
 
       storage.get('BlobServiceUri').setValidators(null);
       storage.get('ManagedIdentityType').setValidators(null);
+      storage.get('ManagedIdentityClientId').setValidators(null);
     }
 
     if (storageKind === 'ManagedIdentityAzureBlobStore')
@@ -115,6 +119,7 @@ export class StorageFormComponent implements OnInit {
       storage.get('BlobServiceUri').setValidators([Validators.required]);
       storage.get('ManagedIdentityType').setValidators([Validators.required]);
       storage.get('ContainerName').setValidators([Validators.required]);
+      storage.get('ManagedIdentityClientId').setValidators(null);
     }
 
     storage.get('ContainerName').updateValueAndValidity();
@@ -122,6 +127,7 @@ export class StorageFormComponent implements OnInit {
     storage.get('Path').updateValueAndValidity();
     storage.get('BlobServiceUri').updateValueAndValidity();
     storage.get('ManagedIdentityType').updateValueAndValidity();
+    storage.get('ManagedIdentityClientId').updateValueAndValidity();
   }
 
   updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean) {

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
@@ -43,7 +43,10 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
     }else{
       data.Schedule.RunDays = [];
     }
-
+    
+    if(data.Storage.StorageKind === 'ManagedIdentityAzureBlobStore' && data.Storage.ManagedIdentityClientId === ""){
+      delete data.Storage.ManagedIdentityClientId;
+    }
     (this.isUpdateOperation ? this.dataService.restClient.updateBackupPolicy(data) :
                               this.dataService.restClient.createBackupPolicy(data)  ).subscribe( () => {
                                 this.dialogRef.close();


### PR DESCRIPTION
Adding a parameter “Client-Id” for Managed Identity in BRS operations. It distinguishes among multiple managed identities while fetching Access token from Azure server.
![image](https://github.com/microsoft/service-fabric-explorer/assets/73738923/e64cf9e2-9526-4cae-99a8-d1dea951aff2)

