### PR TITLE
Update FabricOwl to display reconfiguration reasons

### DIFF
--- a/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
@@ -285,10 +285,10 @@ export let RelatedEventsConfigs: IConcurrentEventsConfig[] = [
     "result": "raw.Action"
   },
   {
-    "eventType": "PartitionReconfigurationStarted",
+    "eventType": "PartitionReconfigured",
     "relevantEventsType": [
       {
-        eventType: "PartitionReconfigured",
+        eventType: "PartitionReconfigurationStarted",
         propertyMappings: [
           {
             source: {
@@ -301,19 +301,96 @@ export let RelatedEventsConfigs: IConcurrentEventsConfig[] = [
         ],
       }
     ],
-    "result": "eventProperties.NewPrimaryNodeName",
-    "resultTransform": [
+    "result": ""
+  },
+  {
+    "eventType": "PartitionReconfigurationStarted",
+    "relevantEventsType": [
       {
-        type: "prefix",
-        value: "New Primary Node Name is "
+        eventType: "ClientReportFaultEvent",
+        propertyMappings: [
+          {
+            source: {
+              property: "eventProperties.ActivityId",
+            },
+            target: {
+              property: "eventProperties.ActivityId"
+            }
+          }
+        ],
+      },
+      {
+        eventType: "ServiceReportFaultEvent",
+        propertyMappings: [
+          {
+            source: {
+              property: "eventProperties.ActivityId",
+            },
+            target: {
+              property: "eventProperties.ActivityId"
+            }
+          }
+        ],
+      },
+      {
+        eventType: "CRMOperationGenerated",
+        propertyMappings: [
+          {
+            source: {
+              property: "eventProperties.ActivityId",
+            },
+            target: {
+              property: "eventProperties.DecisionId"
+            }
+          }
+        ],
+      },
+      {
+        eventType: "ApplicationProcessExited",
+        propertyMappings: [
+          {
+            source: {
+              property: "eventProperties.ActivityId",
+            },
+            target: {
+              property: "eventProperties.ActivityId"
+            }
+          }
+        ],
+      },
+      {
+        eventType: "NodeDown",
+        propertyMappings: [
+          {
+            source: {
+              property: "eventProperties.ActivityId",
+            },
+            target: {
+              property: "eventProperties.ActivityId"
+            }
+          }
+        ],
       }
-    ]
+    ],
+    "result": ""
+  },
+  {
+    "eventType": "ServiceReportFaultEvent",
+    "relevantEventsType": [
+    ],
+    "result": "eventProperties.Description"
   },
   {
     "eventType": "PartitionReconfigured",
     "relevantEventsType": [
     ],
     "result": "eventProperties.ReconfigType"
+  },
+  {
+    "eventType": "CRMOperationGenerated",
+    "relevantEventsType": [
+    ],
+    "result": "eventProperties.Action"
   },
   {
     "eventType": "ClusterNewHealthReport",

--- a/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
@@ -366,7 +366,7 @@ export let RelatedEventsConfigs: IConcurrentEventsConfig[] = [
               property: "eventProperties.ActivityId",
             },
             target: {
-              property: "eventProperties.ActivityId"
+              property: "eventInstanceId"
             }
           }
         ],

--- a/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
@@ -192,12 +192,8 @@ const APE: IRelevantEventsConfig[] = [
     ],
     selfTransform: [
       {
-        type: "trimFront",
-        value: "."
-      },
-      {
         type: "trimBack",
-        value: "For information"
+        value: "("
       },
       {
         type: "prefix",
@@ -381,6 +377,12 @@ export let RelatedEventsConfigs: IConcurrentEventsConfig[] = [
     "result": "eventProperties.Description"
   },
   {
+    "eventType": "ClientReportFaultEvent",
+    "relevantEventsType": [
+    ],
+    "result": "eventProperties.Description"
+  },
+  {
     "eventType": "PartitionReconfigured",
     "relevantEventsType": [
     ],
@@ -390,7 +392,13 @@ export let RelatedEventsConfigs: IConcurrentEventsConfig[] = [
     "eventType": "CRMOperationGenerated",
     "relevantEventsType": [
     ],
-    "result": "eventProperties.Action"
+    "result": "eventProperties.Phase"
+  },
+  {
+    "eventType": "NodeDown",
+    "relevantEventsType": [
+    ],
+    "result": "raw.NodeName"
   },
   {
     "eventType": "ClusterNewHealthReport",

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
@@ -125,8 +125,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
               if (currEvent.reason) {
                 if (currEvent.reason.name == "self") {
                   config.data.push({
-                    from: `${idPrefix}${currEvent.eventInstanceId}</p>`,
-                    to: `${idPrefix}${currEvent.eventInstanceId}</p>`
+                    from: `${idPrefix}${currEvent.eventInstanceId}</p>`
                   });
                 } else {
                   config.data.push({

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
@@ -12,9 +12,15 @@ import { IConcurrentEvents, IRCAItem } from 'src/app/Models/eventstore/rcaEngine
 })
 
 export class VisualizationToolComponent implements OnChanges, AfterViewInit, DetailBaseComponent {
-  private nameSizePx: number = 12;
-  private kindSizePx: number = 12;
+  private idSizePx: number = 12;
+  private eventTitleSizePx: number = 14;
+  private textSizePx: number = 12;
   private titleSizePx: number = 20;
+
+  private idColor: string = "var(--font-placeholder-color)";
+  private eventTitleColor: string = "var(--font-primary-color)";
+  private textColor: string = "var(--font-accent-color)";
+
   private chart: Chart;
 
   visEvents : IConcurrentEvents;
@@ -86,18 +92,21 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
       queue = [this.visEvents];
 
       let levels = 0;
-      let fontPrefix = `<p style='font-size: ${this.nameSizePx}px; color: white;'>`
-      let titlePrefix = `<p style='font-size: ${this.kindSizePx}px; color: white;'>`
+      let idPrefix = `<p style='font-size: ${this.idSizePx}px; color: ${this.idColor};'> <b>EventInstanceId: </b>`
+      let eventTitlePrefix = `<p style='font-size: ${this.eventTitleSizePx}px; color: ${this.eventTitleColor};'>`
+      let descriptionPrefix = `<p style='font-size: ${this.textSizePx}px; color: ${this.textColor};'>`
       let maxHeight = 0;
       while (queue.length > 0) {
           let currSize = queue.length;
           maxHeight = Math.max(currSize, maxHeight);
           for (let i = 0; i < currSize; i++) {
               let currEvent = queue.shift();
-              let action = currEvent.reasonForEvent ? "Reason: " + currEvent.reasonForEvent + "</br>" : "";
+              let action = currEvent.reasonForEvent ? "<b>Reason: </b>" + currEvent.reasonForEvent + "</br>" : "";
+              let timestamp = "<b>Timestamp: </b>" + currEvent.timeStamp;
               let newNodeComponent : SeriesSankeyNodesOptionsObject = {
-                  id: fontPrefix + currEvent.eventInstanceId + "</p>",
-                  title: titlePrefix + action + currEvent.kind + "</p>",
+                  id: idPrefix + currEvent.eventInstanceId + "</p>",
+                  title: eventTitlePrefix + currEvent.kind + "</p>",
+                  description: descriptionPrefix + action + timestamp +"</p>",
                   layout: "hanging",
                   height: 80,
                   opacity: 1,
@@ -116,13 +125,13 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
               if (currEvent.reason) {
                 if (currEvent.reason.name == "self") {
                   config.data.push({
-                    from: `${fontPrefix}${currEvent.eventInstanceId}</p>`,
-                    to: `${fontPrefix}${currEvent.eventInstanceId}</p>`
+                    from: `${idPrefix}${currEvent.eventInstanceId}</p>`,
+                    to: `${idPrefix}${currEvent.eventInstanceId}</p>`
                   });
                 } else {
                   config.data.push({
-                    from: `${fontPrefix}${currEvent.eventInstanceId}</p>`,
-                    to: `${fontPrefix}${currEvent.reason.eventInstanceId}</p>`
+                    to: `${idPrefix}${currEvent.eventInstanceId}</p>`,
+                    from: `${idPrefix}${currEvent.reason.eventInstanceId}</p>`
                   });
                   queue.push(currEvent.reason);
                 }

--- a/src/SfxWeb/src/app/modules/event-store/option-picker/option-picker.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/option-picker/option-picker.component.ts
@@ -12,6 +12,7 @@ export interface IOptionData {
 export interface IOptionConfig{
     enableCluster?: boolean;
     enableNodes?: boolean;
+    enableApplication?: boolean;
     enableRepairTasks?: boolean;
 }
 
@@ -44,6 +45,14 @@ export class OptionPickerComponent implements OnChanges {
         this.options.push(nodes);
       }
       this.checkedStates[nodes.displayName] = this.listEventStoreData.some(ESD => ESD.displayName === nodes.displayName);
+    }
+
+    if (this.optionsConfig.enableApplication) {
+      const application = this.dataService.getApplicationEventData();
+      if(!this.options.some(option => option.displayName === application.displayName)) {
+        this.options.push(application);
+      }
+      this.checkedStates[application.displayName] = this.listEventStoreData.some(ESD => ESD.displayName === application.displayName);
     }
 
     if (this.optionsConfig.enableRepairTasks) {

--- a/src/SfxWeb/src/app/views/partition/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.ts
@@ -27,6 +27,7 @@ export class EventsComponent extends PartitionBaseControllerDirective {
     this.optionsConfig = {
       enableCluster: true,
       enableNodes: true,
+      enableApplication: true,
       enableRepairTasks: true
     };
   }


### PR DESCRIPTION
This PR targets a few changes
- Update FabricOwl configurations to include the main reasons for why a reconfiguration can happen - ClientReportFaultEvent, ServiceReportFaultEvent, PLB movement (CRMOperationGenerated), NodeDown, ApplicationProcessExited
- Update the UI display for the event relations 
![image](https://github.com/user-attachments/assets/d2a9b35d-b6bf-4f8b-9e88-8883735f27a4)
- Create the option to load application-level event in the partition event view so that ApplicationProcessExited (app-level event) can be associated with ReconfigurationStarted (partition-level event) 