### PR TITLE
Fix critical shell-quote CVE in SfxWeb (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/src/SfxWeb/package-lock.json
+++ b/src/SfxWeb/package-lock.json
@@ -18387,9 +18387,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bump transitive shell-quote 1.8.3 -> 1.9.0 via npm update (lockfile-only). Only parent launch-editor depends on it (^1.8.3), so update stays in range with no package.json change. S360 KPI SFI-ES5.2, CG alert 16410775.