### PR TITLE
fix proxy request parsing on linux

### DIFF
--- a/src/Sfx-Proxy/proxy.js
+++ b/src/Sfx-Proxy/proxy.js
@@ -40,11 +40,29 @@ if(config.TargetCluster.PFXLocation){
 
 const fileExists = async path => !!(await fs.stat(path).catch(e => false));
 
+// Find a recording file, handling case differences and %2F decoding by Azure's reverse proxy
+const findRecordingFile = async (targetPath) => {
+    const dir = path.dirname(targetPath);
+    const baseName = path.basename(targetPath).toLowerCase();
+    // Normalize: decode %XX then replace / with - so both sides use the same separator
+    const normalize = (s) => decodeURIComponent(s).toLowerCase().split('/').join('-');
+    const normalized = normalize(baseName);
+    try {
+        const files = await fs.readdir(dir);
+        const match = files.find(f => normalize(f) === normalized);
+        return match ? path.join(dir, match) : null;
+    } catch(e) {
+        return null;
+    }
+}
+
 const reformatUrl = (req) => {
     const copy = JSON.parse(JSON.stringify(req.query)); //make a deep copy to remove _cacheToken since it isnt necessary
     delete copy._cacheToken;
     const params =  Object.keys(copy).sort().map(key => `${key}=${copy[key]}` ).join("&")
-    return config.recordFileBase +  `${req.method.toLowerCase()}${req.path}${params}.json`.split('/').join('-').replace(/:/g, "-");
+    // Use the raw URL path (before Express decodes %2F etc.) so filenames match recordings on case-sensitive filesystems
+    const rawPath = req.originalUrl.split('?')[0];
+    return config.recordFileBase +  `${req.method.toLowerCase()}${rawPath}${params}.json`.split('/').join('-').replace(/:/g, "-");
 }
 
 const writeRequest = async (req, resp) => {
@@ -61,15 +79,16 @@ const writeRequest = async (req, resp) => {
 
 const loadRequest = async (req) => {
     const url = reformatUrl(req);
+    const resolved = await findRecordingFile(url);
     try {
-        return JSON.parse(await fs.readFile(url));
+        return JSON.parse(await fs.readFile(resolved || url));
     } catch(e) {
        throw new Error(`failed to load ${url}`)
     }
 }
 
 const checkFile = async (req) => {
-    return await fileExists(reformatUrl(req))
+    return (await findRecordingFile(reformatUrl(req))) !== null;
 }
 
 const proxyRequest = async (req) => {


### PR DESCRIPTION
Description:

Fixes recording playback failures when the Sfx-Proxy is deployed to Azure Linux App Service.

Problem:
Azure's reverse proxy decodes %2F in request URLs before they reach Node.js. On Linux (case-sensitive filesystem), this causes recording file lookups to fail because:

Recording filenames contain literal %2F (e.g., GettingStartedApplication%2FMyActorService)
Express req.path delivers decoded / instead, which reformatUrl converts to - (e.g., GettingStartedApplication-MyActorService)
The generated filename doesn't match the recording file on disk
This worked previously on Windows because the filesystem is case-insensitive and more lenient with encoded characters.

Fix:

Use req.originalUrl instead of req.path in reformatUrl to preserve URL encoding
Add findRecordingFile that normalizes both the generated filename and actual filenames on disk (decode %2F, lowercase, replace / with -) before comparing
Update checkFile and loadRequest to use findRecordingFile for fuzzy matching