### PR TITLE
fix orchestration test by updating timestamp

### DIFF
--- a/src/SfxWeb/cypress/e2e/cluster.cy.js
+++ b/src/SfxWeb/cypress/e2e/cluster.cy.js
@@ -797,7 +797,16 @@ context('Cluster page', () => {
 
   describe("orchestration view", () => {
     beforeEach(() => {
-      cy.intercept('GET', '**/EventsStore/Partitions/**', { fixture: 'cluster-page/orchestration-view/partition-operation-events.json' }).as('partitionevents');
+      cy.fixture('cluster-page/orchestration-view/partition-operation-events.json').then((partitionEvents) => {
+        partitionEvents.forEach(event => {
+          // update timestamp to use yesterday's date but keep the time
+          let yesterday = new Date();
+          yesterday.setDate(yesterday.getDate() - 1);
+          let eventDate = new Date(event.TimeStamp);
+          event.TimeStamp = new Date(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate(), eventDate.getHours(), eventDate.getMinutes(), eventDate.getSeconds()).toISOString();
+        })
+        cy.intercept('GET', '**/EventsStore/Partitions/**', partitionEvents).as('partitionevents');
+      })
     })
 
     it("opens orchestration view page", () => {


### PR DESCRIPTION
Orchestration Cypress Tests are failing as they are checking against the timeline, which only displays the last 7 day's events. The fixture used has events with timestamp in the past, hence not showing up.
<img width="1280" height="720" alt="Cluster page -- orchestration view -- disaplies the timeline and events when clicking on Confirm with existing partition id (failed) (attempt 2)" src="https://github.com/user-attachments/assets/ea4d522f-1ad7-468b-8a24-a4c392f9192d" />


Fixed by dynamically updating the timestamp of the events within the test.