### PR TITLE
Update SFX with ToBeRemovedReplica Expiration Time

### DIFF
--- a/src/SfxWeb/src/Styles/_tiles.scss
+++ b/src/SfxWeb/src/Styles/_tiles.scss
@@ -68,7 +68,7 @@ $large-window-width: 550px;
   display: grid;
   grid-auto-flow: dense;
   grid-gap: 10px;
-  grid-auto-rows: 150px;
+  grid-auto-rows: minmax(150px, auto);
   margin-bottom: 15px;
 
   @media (min-width: $large-window-width){

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -75,10 +75,15 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
 
     public get role(): string {
         const { PartitionStatus } = this.parent.raw;
-        const { PreviousReplicaRole, ReplicaRole } = this.raw;
+        const { PreviousReplicaRole, ReplicaRole, IsStopped } = this.raw;
+
+        if (IsStopped)
+        {
+            return `Stopped: ToBeDeleted`;
+        }
 
         if (PartitionStatus !== 'Reconfiguring') {
-            return ReplicaRole;
+            return `${ReplicaRole}`;
         }
 
         if (!PreviousReplicaRole || PreviousReplicaRole === 'None') {
@@ -114,6 +119,10 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
 
     public get replicaRoleSortPriority(): number {
         return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole] || 0;
+    }
+
+    public get isStopped(): boolean {
+        return this.raw.IsStopped;
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -75,9 +75,9 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
 
     public get role(): string {
         const { PartitionStatus } = this.parent.raw;
-        const { PreviousReplicaRole, ReplicaRole, IsStopped } = this.raw;
+        const { PreviousReplicaRole, ReplicaRole, ReplicaIsStopped } = this.raw;
 
-        if (IsStopped)
+        if (ReplicaIsStopped)
         {
             return `Stopped: ToBeDeleted`;
         }
@@ -121,8 +121,8 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
         return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole] || 0;
     }
 
-    public get isStopped(): boolean {
-        return this.raw.IsStopped;
+    public get replicaIsStopped(): boolean {
+        return this.raw.ReplicaIsStopped;
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -75,11 +75,11 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
 
     public get role(): string {
         const { PartitionStatus } = this.parent.raw;
-        const { PreviousReplicaRole, ReplicaRole, ReplicaIsStopped } = this.raw;
+        const { PreviousReplicaRole, ReplicaRole, ReplicaStatus} = this.raw;
 
-        if (ReplicaIsStopped)
+        if (ReplicaStatus == 'ToBeRemoved')
         {
-            return `Stopped: ToBeDeleted`;
+            return `ToBeRemoved`;
         }
 
         if (PartitionStatus !== 'Reconfiguring') {
@@ -121,12 +121,8 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
         return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole] || 0;
     }
 
-    public get replicaIsStopped(): boolean {
-        return this.raw.ReplicaIsStopped;
-    }
-
     public get stoppedReplicaExpirationTimeUtc(): string {
-        return TimeUtils.timestampToUTCString(this.raw.StoppedReplicaExpirationTimeUtc);
+        return TimeUtils.timestampToUTCString(this.raw.ToBeRemovedReplicaExpirationTimeUtc);
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -126,7 +126,7 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
     }
 
     public get stoppedReplicaExpirationTimeUtc(): string {
-        return TimeUtils.timestampToUTCString(this.raw.StoppedReplicaExpirationTimeUTC);
+        return TimeUtils.timestampToUTCString(this.raw.StoppedReplicaExpirationTimeUtc);
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -125,6 +125,10 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
         return this.raw.ReplicaIsStopped;
     }
 
+    public get stoppedReplicaExpirationTimeUtc(): string {
+        return TimeUtils.timestampToUTCString(this.raw.StoppedReplicaExpirationTimeUTC);
+    }
+
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<any> {
         // Refresh the parent partition here as well because we need its status to display the correct role name
         return this.parent.refresh().pipe(mergeMap(

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -710,6 +710,7 @@ export interface IRawReplicaOnPartition {
         ReplicaStatus: string;
         ServiceKind: string;
         IsStopped: boolean;
+        StoppedReplicaExpirationTimestampUTC: string;
     }
 
 export interface IRawReplicaHealthState {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -709,8 +709,7 @@ export interface IRawReplicaOnPartition {
         NodeName: string;
         ReplicaStatus: string;
         ServiceKind: string;
-        ReplicaIsStopped: boolean;
-        StoppedReplicaExpirationTimeUtc: string;
+        ToBeRemovedReplicaExpirationTimeUtc: string;
     }
 
 export interface IRawReplicaHealthState {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -710,7 +710,7 @@ export interface IRawReplicaOnPartition {
         ReplicaStatus: string;
         ServiceKind: string;
         ReplicaIsStopped: boolean;
-        StoppedReplicaExpirationTimestampUTC: string;
+        StoppedReplicaExpirationTimeUtc: string;
     }
 
 export interface IRawReplicaHealthState {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -709,6 +709,7 @@ export interface IRawReplicaOnPartition {
         NodeName: string;
         ReplicaStatus: string;
         ServiceKind: string;
+        IsStopped: boolean;
     }
 
 export interface IRawReplicaHealthState {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -709,7 +709,7 @@ export interface IRawReplicaOnPartition {
         NodeName: string;
         ReplicaStatus: string;
         ServiceKind: string;
-        IsStopped: boolean;
+        ReplicaIsStopped: boolean;
         StoppedReplicaExpirationTimestampUTC: string;
     }
 

--- a/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.html
+++ b/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.html
@@ -1,5 +1,5 @@
 <div class="dashboard-wrapper">
-    <div class="dashboard dashboard-small">
+    <div class="dashboard dashboard-medium">
         <div class="dashboard-tile flex-center" style="height: 100%;">
             <div class="flex-center"  style="height: 100%;">
                 <div class="badge-container" *ngIf="healthState">

--- a/src/SfxWeb/src/app/views/partition/commands/commands.component.ts
+++ b/src/SfxWeb/src/app/views/partition/commands/commands.component.ts
@@ -57,7 +57,7 @@ export class CommandsComponent extends PartitionBaseControllerDirective{
     this.commands.push(getPartition);
 
     const statusFilter = new PowershellCommandParameter("ReplicaStatusFilter", CommandParamTypes.enum,
-      { options: ['Default', 'InBuild', 'Standby', 'Ready', 'Down', 'Dropped', 'Completed', 'All'] });
+      { options: ['Default', 'InBuild', 'Standby', 'Ready', 'Down', 'Dropped', 'Completed', 'ToBeRemoved', 'All'] });
 
     const getReplicas = new PowershellCommand(
       'Get Replicas',

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="replica">
-  <div *ngIf="replica.raw.IsStopped">
-    <h3> IsStopped: {{replica.raw.IsStopped}}</h3>
+  <div *ngIf="replica.raw.ReplicaIsStopped">
+    <h3> IsStopped: {{replica.raw.ReplicaIsStopped}}</h3>
     <h3> Replica Expiration TimeStamp UTC: {{replica.raw.StoppedReplicaExpirationTimeUtc}} </h3>
   </div>
   <div class="tile-container">

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="replica">
-  <div *ngIf="replica.raw.ReplicaIsStopped">
-    <h3> IsStopped: {{replica.raw.ReplicaIsStopped}}</h3>
-    <h3> Replica Expiration TimeStamp UTC: {{replica.raw.StoppedReplicaExpirationTimeUtc}} </h3>
+  <div *ngIf="replica.raw.ReplicaStatus === 'ToBeRemoved'">
+      <h3> ReplicaStatus: {{replica.raw.ReplicaStatus}}</h3>
+      <h3> ToBeRemovedReplicaExpirationTimeUTC: {{replica.raw.ToBeRemovedReplicaExpirationTimeUtc}} </h3>
   </div>
   <div class="tile-container">
     <app-essential-health-tile [healthState]="replica?.healthState" *ngIf="replica && replica.isInitialized"

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
@@ -1,8 +1,4 @@
 <div *ngIf="replica">
-  <div *ngIf="replica.raw.ReplicaStatus === 'ToBeRemoved'">
-      <h3> ReplicaStatus: {{replica.raw.ReplicaStatus}}</h3>
-      <h3> ToBeRemovedReplicaExpirationTimeUTC: {{replica.raw.ToBeRemovedReplicaExpirationTimeUtc}} </h3>
-  </div>
   <div class="tile-container">
     <app-essential-health-tile [healthState]="replica?.healthState" *ngIf="replica && replica.isInitialized"
       class="long" [listItems]="essentialItems">

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.html
@@ -1,5 +1,8 @@
 <div *ngIf="replica">
-
+  <div *ngIf="replica.raw.IsStopped">
+    <h3> IsStopped: {{replica.raw.IsStopped}}</h3>
+    <h3> Replica Expiration TimeStamp UTC: {{replica.raw.StoppedReplicaExpirationTimeUtc}} </h3>
+  </div>
   <div class="tile-container">
     <app-essential-health-tile [healthState]="replica?.healthState" *ngIf="replica && replica.isInitialized"
       class="long" [listItems]="essentialItems">

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -3,8 +3,8 @@ import { ListSettings } from 'src/app/Models/ListSettings';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { IResponseMessageHandler } from 'src/app/Common/ResponseMessageHandlers';
-import { forkJoin, Observable } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { of, forkJoin, Observable } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { RoutesService } from 'src/app/services/routes.service';
 import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile/essential-health-tile.component';
@@ -29,65 +29,90 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     return forkJoin([
-      this.replica.health.refresh(messageHandler),
-      this.replica.detail.refresh(messageHandler).pipe(map(() => {
+      this.replica.health.refresh(messageHandler).pipe(
+        catchError(err => {
+          console.error('Health refresh failed', err);
+          return of(null); // Or some fallback/default value
+        })
+      ),
+      this.replica.detail.refresh(messageHandler).pipe(
+        map(() => {
+          if (!this.isSystem) {
+            const rawDataProperty = this.replica.isStatefulService
+              ? 'DeployedServiceReplica'
+              : 'DeployedServiceReplicaInstance';
+            const detailRaw = this.replica.detail.raw[rawDataProperty];
+
+            const serviceNameOnly = detailRaw?.ServiceManifestName;
+            const activationId = detailRaw?.ServicePackageActivationId || null;
+
+            if (serviceNameOnly) {
+              this.nodeView = RoutesService.getDeployedReplicaViewPath(
+                this.replica.raw.NodeName,
+                this.appId,
+                serviceNameOnly,
+                activationId,
+                this.partitionId,
+                this.replicaId
+              );
+            }
+          }
+        }),
+        catchError(err => {
+          console.error('Detail refresh failed', err);
+          return of(null); // Still allow forkJoin to complete
+        })
+      )
+    ]).pipe(
+      map(() => {
+        this.essentialItems = [
+          {
+            descriptionName: 'Node Name',
+            copyTextValue: this.replica.raw?.NodeName ?? 'Unknown',
+            selectorName: 'nodeName',
+            displaySelector: true
+          },
+          {
+            descriptionName: 'Process Id',
+            displayText: this.replica.detail?.processID ?? 'Unavailable',
+            copyTextValue: this.replica.detail?.processID ?? 'Unavailable'
+          },
+          {
+            descriptionName: 'Status',
+            displayText: this.replica.raw?.ReplicaStatus ?? 'Unknown',
+            copyTextValue: this.replica.raw?.ReplicaStatus ?? 'Unknown',
+            selectorName: 'status',
+            displaySelector: true
+          }
+        ];
+
+        if (this.replica.raw?.ReplicaIsStopped) {
+          const strIsStopped = String(this.replica.raw.ReplicaIsStopped);
+          this.essentialItems.push({
+            descriptionName: 'IsStopped',
+            displayText: strIsStopped,
+            copyTextValue: strIsStopped,
+            selectorName: 'stopped'
+          });
+
+          const now = new Date();
+          const tomorrowUTC = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+          const expirationTimestampUTC = tomorrowUTC.toISOString();
+          this.essentialItems.push({
+            descriptionName: 'Replica Expiration Timestamp UTC',
+            displayText: expirationTimestampUTC,
+            copyTextValue: expirationTimestampUTC,
+            selectorName: 'stoppedExpirationTimestamp'
+          });
+        }
+
         if (!this.isSystem) {
-          const rawDataProperty = this.replica.isStatefulService ? 'DeployedServiceReplica' : 'DeployedServiceReplicaInstance';
-          const detailRaw = this.replica.detail.raw[rawDataProperty];
-
-          const serviceNameOnly = detailRaw.ServiceManifestName;
-          const activationId = detailRaw.ServicePackageActivationId || null;
-          this.nodeView = RoutesService.getDeployedReplicaViewPath(this.replica.raw.NodeName, this.appId, serviceNameOnly, activationId, this.partitionId, this.replicaId);
+          this.essentialItems.push({
+            selectorName: 'viewNode',
+            displaySelector: true
+          });
         }
-      }))
-    ]).pipe(map(() => {
-      this.essentialItems = [
-        {
-          descriptionName: 'Node Name',
-          copyTextValue: this.replica.raw.NodeName,
-          selectorName: 'nodeName',
-          displaySelector: true
-        },
-        {
-          descriptionName: 'Process Id',
-          displayText: this.replica.detail.processID,
-          copyTextValue: this.replica.detail.processID
-        },
-        {
-          descriptionName: 'Status',
-          displayText: this.replica.raw.ReplicaStatus,
-          copyTextValue: this.replica.raw.ReplicaStatus,
-          selectorName: 'status',
-          displaySelector: true
-        }
-      ];
-
-      if(this.replica.raw.ReplicaIsStopped) {
-        const strIsStopped = String(this.replica.raw.ReplicaIsStopped);
-        this.essentialItems.push({
-          descriptionName: 'IsStopped',
-          displayText: strIsStopped,
-          copyTextValue: strIsStopped,
-          selectorName: 'stopped'
-        })
-        
-        const now = new Date();
-        const tomorrowUTC = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-        const expirationTimestampUTC = tomorrowUTC.toISOString();
-        this.essentialItems.push({
-          descriptionName: 'Replica Expiration Timestamp UTC',
-          displayText: expirationTimestampUTC,
-          copyTextValue: expirationTimestampUTC,
-          selectorName: 'stoppedExpirationTimestamp'
-        })
-      }
-
-      if(!this.isSystem) {
-        this.essentialItems.push(        {
-          selectorName: 'viewNode',
-          displaySelector: true
-        })
-      }
-    }));
+      })
+    );
   }
 }

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -71,14 +71,12 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
           selectorName: 'stopped'
         })
         
-        const now = new Date();
-        const tomorrowUTC = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-        const expirationTimestampUTC = tomorrowUTC.toISOString();
+        const expirationTimestampUTC = this.replica.raw.StoppedReplicaExpirationTimeUTC;
         this.essentialItems.push({
-          descriptionName: 'Replica Expiration Timestamp UTC',
+          descriptionName: 'Replica Expiration Time UTC',
           displayText: expirationTimestampUTC,
           copyTextValue: expirationTimestampUTC,
-          selectorName: 'stoppedExpirationTimestamp'
+          selectorName: 'stoppedExpirationTimeUTC'
         })
       }
 

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -62,21 +62,13 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
         }
       ];
 
-      if(this.replica.raw.ReplicaIsStopped) {
-        const strIsStopped = String(this.replica.raw.ReplicaIsStopped);
-        this.essentialItems.push({
-          descriptionName: 'IsStopped',
-          displayText: strIsStopped,
-          copyTextValue: strIsStopped,
-          selectorName: 'stopped'
-        })
-        
-        const expirationTimestampUTC = this.replica.raw.StoppedReplicaExpirationTimeUtc;
+      if(this.replica.raw.ReplicaStatus == 'ToBeRemoved') {      
+        const expirationTimestampUTC = this.replica.raw.ToBeRemovedReplicaExpirationTimeUtc;
         this.essentialItems.push({
           descriptionName: 'Replica Expiration Time UTC',
           displayText: expirationTimestampUTC,
           copyTextValue: expirationTimestampUTC,
-          selectorName: 'stoppedExpirationTimeUTC'
+          selectorName: 'toBeRemovedExpirationTimeUTC'
         })
       }
 

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -62,6 +62,18 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
         }
       ];
 
+      this.replica.raw.IsStopped = true;
+
+      if(this.replica.raw.IsStopped) {
+        const strIsStopped = String(this.replica.raw.IsStopped);
+        this.essentialItems.push({
+          descriptionName: 'IsStopped',
+          displayText: strIsStopped,
+          copyTextValue: strIsStopped,
+          selectorName: 'stopped'
+        })
+      }
+
       if(!this.isSystem) {
         this.essentialItems.push(        {
           selectorName: 'viewNode',

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -71,7 +71,7 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
           selectorName: 'stopped'
         })
         
-        const expirationTimestampUTC = this.replica.raw.StoppedReplicaExpirationTimeUTC;
+        const expirationTimestampUTC = this.replica.raw.StoppedReplicaExpirationTimeUtc;
         this.essentialItems.push({
           descriptionName: 'Replica Expiration Time UTC',
           displayText: expirationTimestampUTC,

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -62,10 +62,8 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
         }
       ];
 
-      this.replica.raw.IsStopped = true;
-
-      if(this.replica.raw.IsStopped) {
-        const strIsStopped = String(this.replica.raw.IsStopped);
+      if(this.replica.raw.ReplicaIsStopped) {
+        const strIsStopped = String(this.replica.raw.ReplicaIsStopped);
         this.essentialItems.push({
           descriptionName: 'IsStopped',
           displayText: strIsStopped,

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -72,6 +72,16 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
           copyTextValue: strIsStopped,
           selectorName: 'stopped'
         })
+        
+        const now = new Date();
+        const tomorrowUTC = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+        const expirationTimestampUTC = tomorrowUTC.toISOString();
+        this.essentialItems.push({
+          descriptionName: 'Replica Expiration Timestamp UTC',
+          displayText: expirationTimestampUTC,
+          copyTextValue: expirationTimestampUTC,
+          selectorName: 'stoppedExpirationTimestamp'
+        })
       }
 
       if(!this.isSystem) {


### PR DESCRIPTION
With the addition of soft-deleted replicas, whether a replica is soft-deleted should be visible within SFX and if a replica is in a soft-deleted state, its expiration time (the latest time automatic cleanup of a soft-deleted replica will occur while the partition is healthy) should be visible in the essentials view. 

The essentials page of the Replica view should also present data to customers even if refreshing of health fails so a consistent view (including the replica expiration time) can be visible. 