### PR TITLE
deps(SfxWeb): bump 10 transitive deps to their patched versions to clear high/moderate CG

### DIFF
--- a/src/SfxWeb/package-lock.json
+++ b/src/SfxWeb/package-lock.json
@@ -8895,9 +8895,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha1-1j+YY7zYk4gVyG+eKr04AYnZbf4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11131,9 +11131,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "version": "6.6.9",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha1-/Rfp9OOiVkI1kldLYKwmLpGvS4I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11146,7 +11146,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -11970,9 +11970,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
       "dev": true,
       "funding": [
         {
@@ -13183,9 +13183,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha1-rCPDoBmSq2ZeFKyf//KY8ozXSgw=",
       "dev": true,
       "license": "MIT"
     },
@@ -13256,9 +13256,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13858,9 +13858,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha1-790TEUls1YVzBjP8VyU6RWQaPoU=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14400,14 +14400,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha1-9+DaP1iq6gP+oBB02EC19zntfdw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/lazy-ass": {
@@ -17405,8 +17405,8 @@
     },
     "node_modules/qs": {
       "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha1-tWNM+dmtmJjjH7o1BOhm6O+2eYw=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18604,14 +18604,14 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.8",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha1-yfyr9gLb1bCSWMqY5exqeuQ2Bpg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-parser": {
@@ -19417,9 +19417,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
-      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
+      "version": "5.33.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/systeminformation/-/systeminformation-5.33.0.tgz",
+      "integrity": "sha1-3l5Y0BgKwuVGD7zlhDB6+Y1Z6w8=",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -19436,7 +19436,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",
@@ -20503,9 +20503,9 @@
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.13",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha1-EqpQfqynbClcJ4sa6/RpirLBhF8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20908,9 +20908,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha1-BFZQzUsSB4CedUcUYiPDgUqa9YY=",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What
Bump 10 transitive deps to their patched versions to clear high/moderate CG / npm audit alerts in SfxWeb:
- axios 1.16.1 → 1.18.1 
- immutable 5.1.5 → 5.1.9 
- fast-uri 3.1.2 → 3.1.4 
- engine.io 6.6.6 → 6.6.9
- systeminformation 5.31.6 → 5.33.0
- ws (main) 8.18.3 → 8.21.1 
- launch-editor 2.13.2 → 2.14.1
- socket.io-adapter 2.5.6 → 2.5.8
- joi 18.1.2 → 18.2.3
- ip-address 10.1.0 → 10.2.0

## How
Targeted `npm update <pkg list>` — **lockfile-only**, no package.json change, no overrides.
All parents' semver ranges already allow the fixed versions 
All bumps are same-major (patch/minor) — no breaking changes.

## Validation
- `npm audit`: total 50 → 40; each listed package no longer flagged.
- `npm run build`: succeeds (exit 0).