### PR TITLE
Add SSRF codeql suppression to SFX-Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Navigate to `src/Sfx-Proxy`
 npm start
 ```
 
+> [!NOTE]  
+> SFX-Proxy is a local dev tool to forward cluster requests for testing purposes. It should not be hosted as a public server.
+
 There are 2 optional flags
 -r which would record every request to a folder(by default called playbackRecordings) and overwriting if the same request is made again
 -p every request will be checked for a saved response and if one exists get served instead

--- a/src/Sfx-Proxy/proxy.js
+++ b/src/Sfx-Proxy/proxy.js
@@ -76,6 +76,8 @@ const proxyRequest = async (req) => {
     const method = req.method.toLowerCase();
     let conf = {
         method,
+        // this line leaves potential for SSFR, however, since this is a loal dev tool, it is not a concern
+        // codeql [SM04580]: suppress
         url: `${config.TargetCluster.Url}${url}`,
         data, 
         headers


### PR DESCRIPTION
the codeql warning is not needed as SFX-Proxy is a local dev tool