### PR TITLE
Add LastQuorumLossDurationInSeconds to partition tests to fix broken build

### DIFF
--- a/src/SfxWeb/src/app/Models/RawDataTypes.spec.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.spec.ts
@@ -171,7 +171,8 @@ describe('ServiceKind Type Guards', () => {
                 },
                 MinInstanceCount: 0,
                 SelfReconfiguringInstanceCount: 0,
-                SelfReconfiguringMinInstanceCount: 0
+                SelfReconfiguringMinInstanceCount: 0,
+                LastQuorumLossDurationInSeconds: 0
             };
             expect(isStatefulService(partition)).toBe(true);
             expect(isStatelessService(partition)).toBe(false);
@@ -200,7 +201,8 @@ describe('ServiceKind Type Guards', () => {
                 },
                 MinInstanceCount: 1,
                 SelfReconfiguringInstanceCount: 0,
-                SelfReconfiguringMinInstanceCount: 0
+                SelfReconfiguringMinInstanceCount: 0,
+                LastQuorumLossDurationInSeconds: 0
             };
             expect(isStatefulService(partition)).toBe(false);
             expect(isStatelessService(partition)).toBe(true);
@@ -229,7 +231,8 @@ describe('ServiceKind Type Guards', () => {
                 },
                 MinInstanceCount: 0,
                 SelfReconfiguringInstanceCount: 3,
-                SelfReconfiguringMinInstanceCount: 1
+                SelfReconfiguringMinInstanceCount: 1,
+                LastQuorumLossDurationInSeconds: 0
             };
             expect(isStatefulService(partition)).toBe(false);
             expect(isStatelessService(partition)).toBe(false);


### PR DESCRIPTION
I broke the build [here](https://github.com/microsoft/service-fabric-explorer/actions/runs/21416470006/job/61666151822) when introducing LastQuorumLossDurationInSeconds to the IRawPartition object. Fixing it in this PR by adding LastQuorumLossDurationInSeconds to tests that uses IRawPartition.