### PR TITLE
deps(SfxWeb): bump shell-quote 1.10.0 + websocket-driver 0.7.5 to clear critical CG alerts

### DIFF
--- a/src/SfxWeb/package-lock.json
+++ b/src/SfxWeb/package-lock.json
@@ -18387,9 +18387,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "version": "1.10.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha1-SCAz4ZLk9cBxUVIf+gNADscbGw8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20783,9 +20783,9 @@
       "peer": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha1-Vp0idkqyHy3iCvDnS0EeiuWg+kY=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Bump two transitive deps to clear critical Component Governance / npm audit alerts in SfxWeb:
- `shell-quote` 1.9.0 → 1.10.0 
- `websocket-driver` 0.7.4 → 0.7.5 

Targeted `npm update shell-quote websocket-driver` -**lockfile-only**, no `package.json`
change, no `overrides`. Both parents' semver ranges already allow the fixed versions

- `npm audit`: both packages no longer flagged
- `npm run build`: succeeds 
- Diff is 6 lines, exactly the two package entries.