### PR TITLE
[1b/5] Enable TypeScript strict mode + fix violations

### DIFF
--- a/src/SfxWeb/package-lock.json
+++ b/src/SfxWeb/package-lock.json
@@ -59,6 +59,8 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@types/adal": "^1.0.29",
         "@types/jasmine": "3.10",
+        "@types/lodash": "^4.17.24",
+        "@types/luxon": "^3.7.2",
         "@types/node": "^18.19.130",
         "@types/nouislider": "^9.0.6",
         "@typescript-eslint/eslint-plugin": "^8.64.0",
@@ -8061,6 +8063,20 @@
       "version": "7.0.15",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha1-SuM0/GLA6RXKjtjjXcxtTuspIV8=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha1-CCuyrfVLxv4dUUoNgKgqxqdc+qw=",
       "dev": true,
       "license": "MIT"
     },

--- a/src/SfxWeb/package.json
+++ b/src/SfxWeb/package.json
@@ -76,6 +76,8 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/adal": "^1.0.29",
     "@types/jasmine": "3.10",
+    "@types/lodash": "^4.17.24",
+    "@types/luxon": "^3.7.2",
     "@types/node": "^18.19.130",
     "@types/nouislider": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^8.64.0",

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License. See License file under the project root for license information.
 // -----------------------------------------------------------------------------
@@ -266,11 +266,11 @@ export class RepairTaskMessages {
 
   public static messageMap(id: string) {
     const map = {};
-    map[RepairTaskMessages.longExecutingId] = RepairTaskMessages.longExecutingMessage;
-    map[RepairTaskMessages.seedNodeChecksId] = RepairTaskMessages.seedNodeChecks;
-    map[RepairTaskMessages.safetyChecksId] = RepairTaskMessages.safetyChecks;
-    map[RepairTaskMessages.clusterHealthCheckId] = RepairTaskMessages.clusterHealthCheck;
-    return map[id];
+    (map as any)[RepairTaskMessages.longExecutingId] = RepairTaskMessages.longExecutingMessage;
+    (map as any)[RepairTaskMessages.seedNodeChecksId] = RepairTaskMessages.seedNodeChecks;
+    (map as any)[RepairTaskMessages.safetyChecksId] = RepairTaskMessages.safetyChecks;
+    (map as any)[RepairTaskMessages.clusterHealthCheckId] = RepairTaskMessages.clusterHealthCheck;
+    return (map as any)[id];
   }
 }
 

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -269,12 +269,13 @@ export class RepairTaskMessages {
   public static clusterHealthCheckId = "clusterhealthcheck";
 
   public static messageMap(id: string) {
-    const map = {};
-    (map as any)[RepairTaskMessages.longExecutingId] = RepairTaskMessages.longExecutingMessage;
-    (map as any)[RepairTaskMessages.seedNodeChecksId] = RepairTaskMessages.seedNodeChecks;
-    (map as any)[RepairTaskMessages.safetyChecksId] = RepairTaskMessages.safetyChecks;
-    (map as any)[RepairTaskMessages.clusterHealthCheckId] = RepairTaskMessages.clusterHealthCheck;
-    return (map as any)[id];
+    const map: Record<string, string> = {
+      [RepairTaskMessages.longExecutingId]: RepairTaskMessages.longExecutingMessage,
+      [RepairTaskMessages.seedNodeChecksId]: RepairTaskMessages.seedNodeChecks,
+      [RepairTaskMessages.safetyChecksId]: RepairTaskMessages.safetyChecks,
+      [RepairTaskMessages.clusterHealthCheckId]: RepairTaskMessages.clusterHealthCheck
+    };
+    return map[id];
   }
 }
 

--- a/src/SfxWeb/src/app/Common/Constants.ts
+++ b/src/SfxWeb/src/app/Common/Constants.ts
@@ -177,6 +177,10 @@ export class HealthStateConstants {
         Error: 3,
         Unknown: 4
     };
+
+    public static getValue(text: string): number {
+        return HealthStateConstants.Values[text as keyof typeof HealthStateConstants.Values];
+    }
 }
 
 export class SortPriorities {

--- a/src/SfxWeb/src/app/Common/ResponseMessageHandlers.ts
+++ b/src/SfxWeb/src/app/Common/ResponseMessageHandlers.ts
@@ -13,13 +13,13 @@ export interface IResponseMessageHandler {
 
 export class GetResponseMessageHandler implements IResponseMessageHandler {
     public getSuccessMessage(apiDesc: string, response: HttpResponse<any>): string {
-        return null;
+        return null!;
     }
 
     public getErrorMessage(apiDesc: string, response: HttpErrorResponse): string {
         if (response.status === 404) {
             // By default exclude 404 error for all get requests
-            return null;
+            return null!;
         }
         return this.getErrorMessageInternal(apiDesc, response);
     }
@@ -67,11 +67,11 @@ export class DeleteResponseMessageHandler extends GetResponseMessageHandler {
 
 export class SilentResponseMessageHandler implements IResponseMessageHandler {
     public getSuccessMessage(apiDesc: string, response: HttpResponse<any>): string {
-        return null;
+        return null!;
     }
 
     public getErrorMessage(apiDesc: string, response: HttpErrorResponse): string {
-        return null;
+        return null!;
     }
 }
 

--- a/src/SfxWeb/src/app/Models/Action.ts
+++ b/src/SfxWeb/src/app/Models/Action.ts
@@ -31,23 +31,23 @@ export class Action {
     }
 
     public run(...params: any[]) {
-       this.runInternal(() => null, () => null, params).subscribe();
+       this.runInternal(() => null, () => null, params)!.subscribe();
     }
 
     public runWithCallbacks(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
-        return this.runInternal(success, error, params);
+        return this.runInternal(success, error, params)!;
     }
 
     public runWithFinalNotification(...params: any[]) {
       return new Observable(subscriber => {
-        this.runInternal(() => null, () => null, params).subscribe(data => {
+                this.runInternal(() => null, () => null, params)!.subscribe(data => {
           subscriber.next(data);
           subscriber.complete();
         });
       });
     }
 
-    protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
+        protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> | undefined {
 
         if (this.canRun()) {
             this.running = true;
@@ -56,7 +56,6 @@ export class Action {
                 this.running = false;
             }));
         }
-        return of(null);
     }
 }
 
@@ -91,7 +90,7 @@ export class ActionWithDialog extends Action {
                 const dialogRef = this.dialog.open(this.template, {data: this, panelClass: 'mat-dialog-container-wrapper'});
                 return dialogRef.afterClosed().pipe(mergeMap( (data: boolean) => {
                     if (data){
-                        return super.runInternal(success, error, params);
+                        return super.runInternal(success, error, params)!;
                     }
                     return of(null);
                 }));

--- a/src/SfxWeb/src/app/Models/Action.ts
+++ b/src/SfxWeb/src/app/Models/Action.ts
@@ -56,6 +56,7 @@ export class Action {
                 this.running = false;
             }));
         }
+        return of(null);
     }
 }
 
@@ -130,7 +131,7 @@ export class IsolatedAction extends Action implements IModalData{
         public modalBody?: IModalBody,
         ) {
 
-        super(name, title, runningTitle, null, canRun);
+        super(name, title, runningTitle, null!, canRun);
     }
 
 

--- a/src/SfxWeb/src/app/Models/Action.ts
+++ b/src/SfxWeb/src/app/Models/Action.ts
@@ -23,31 +23,31 @@ export class Action {
         public name: string,
         public title: string,
         public runningTitle: string,
-        protected execute: (...params: any[]) => Observable<any>,
+        protected execute: () => Observable<any>,
         public canRun: () => boolean,
         public isAdvanced: boolean = false) {
 
         this.running = false;
     }
 
-    public run(...params: any[]) {
-       this.runInternal(() => null, () => null, params)!.subscribe();
+    public run() {
+       this.runInternal(() => null, () => null)!.subscribe();
     }
 
-    public runWithCallbacks(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
-        return this.runInternal(success, error, params)!;
+    public runWithCallbacks(success: (result: any) => void, error: (reason: string) => void): Observable<any> {
+        return this.runInternal(success, error)!;
     }
 
-    public runWithFinalNotification(...params: any[]) {
+    public runWithFinalNotification() {
       return new Observable(subscriber => {
-                this.runInternal(() => null, () => null, params)!.subscribe(data => {
+                this.runInternal(() => null, () => null)!.subscribe(data => {
           subscriber.next(data);
           subscriber.complete();
         });
       });
     }
 
-        protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> | undefined {
+        protected runInternal(success: (result: any) => void, error: (reason: string) => void): Observable<any> | undefined {
 
         if (this.canRun()) {
             this.running = true;
@@ -77,20 +77,20 @@ export class ActionWithDialog extends Action {
         public name: string,
         public title: string,
         public runningTitle: string,
-        public execute: (...params: any[]) => Observable<any>,
+        public execute: () => Observable<any>,
         public canRun: () => boolean,
         public beforeOpen?: () => Observable<any>) {
 
         super(name, title, runningTitle, execute, canRun);
     }
 
-    protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
+    protected runInternal(success: (result: any) => void, error: (reason: string) => void): Observable<any> {
         if (this.canRun()) {
             return of(this.beforeOpen ? this.beforeOpen() : true).pipe(mergeMap(() => {
                 const dialogRef = this.dialog.open(this.template, {data: this, panelClass: 'mat-dialog-container-wrapper'});
                 return dialogRef.afterClosed().pipe(mergeMap( (data: boolean) => {
                     if (data){
-                        return super.runInternal(success, error, params)!;
+                        return super.runInternal(success, error)!;
                     }
                     return of(null);
                 }));
@@ -107,7 +107,7 @@ export class ActionWithConfirmationDialog extends ActionWithDialog implements IM
         public name: string,
         public title: string,
         public runningTitle: string,
-        public execute: (...params: any[]) => Observable<any>,
+        public execute: () => Observable<any>,
         public canRun: () => boolean,
         public modalTitle : IModalTitle,
         public modalBody?: IModalBody,
@@ -134,7 +134,7 @@ export class IsolatedAction extends Action implements IModalData{
     }
 
 
-    protected runInternal(success: (result: any) => void, error: (reason: string) => void, ...params: any[]): Observable<any> {
+    protected runInternal(success: (result: any) => void, error: (reason: string) => void): Observable<any> {
         if (this.canRun()) {
           this.running = true;
           return (!!this.beforeOpen ? this.beforeOpen() : of(null)).pipe(mergeMap(() => {

--- a/src/SfxWeb/src/app/Models/ActionCollection.ts
+++ b/src/SfxWeb/src/app/Models/ActionCollection.ts
@@ -52,7 +52,7 @@ export class ActionCollection {
                 return throwError(reason);
             }];
 
-        return action.runWithCallbacks.apply(action, params);
+        return action.runWithCallbacks.apply(action, params as any);
     }
 }
 

--- a/src/SfxWeb/src/app/Models/ActionCollection.ts
+++ b/src/SfxWeb/src/app/Models/ActionCollection.ts
@@ -42,7 +42,7 @@ export class ActionCollection {
     }
 
     private runInternal(action: Action, source: string): Observable<any> {
-        const params: any[] = [
+        return action.runWithCallbacks(
             // success handler
             (result: any) => {
             },
@@ -50,9 +50,7 @@ export class ActionCollection {
             (reason: any) => {
                 const result = reason && reason.statusText && reason.status && reason.status + ': ' + reason.statusText || false;
                 return throwError(reason);
-            }];
-
-        return action.runWithCallbacks.apply(action, params as any);
+            });
     }
 }
 

--- a/src/SfxWeb/src/app/Models/DataModels/Aad.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Aad.ts
@@ -14,14 +14,14 @@ export class AuthenticationBootstrapConstants {
 
 export class AadMetadata extends DataModelBase<IRawAadMetadata> {
     public constructor(raw: IRawAadMetadata) {
-        super(null, raw);
+        super(null!, raw);
     }
 
     public get metadata(): IRawAadMetadataMetadata {
         if (this.raw) {
             return this.raw.metadata;
         }
-        return null;
+        return null!;
     }
 
     public get isAadAuthType(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -41,7 +41,7 @@ export class Application extends DataModelBase<IRawApplication> {
     public health: ApplicationHealth;
     public serviceTypes: ServiceTypeCollection;
     public applicationBackupConfigurationInfoCollection: ApplicationBackupConfigurationInfoCollection;
-    public backupPolicyName: string;
+    public backupPolicyName!: string;
     public cleanBackup: boolean;
 
     public constructor(data: DataService, raw?: IRawApplication) {
@@ -87,7 +87,7 @@ export class Application extends DataModelBase<IRawApplication> {
     }
 
     public get resourceId(): string {
-        return this.raw.ApplicationMetadata?.ArmMetadata?.ArmResourceId;
+        return this.raw.ApplicationMetadata?.ArmMetadata?.ArmResourceId ?? '';
     }
 
     public get isArmManaged(): boolean{
@@ -121,7 +121,7 @@ export class Application extends DataModelBase<IRawApplication> {
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplication> {
-        return this.data.restClient.getApplication(this.id, this.data.readOnlyHeader, messageHandler);
+        return this.data.restClient.getApplication(this.id, !!this.data.readOnlyHeader, messageHandler);
     }
 
     private setUpActions(): void {
@@ -168,7 +168,7 @@ export class Application extends DataModelBase<IRawApplication> {
     private cleanUpApplicationReplicas() {
         this.data.getNodes(true)
             .subscribe(nodes => {
-                const replicas = [];
+                const replicas: any[] = [];
 
                 const replicaQueries = nodes.collection.map((node) =>
                     this.data.restClient.getReplicasOnNode(node.name, this.id)
@@ -214,7 +214,7 @@ export class SystemApplication extends Application {
 
     public get status(): ITextAndBadge {
         // Do not show status for system application
-        return null;
+        return null!;
     }
 
     public get viewPath(): string {
@@ -243,7 +243,7 @@ export class ApplicationHealth extends HealthBase<IRawApplicationHealth> {
 
     public get deploymentsHealthState(): ITextAndBadge {
         const deployedAppsHealthStates = this.raw.DeployedApplicationHealthStates.map(app => this.valueResolver.resolveHealthStatus(app.AggregatedHealthState));
-        return this.valueResolver.resolveHealthStatus(Utils.max(deployedAppsHealthStates.map( healthState => HealthStateConstants.Values[healthState.text])).toString());
+        return this.valueResolver.resolveHealthStatus(Utils.max(deployedAppsHealthStates.map( healthState => (HealthStateConstants.Values as any)[healthState.text])).toString());
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplicationHealth> {
@@ -298,7 +298,7 @@ export class ApplicationUpgradeProgress extends DataModelBase<IRawApplicationUpg
 
     public unhealthyEvaluations: HealthEvaluation[] = [];
     public upgradeDomains: UpgradeDomain[] = [];
-    public upgradeDescription: UpgradeDescription;
+    public upgradeDescription!: UpgradeDescription;
 
     public constructor(data: DataService, public parent: Application) {
         super(data, null, parent);

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -87,7 +87,7 @@ export class Application extends DataModelBase<IRawApplication> {
     }
 
     public get resourceId(): string {
-        return this.raw.ApplicationMetadata?.ArmMetadata?.ArmResourceId ?? '';
+        return this.raw.ApplicationMetadata?.ArmMetadata?.ArmResourceId!;
     }
 
     public get isArmManaged(): boolean{
@@ -121,7 +121,7 @@ export class Application extends DataModelBase<IRawApplication> {
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplication> {
-        return this.data.restClient.getApplication(this.id, !!this.data.readOnlyHeader, messageHandler);
+        return this.data.restClient.getApplication(this.id, this.data.readOnlyHeader!, messageHandler);
     }
 
     private setUpActions(): void {

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -1,6 +1,6 @@
 import {
     IRawApplication, IRawApplicationHealth, IRawApplicationManifest, IRawDeployedApplicationHealthState,
-    IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo
+    IRawApplicationUpgradeProgress, IRawApplicationBackupConfigurationInfo, IRawDeployedReplica
 } from '../RawDataTypes';
 import { DataModelBase, IDecorators } from './Base';
 import { HtmlUtils } from 'src/app/Utils/HtmlUtils';
@@ -168,7 +168,7 @@ export class Application extends DataModelBase<IRawApplication> {
     private cleanUpApplicationReplicas() {
         this.data.getNodes(true)
             .subscribe(nodes => {
-                const replicas: any[] = [];
+                const replicas: { Replica: IRawDeployedReplica; NodeName: string }[] = [];
 
                 const replicaQueries = nodes.collection.map((node) =>
                     this.data.restClient.getReplicasOnNode(node.name, this.id)

--- a/src/SfxWeb/src/app/Models/DataModels/Application.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Application.ts
@@ -243,7 +243,7 @@ export class ApplicationHealth extends HealthBase<IRawApplicationHealth> {
 
     public get deploymentsHealthState(): ITextAndBadge {
         const deployedAppsHealthStates = this.raw.DeployedApplicationHealthStates.map(app => this.valueResolver.resolveHealthStatus(app.AggregatedHealthState));
-        return this.valueResolver.resolveHealthStatus(Utils.max(deployedAppsHealthStates.map( healthState => (HealthStateConstants.Values as any)[healthState.text])).toString());
+        return this.valueResolver.resolveHealthStatus(Utils.max(deployedAppsHealthStates.map( healthState => HealthStateConstants.getValue(healthState.text))).toString());
     }
 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawApplicationHealth> {

--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -45,7 +45,7 @@ export class ApplicationType extends DataModelBase<IRawApplicationType> {
     }
 
     public get resourceId(): string {
-        return this.raw.ApplicationTypeMetadata?.ArmMetadata?.ArmResourceId ?? '';
+        return this.raw.ApplicationTypeMetadata?.ArmMetadata?.ArmResourceId!;
     }
 
     public get isArmManaged(): boolean{
@@ -94,7 +94,7 @@ export class ApplicationType extends DataModelBase<IRawApplicationType> {
             },
             ActionDialogComponent,
             () => true,
-            undefined,
+            null!,
             {
                 title: "Create app instance",
             },
@@ -180,10 +180,10 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
             () => true,
             {
                 title: 'Confirm Type Unprovision',
-                class: this.isArmManaged ? 'warning' : undefined
+                class: this.isArmManaged ? 'warning' : null!
             },
             {
-                template: this.isArmManaged ? MessageWithWarningComponent : undefined,
+                template: this.isArmManaged ? MessageWithWarningComponent : null!,
                 inputs: {
                     message: `Unprovision all ${this.isArmManaged ? " non-arm managed " : null} versions of application type ${this.name} from cluster ${window.location.host}?`,
                     confirmationKeyword: this.name,

--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -24,7 +24,7 @@ import { ActionDialogComponent } from 'src/app/modules/action-dialog/action-dial
 
 export class ApplicationType extends DataModelBase<IRawApplicationType> {
     /*IsInUse is only set on the AppType on the appType Essential page*/
-    public isInUse: boolean = null;
+    public isInUse: boolean | null = null;
     public serviceTypes: ServiceTypeCollection;
 
     public constructor(data: DataService, raw?: IRawApplicationType) {
@@ -45,7 +45,7 @@ export class ApplicationType extends DataModelBase<IRawApplicationType> {
     }
 
     public get resourceId(): string {
-        return this.raw.ApplicationTypeMetadata?.ArmMetadata?.ArmResourceId;
+        return this.raw.ApplicationTypeMetadata?.ArmMetadata?.ArmResourceId ?? '';
     }
 
     public get isArmManaged(): boolean{
@@ -94,7 +94,7 @@ export class ApplicationType extends DataModelBase<IRawApplicationType> {
             },
             ActionDialogComponent,
             () => true,
-            null,
+            undefined,
             {
                 title: "Create app instance",
             },
@@ -141,7 +141,7 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
       this.apps = apps.collection.filter(app => app.raw.TypeName === this.name);
 
       if (this.apps.length > 0) {
-        this.appsHealthState = this.valueResolver.resolveHealthStatus(Utils.max(this.apps.map(app => HealthStateConstants.Values[app.healthState.text])).toString());
+        this.appsHealthState = this.valueResolver.resolveHealthStatus(Utils.max(this.apps.map(app => (HealthStateConstants.Values as any)[app.healthState.text])).toString());
       } else {
         // When there are no apps in this apptype, treat it as healthy
         this.appsHealthState = ValueResolver.healthStatuses[1];
@@ -180,10 +180,10 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
             () => true,
             {
                 title: 'Confirm Type Unprovision',
-                class: this.isArmManaged ? 'warning' : null
+                class: this.isArmManaged ? 'warning' : undefined
             },
             {
-                template: this.isArmManaged ? MessageWithWarningComponent : null,
+                template: this.isArmManaged ? MessageWithWarningComponent : undefined,
                 inputs: {
                     message: `Unprovision all ${this.isArmManaged ? " non-arm managed " : null} versions of application type ${this.name} from cluster ${window.location.host}?`,
                     confirmationKeyword: this.name,
@@ -196,7 +196,7 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
 
     private unprovision(): Observable<any> {
         return this.data.getAppTypeGroup(this.name, true).pipe(mergeMap(appTypeGroup => {
-            const unprovisonPromises = [];
+            const unprovisonPromises: any[] = [];
             appTypeGroup.appTypes.forEach(applicationType => {
                 if (!applicationType.isArmManaged) {
                     unprovisonPromises.push(applicationType.unprovision());

--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -196,7 +196,7 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
 
     private unprovision(): Observable<any> {
         return this.data.getAppTypeGroup(this.name, true).pipe(mergeMap(appTypeGroup => {
-            const unprovisonPromises: any[] = [];
+            const unprovisonPromises: Observable<any>[] = [];
             appTypeGroup.appTypes.forEach(applicationType => {
                 if (!applicationType.isArmManaged) {
                     unprovisonPromises.push(applicationType.unprovision());

--- a/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ApplicationType.ts
@@ -141,7 +141,7 @@ export class ApplicationTypeGroup extends DataModelBase<IRawApplicationType> {
       this.apps = apps.collection.filter(app => app.raw.TypeName === this.name);
 
       if (this.apps.length > 0) {
-        this.appsHealthState = this.valueResolver.resolveHealthStatus(Utils.max(this.apps.map(app => (HealthStateConstants.Values as any)[app.healthState.text])).toString());
+        this.appsHealthState = this.valueResolver.resolveHealthStatus(Utils.max(this.apps.map(app => HealthStateConstants.getValue(app.healthState.text))).toString());
       } else {
         // When there are no apps in this apptype, treat it as healthy
         this.appsHealthState = ValueResolver.healthStatuses[1];

--- a/src/SfxWeb/src/app/Models/DataModels/Base.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Base.ts
@@ -80,7 +80,7 @@ export class DataModelBase<T> implements IDataModel<T> {
     public parent: any;
 
     protected valueResolver: ValueResolver;
-    private refreshingPromise: Subject<any> | null = null;
+    private refreshingPromise?: Subject<any> | null;
 
     public get isRefreshing(): boolean {
         return !!this.refreshingPromise;

--- a/src/SfxWeb/src/app/Models/DataModels/Base.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Base.ts
@@ -75,12 +75,12 @@ export interface IDecorators {
 
 export class DataModelBase<T> implements IDataModel<T> {
     public isInitialized: boolean;
-    public actions: ActionCollection;
+    public actions!: ActionCollection;
     public raw: T;
     public parent: any;
 
     protected valueResolver: ValueResolver;
-    private refreshingPromise: Subject<any>;
+    private refreshingPromise: Subject<any> | null = null;
 
     public get isRefreshing(): boolean {
         return !!this.refreshingPromise;
@@ -111,8 +111,8 @@ export class DataModelBase<T> implements IDataModel<T> {
         return ValueResolver.unknown;
     }
 
-    public constructor(public data: DataService, raw?: T, parent?: any) {
-        this.raw = raw;
+    public constructor(public data: DataService, raw?: T | null, parent?: any) {
+        this.raw = raw!;
         this.parent = parent;
         this.valueResolver = new ValueResolver();
 
@@ -131,12 +131,12 @@ export class DataModelBase<T> implements IDataModel<T> {
             this.retrieveNewData(messageHandler).pipe(mergeMap((raw: T) => {
                 return this.update(raw);
             })).subscribe( data => {
-                this.refreshingPromise.next(this);
-                this.refreshingPromise.complete();
+                this.refreshingPromise!.next(this);
+                this.refreshingPromise!.complete();
                 this.refreshingPromise = null;
             },
             err => {
-                this.refreshingPromise.error(this);
+                this.refreshingPromise!.error(this);
                 this.refreshingPromise = null;
             });
 
@@ -161,7 +161,7 @@ export class DataModelBase<T> implements IDataModel<T> {
     }
 
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IHealthStateFilter {
-        return null;
+        return null!;
     }
 
     public mergeHealthStateChunk(healthChunk: IHealthStateChunk): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/Base.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Base.ts
@@ -174,7 +174,7 @@ export class DataModelBase<T> implements IDataModel<T> {
     }
 
     protected get rawAny(): any {
-        return this.raw as any;
+        return this.raw;
     }
 
     // Derived class should override this function to retrieve new version of raw data.

--- a/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
@@ -128,7 +128,7 @@ export interface INodeTypeInfo {
 }
 
 export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
-    public clusterManifestName: string;
+    public clusterManifestName!: string;
 
     public isSfrpCluster = false;
     public isSfmcCluster = false;
@@ -139,7 +139,7 @@ export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
     public isRepairManagerEnabled = false;
     public isEventStoreEnabled = false;
     public eventStoreTimeRange = 30;
-    public nodeTypeProperties: INodeTypeInfo[];
+    public nodeTypeProperties!: INodeTypeInfo[];
 
     public constructor(data: DataService) {
         super(data);
@@ -153,8 +153,8 @@ export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
         const params = element.getElementsByTagName('Parameter');
         for (let i = 0; i < params.length; i ++) {
             const item = params.item(i);
-            if (item.getAttribute('Name') === 'ImageStoreConnectionString'){
-                this.imageStoreConnectionString = item.getAttribute('Value');
+            if (item!.getAttribute('Name') === 'ImageStoreConnectionString'){
+                this.imageStoreConnectionString = item!.getAttribute('Value')!;
                 break;
             }
         }
@@ -165,8 +165,8 @@ export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
         const sfmcResourceIdSegment = 'microsoft.servicefabric/managedclusters/';
         for (let i = 0; i < params.length; i ++) {
             const item = params.item(i);
-            const armResourceId = item.getAttribute('Value');
-            if (item.getAttribute('Name') === 'ArmResourceId' &&
+            const armResourceId = item!.getAttribute('Value');
+            if (item!.getAttribute('Name') === 'ArmResourceId' &&
                 armResourceId &&
                 armResourceId.toLowerCase().includes(sfmcResourceIdSegment)) {
                 this.isSfmcCluster = true;
@@ -182,14 +182,14 @@ export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
 
       for (let nodeIndex = 0; nodeIndex < XMLnodeTypes.length; ++nodeIndex) {
         const XMLnode = XMLnodeTypes[nodeIndex]
-        const nodeType = XMLnode.getAttribute("Name")
+        const nodeType = XMLnode.getAttribute("Name")!
         const placementProperties = XMLnode.getElementsByTagName("PlacementProperties")
         let keyProperties: Record<string, string> = {}
         for (let i = 0; i < placementProperties.length; ++i) {
           const properties = placementProperties[i].getElementsByTagName("Property")
 
           for (let j = 0; j < properties.length; j++) {
-            keyProperties[properties[j].getAttribute("Name")] = properties[j].getAttribute("Value")
+            keyProperties[properties[j].getAttribute("Name")!] = properties[j].getAttribute("Value")!
           }
         }
         nodeTypes.push({
@@ -214,30 +214,30 @@ export class ClusterManifest extends DataModelBase<IRawClusterManifest> {
 
         // let $xml = $($.parseXML(this.raw.Manifest));
         const manifest = xml.getElementsByTagName('ClusterManifest')[0];
-        this.clusterManifestName = manifest.getAttribute('Name');
+        this.clusterManifestName = manifest.getAttribute('Name')!;
 
         const FabricSettings = manifest.getElementsByTagName('FabricSettings')[0];
         const management = FabricSettings.getElementsByTagName('Section');
 
         for (let i = 0; i < management.length; i ++) {
             const item = management.item(i);
-            if (item.getAttribute('Name') === 'Management'){
-                this.getImageStoreConnectionString(item);
-            }else if (item.getAttribute('Name') === 'BackupRestoreService'){
+            if (item!.getAttribute('Name') === 'Management'){
+                this.getImageStoreConnectionString(item!);
+            }else if (item!.getAttribute('Name') === 'BackupRestoreService'){
                 this.isBackupRestoreEnabled = true;
-            }else if (item.getAttribute('Name') === 'UpgradeService'){
+            }else if (item!.getAttribute('Name') === 'UpgradeService'){
                 this.isSfrpCluster = true;
-            }else if (item.getAttribute('Name') === 'Paas') {
-                this.checkSFMCCluster(item);
-            }else if (item.getAttribute('Name') === 'RepairManager'){
+            }else if (item!.getAttribute('Name') === 'Paas') {
+                this.checkSFMCCluster(item!);
+            }else if (item!.getAttribute('Name') === 'RepairManager'){
                 this.isRepairManagerEnabled = true;
-            }else if (item.getAttribute('Name') === 'EventStoreService'){
+            }else if (item!.getAttribute('Name') === 'EventStoreService'){
                 this.isEventStoreEnabled = true;
-            } else if (item.getAttribute('Name') === 'AzureBlobServiceFabricEtw') {
-                const params = item.getElementsByTagName('Parameter');
+            } else if (item!.getAttribute('Name') === 'AzureBlobServiceFabricEtw') {
+                const params = item!.getElementsByTagName('Parameter');
                 for (let j = 0; j < params.length; j++){
-                    if (params.item(j).getAttribute('Name') === 'DataDeletionAgeInDays') {
-                        this.eventStoreTimeRange = +params.item(j).getAttribute('Value')
+                    if (params.item(j)!.getAttribute('Name') === 'DataDeletionAgeInDays') {
+                        this.eventStoreTimeRange = +params.item(j)!.getAttribute('Value')!
                     }
                 }
             }
@@ -266,7 +266,7 @@ export class ClusterUpgradeProgress extends DataModelBase<IRawClusterUpgradeProg
 
     public unhealthyEvaluations: HealthEvaluation[] = [];
     public upgradeDomains: UpgradeDomain[] = [];
-    public upgradeDescription: UpgradeDescription;
+    public upgradeDescription!: UpgradeDescription;
 
     public get isUpgrading(): boolean {
         return UpgradeDomainStateRegexes.InProgress.test(this.raw.UpgradeState) || this.raw.UpgradeState === ClusterUpgradeStates.RollingForwardPending;
@@ -339,7 +339,7 @@ export class ClusterUpgradeProgress extends DataModelBase<IRawClusterUpgradeProg
     }
 
     protected updateInternal(): Observable<any> | void {
-        this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, null, null, this.data);
+        this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, undefined, null, this.data);
 
         const upgradeUnits = this.isUDUpgrade ? this.raw.UpgradeDomains : this.raw.UpgradeUnits;
         const domains = upgradeUnits.map(ud => new UpgradeDomain(this.data, ud, !this.isUDUpgrade));

--- a/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Cluster.ts
@@ -339,7 +339,7 @@ export class ClusterUpgradeProgress extends DataModelBase<IRawClusterUpgradeProg
     }
 
     protected updateInternal(): Observable<any> | void {
-        this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, undefined, null, this.data);
+        this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, null!, null, this.data);
 
         const upgradeUnits = this.isUDUpgrade ? this.raw.UpgradeDomains : this.raw.UpgradeUnits;
         const domains = upgradeUnits.map(ud => new UpgradeDomain(this.data, ud, !this.isUDUpgrade));

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedApplication.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedApplication.ts
@@ -57,13 +57,13 @@ export class DeployedApplication extends DataModelBase<IRawDeployedApplication> 
             };
             clusterHealthChunkQueryDescription.ApplicationFilters.push(appFilter);
         }
-        let deployedApplicationFilter = appFilter.DeployedApplicationFilters.find(filter => filter.NodeNameFilter === this.parent.name);
+        let deployedApplicationFilter = appFilter.DeployedApplicationFilters!.find(filter => filter.NodeNameFilter === this.parent.name);
         if (!deployedApplicationFilter) {
             deployedApplicationFilter = {
                 NodeNameFilter: this.parent.name,
                 DeployedServicePackageFilters: []
             };
-            appFilter.DeployedApplicationFilters.push(deployedApplicationFilter);
+            appFilter.DeployedApplicationFilters!.push(deployedApplicationFilter);
         }
         if (deployedApplicationFilter.DeployedServicePackageFilters && deployedApplicationFilter.DeployedServicePackageFilters.length === 0) {
             deployedApplicationFilter.DeployedServicePackageFilters = [{

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedCodePackage.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedCodePackage.ts
@@ -16,9 +16,9 @@ import { RoutesService } from 'src/app/services/routes.service';
 // -----------------------------------------------------------------------------
 
 export class DeployedCodePackage extends DataModelBase<IRawDeployedCodePackage> {
-    public mainEntryPoint: CodePackageEntryPoint;
-    public setupEntryPoint: CodePackageEntryPoint;
-    public containerLogs: ContainerLogs;
+    public mainEntryPoint!: CodePackageEntryPoint;
+    public setupEntryPoint!: CodePackageEntryPoint;
+    public containerLogs!: ContainerLogs;
     public containerLogsTail: string;
 
     public constructor(data: DataService, raw: IRawDeployedCodePackage, public parent: DeployedServicePackage) {
@@ -46,7 +46,7 @@ export class DeployedCodePackage extends DataModelBase<IRawDeployedCodePackage> 
     protected retrieveNewData(messageHandler?: IResponseMessageHandler): Observable<IRawDeployedCodePackage> {
         return this.data.restClient.getDeployedCodePackage(this.parent.parent.parent.name, this.parent.parent.id, this.parent.name, this.name, messageHandler)
             .pipe(map(response => {
-                return response.find(raw => raw.ServicePackageActivationId === this.parent.servicePackageActivationId);
+                return response.find(raw => raw.ServicePackageActivationId === this.parent.servicePackageActivationId)!;
             }));
     }
 

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
@@ -32,7 +32,7 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
 
     public address: any;
     public detail: DeployedReplicaDetail;
-    public partition: IRawPartition;
+    public partition!: IRawPartition;
 
     public constructor(data: DataService, raw: IRawDeployedReplica, public parent: DeployedServicePackage) {
         super(data, raw, parent);
@@ -127,7 +127,7 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
     }
 
     public get replicaRoleSortPriority(): number {
-        return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole] || 0;
+        return (SortPriorities.ReplicaRolesToSortPriorities as any)[this.raw.ReplicaRole] || 0;
     }
 
     public restartReplica(): Observable<any> {
@@ -186,8 +186,8 @@ export class DeployedReplicaDetail extends DataModelBase<IRawDeployedReplicaDeta
         ]
     };
 
-    public replicatorStatus: ReplicatorStatus;
-    public reportedLoad: LoadMetricReport[];
+    public replicatorStatus!: ReplicatorStatus;
+    public reportedLoad!: LoadMetricReport[];
 
     public get currentServiceOperationStartTimeUtc(): string {
         return TimeUtils.timestampToUTCString(this.raw.CurrentServiceOperationStartTimeUtc);
@@ -229,7 +229,7 @@ export class DeployedReplicaDetail extends DataModelBase<IRawDeployedReplicaDeta
 }
 
 export class ReplicatorStatus extends DataModelBase<IRawReplicatorStatus> {
-    public remoteReplicators: RemoteReplicatorStatus[];
+    public remoteReplicators!: RemoteReplicatorStatus[];
 
     public get LastCopyOperationReceivedTimeUtc(): string {
         return TimeUtils.timestampToUTCString(this.raw.LastCopyOperationReceivedTimeUtc);

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedReplica.ts
@@ -127,7 +127,7 @@ export class DeployedReplica extends DataModelBase<IRawDeployedReplica> {
     }
 
     public get replicaRoleSortPriority(): number {
-        return (SortPriorities.ReplicaRolesToSortPriorities as any)[this.raw.ReplicaRole] || 0;
+        return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole as keyof typeof SortPriorities.ReplicaRolesToSortPriorities] || 0;
     }
 
     public restartReplica(): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/DeployedServicePackage.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/DeployedServicePackage.ts
@@ -48,7 +48,7 @@ export class DeployedServicePackage extends DataModelBase<IRawDeployedServicePac
         return this.data.restClient.getDeployedServicePackage(this.parent.parent.name, this.parent.id, this.name, messageHandler)
             .pipe(map(response => {
                 return this.servicePackageActivationId
-                    ? response.find(item => this.servicePackageActivationId === item.ServicePackageActivationId)
+                    ? response.find(item => this.servicePackageActivationId === item.ServicePackageActivationId)!
                     : response[0];
             }));
     }

--- a/src/SfxWeb/src/app/Models/DataModels/HealthEvent.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/HealthEvent.ts
@@ -55,7 +55,7 @@ export class HealthBase<T extends IRawHealth> extends DataModelBase<T> {
         // There is no unique ID to identify the unhealthy evaluations collection, update the collection directly.
         // Make sure that the apps are initialized because some of the parsedHealth Evaluations need to reference the app's collection and that needs to be set.
         return this.data.apps.ensureInitialized().pipe(map( () => {
-            this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, null, null, this.data);
+            this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, undefined, null, this.data);
         }));
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/HealthEvent.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/HealthEvent.ts
@@ -55,7 +55,7 @@ export class HealthBase<T extends IRawHealth> extends DataModelBase<T> {
         // There is no unique ID to identify the unhealthy evaluations collection, update the collection directly.
         // Make sure that the apps are initialized because some of the parsedHealth Evaluations need to reference the app's collection and that needs to be set.
         return this.data.apps.ensureInitialized().pipe(map( () => {
-            this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, undefined, null, this.data);
+            this.unhealthyEvaluations = HealthUtils.getParsedHealthEvaluations(this.raw.UnhealthyEvaluations, null!, null, this.data);
         }));
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/ImageStore.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/ImageStore.ts
@@ -14,17 +14,17 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
     // These start as true to not display prematurely while loading correct state.
     public isAvailable = true;
     public isNative = true;
-    public connectionString: string;
+    public connectionString!: string;
     public root: ImageStoreFolder = new ImageStoreFolder();
     public initialized = false;
     public cachedCurrentDirectoryFolderSizes: { [path: string]: {size: number, loading: boolean, date?: Date } } = {};
 
     public currentFolder: ImageStoreFolder;
     public pathBreadcrumbItems: IStorePathBreadcrumbItem[] = [];
-    public allChildren: ImageStoreItem[];
+    public allChildren!: ImageStoreItem[];
 
     public isLoadingFolderContent = false;
-    public currentDirectoryBeingLoaded: string = null;
+    public currentDirectoryBeingLoaded: string | null = null;
 
     // helper to determine which way for slashes to be added in.
     public static slashDirection(path: string): boolean {
@@ -114,7 +114,7 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
             return of(null);
         }
 
-        let item: ImageStoreItem = this.currentFolder.childrenFolders.find(folder => folder.path === path);
+        let item: ImageStoreItem | undefined = this.currentFolder.childrenFolders.find(folder => folder.path === path);
         if (!item) {
             item = this.currentFolder.childrenFiles.find(file => file.path === path);
         }
@@ -158,7 +158,7 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
         });
 
         folder.childrenFiles = content.StoreFiles.map(f => new ImageStoreFile(f));
-        folder.allChildren = [].concat(folder.childrenFiles).concat(folder.childrenFolders);
+        folder.allChildren = ([] as ImageStoreItem[]).concat(folder.childrenFiles).concat(folder.childrenFolders);
         folder.fileCount = folder.childrenFiles.length;
 
         this.currentFolder = folder;
@@ -196,13 +196,13 @@ export class ImageStore extends DataModelBase<IRawImageStoreContent> {
 
 export class ImageStoreItem {
     // Used for name based sorting in the table
-    public isFolder: number;
+    public isFolder!: number;
 
     public path: string;
     public displayName: string;
     public isReserved: boolean;
-    public displayedSize: string;
-    public size: number;
+    public displayedSize!: string;
+    public size!: number;
 
     public uniqueId: string;
 
@@ -219,11 +219,11 @@ export class ImageStoreItem {
 export class ImageStoreFolder extends ImageStoreItem {
     public isFolder = -1;
     public size = -1; // setting to -1 for sorting
-    public fileCount: number;
+    public fileCount!: number;
     public isExpanded = false;
-    public childrenFolders: ImageStoreFolder[];
-    public childrenFiles: ImageStoreFile[];
-    public allChildren: ImageStoreItem[];
+    public childrenFolders!: ImageStoreFolder[];
+    public childrenFiles!: ImageStoreFile[];
+    public allChildren!: ImageStoreItem[];
 
     constructor(raw?: IRawStoreFolder) {
         super(raw ? raw.StoreRelativePath : '');
@@ -239,8 +239,8 @@ export class ImageStoreFolder extends ImageStoreItem {
 export class ImageStoreFile extends ImageStoreItem {
     public isFolder = 1;
 
-    public version: string;
-    public modifiedDate: string;
+    public version!: string;
+    public modifiedDate!: string;
     public size = 0;
 
     constructor(raw?: IRawStoreFile) {

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -90,16 +90,16 @@ export class Node extends DataModelBase<IRawNode> {
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IHealthStateFilter {
         // To get all deployed applications on this node, we need to add deployed application filters in all existing application filters.
         // (There will be at least one application filter there by default which is returned by DataService.getInitialClusterHealthChunkQueryDescription)
-        Object.keys(clusterHealthChunkQueryDescription.ApplicationFilters).forEach(filter => {
-            if (!clusterHealthChunkQueryDescription.ApplicationFilters[filter].DeployedApplicationFilters) {
-                clusterHealthChunkQueryDescription.ApplicationFilters[filter].DeployedApplicationFilters = [];
+        clusterHealthChunkQueryDescription.ApplicationFilters.forEach(appFilter => {
+            if (!appFilter.DeployedApplicationFilters) {
+                appFilter.DeployedApplicationFilters = [];
             }
-            clusterHealthChunkQueryDescription.ApplicationFilters[filter].DeployedApplicationFilters.push(
+            appFilter.DeployedApplicationFilters.push(
                 {
                     NodeNameFilter: this.name
                 });
         });
-        return null;
+        return null!;
     }
 
     public setAdvancedActions(): void {
@@ -249,7 +249,7 @@ export class Node extends DataModelBase<IRawNode> {
 }
 
 export class NodeLoadInformation extends DataModelBase<IRawNodeLoadInformation> {
-    public metrics: Record<string, number>;
+    public metrics!: Record<string, number>;
     public decorators: IDecorators = {
         hideList: [
             'NodeName'
@@ -290,7 +290,7 @@ export class NodeLoadMetricInformation extends DataModelBase<IRawNodeLoadMetricI
         ]
     };
     public get hasCapacity(): boolean {
-        return this.raw.NodeCapacity && +this.raw.NodeCapacity > 0;
+        return !!this.raw.NodeCapacity && +this.raw.NodeCapacity > 0;
     }
 
     public get isSystemMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -90,11 +90,11 @@ export class Node extends DataModelBase<IRawNode> {
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IHealthStateFilter {
         // To get all deployed applications on this node, we need to add deployed application filters in all existing application filters.
         // (There will be at least one application filter there by default which is returned by DataService.getInitialClusterHealthChunkQueryDescription)
-        clusterHealthChunkQueryDescription.ApplicationFilters.forEach(appFilter => {
-            if (!appFilter.DeployedApplicationFilters) {
-                appFilter.DeployedApplicationFilters = [];
+        Object.keys(clusterHealthChunkQueryDescription.ApplicationFilters).forEach(filter => {
+            if (!(clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters) {
+                (clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters = [];
             }
-            appFilter.DeployedApplicationFilters.push(
+            (clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters.push(
                 {
                     NodeNameFilter: this.name
                 });
@@ -290,7 +290,7 @@ export class NodeLoadMetricInformation extends DataModelBase<IRawNodeLoadMetricI
         ]
     };
     public get hasCapacity(): boolean {
-        return !!this.raw.NodeCapacity && +this.raw.NodeCapacity > 0;
+        return (this.raw.NodeCapacity && +this.raw.NodeCapacity > 0) as unknown as boolean;
     }
 
     public get isSystemMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -290,7 +290,7 @@ export class NodeLoadMetricInformation extends DataModelBase<IRawNodeLoadMetricI
         ]
     };
     public get hasCapacity(): boolean {
-        return (this.raw.NodeCapacity && +this.raw.NodeCapacity > 0) as unknown as boolean;
+        return !!this.raw.NodeCapacity && +this.raw.NodeCapacity > 0;
     }
 
     public get isSystemMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Node.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Node.ts
@@ -90,11 +90,11 @@ export class Node extends DataModelBase<IRawNode> {
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IHealthStateFilter {
         // To get all deployed applications on this node, we need to add deployed application filters in all existing application filters.
         // (There will be at least one application filter there by default which is returned by DataService.getInitialClusterHealthChunkQueryDescription)
-        Object.keys(clusterHealthChunkQueryDescription.ApplicationFilters).forEach(filter => {
-            if (!(clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters) {
-                (clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters = [];
+        clusterHealthChunkQueryDescription.ApplicationFilters.forEach(appFilter => {
+            if (!appFilter.DeployedApplicationFilters) {
+                appFilter.DeployedApplicationFilters = [];
             }
-            (clusterHealthChunkQueryDescription.ApplicationFilters as any)[filter].DeployedApplicationFilters.push(
+            appFilter.DeployedApplicationFilters.push(
                 {
                     NodeNameFilter: this.name
                 });

--- a/src/SfxWeb/src/app/Models/DataModels/PartitionBackupInfo.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/PartitionBackupInfo.ts
@@ -17,15 +17,15 @@ export class PartitionBackupInfo {
     public partitionBackupConfigurationInfo: PartitionBackupConfigurationInfo;
     public partitionBackupList: PartitionBackupCollection;
     public latestPartitionBackup: SinglePartitionBackupCollection;
-    public backupPolicyName: string;
+    public backupPolicyName!: string;
     public cleanBackup: boolean;
-    public storage: IRawStorage;
-    public backupId: string;
-    public backupLocation: string;
+    public storage!: IRawStorage;
+    public backupId!: string;
+    public backupLocation!: string;
     public partitionBackupProgress: PartitionBackupProgress;
     public partitionRestoreProgress: PartitionRestoreProgress;
-    public BackupTimeout: number;
-    public RestoreTimeout: number;
+    public BackupTimeout!: number;
+    public RestoreTimeout!: number;
 
     public constructor(data: DataService, public parent: Partition) {
 
@@ -99,7 +99,7 @@ export class PartitionBackup extends DataModelBase<IRawPartitionBackup> {
                 () => true
             );
         } else {
-            this.action = null;
+            this.action = null!;
         }
     }
 

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -168,7 +168,7 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
     }
 
     public get replicaRoleSortPriority(): number {
-        return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole] || 0;
+        return (SortPriorities.ReplicaRolesToSortPriorities as any)[this.raw.ReplicaRole] || 0;
     }
 
     public get stoppedReplicaExpirationTimeUtc(): string {

--- a/src/SfxWeb/src/app/Models/DataModels/Replica.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Replica.ts
@@ -168,7 +168,7 @@ export class ReplicaOnPartition extends DataModelBase<IRawReplicaOnPartition> {
     }
 
     public get replicaRoleSortPriority(): number {
-        return (SortPriorities.ReplicaRolesToSortPriorities as any)[this.raw.ReplicaRole] || 0;
+        return SortPriorities.ReplicaRolesToSortPriorities[this.raw.ReplicaRole as keyof typeof SortPriorities.ReplicaRolesToSortPriorities] || 0;
     }
 
     public get stoppedReplicaExpirationTimeUtc(): string {

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -54,7 +54,7 @@ export class Service extends DataModelBase<IRawService> {
     public health: ServiceHealth;
     public description: ServiceDescription;
     public serviceBackupConfigurationInfoCollection: ServiceBackupConfigurationInfoCollection;
-    public backupPolicyName: string;
+    public backupPolicyName!: string;
     public cleanBackup: boolean;
 
     public constructor(data: DataService, raw: IRawService, public parent: Application) {
@@ -100,7 +100,7 @@ export class Service extends DataModelBase<IRawService> {
     }
 
     public get resourceId(): string {
-        return this.raw.ServiceMetadata?.ArmMetadata?.ArmResourceId;
+        return this.raw.ServiceMetadata?.ArmMetadata?.ArmResourceId ?? '';
     }
 
     public get isArmManaged(): boolean {
@@ -109,15 +109,15 @@ export class Service extends DataModelBase<IRawService> {
 
     public addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription: IClusterHealthChunkQueryDescription): IServiceHealthStateFilter {
         const appFilter = this.parent.addHealthStateFiltersForChildren(clusterHealthChunkQueryDescription);
-        let serviceFilter = appFilter.ServiceFilters.find(filter => filter.ServiceNameFilter === this.name);
+        let serviceFilter = appFilter.ServiceFilters!.find(filter => filter.ServiceNameFilter === this.name);
         if (!serviceFilter) {
             serviceFilter = {
                 ServiceNameFilter: this.name,
                 PartitionFilters: []
             };
-            appFilter.ServiceFilters.push(serviceFilter);
+            appFilter.ServiceFilters!.push(serviceFilter);
         }
-        if (serviceFilter.PartitionFilters.length === 0) {
+        if (serviceFilter.PartitionFilters!.length === 0) {
             serviceFilter.PartitionFilters = [{
                 HealthStateFilter: HealthStateFilterFlags.All
             }];
@@ -173,7 +173,7 @@ export class Service extends DataModelBase<IRawService> {
                     this,
                     ActionDialogComponent,
                     () => this.isStatelessService,
-                    null,
+                    undefined,
                     {
                         title: "Scale Service",
                     },
@@ -286,7 +286,7 @@ export class ServiceType extends DataModelBase<IRawServiceType> {
 
 export class ServiceManifest extends DataModelBase<IRawServiceManifest> {
     public packages: ServiceTypePackage[] = [];
-    public serviceManifestName: string;
+    public serviceManifestName!: string;
 
     public constructor(data: DataService, public parent: DeployedServicePackage | ServiceType) {
         super(data, null, parent);
@@ -310,12 +310,12 @@ export class ServiceManifest extends DataModelBase<IRawServiceManifest> {
             const xml = parser.parseFromString(this.raw.Manifest, 'text/xml');
 
             const manifest = xml.getElementsByTagName('ServiceManifest')[0];
-            this.serviceManifestName = manifest.getAttribute('Name');
+            this.serviceManifestName = manifest.getAttribute('Name')!;
 
             // let $xml = $($.parseXML(this.raw.Manifest));
             let packType = xml.getElementsByTagName('CodePackage');
 
-            const packages = [];
+            const packages: any[] = [];
             Array.from(packType).forEach( (item: any) => {
                 packages.push(new ServiceTypePackage(this.data, 'Code', item.getAttribute('Name'), item.getAttribute('Version')));
             });
@@ -346,11 +346,11 @@ export class ServiceTypePackage extends DataModelBase<any> {
 }
 
 export class CreateServiceDescription {
-    public raw: IRawCreateServiceDescription;
+    public raw!: IRawCreateServiceDescription;
 
-    public initializationData: string;
-    public createFromTemplate: boolean;
-    public isAdvancedOptionCollapsed: boolean;
+    public initializationData!: string;
+    public createFromTemplate!: boolean;
+    public isAdvancedOptionCollapsed!: boolean;
 
     public get createDescription(): IRawCreateServiceDescription {
         const descriptionCloned = cloneDeep(this.raw);
@@ -378,7 +378,7 @@ export class CreateServiceDescription {
              
             flags ^= 0x80;
         } else {
-            delete descriptionCloned.AuxiliaryReplicaCount;
+            delete (descriptionCloned as any).AuxiliaryReplicaCount;
             if (this.raw.ServiceLoadMetrics !== null && this.raw.ServiceLoadMetrics.length > 0) {
                 descriptionCloned.ServiceLoadMetrics.forEach(metric => delete metric.AuxiliaryDefaultLoad);
             }

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -100,7 +100,7 @@ export class Service extends DataModelBase<IRawService> {
     }
 
     public get resourceId(): string {
-        return this.raw.ServiceMetadata?.ArmMetadata?.ArmResourceId ?? '';
+        return this.raw.ServiceMetadata?.ArmMetadata?.ArmResourceId!;
     }
 
     public get isArmManaged(): boolean {
@@ -173,7 +173,7 @@ export class Service extends DataModelBase<IRawService> {
                     this,
                     ActionDialogComponent,
                     () => this.isStatelessService,
-                    undefined,
+                    null!,
                     {
                         title: "Scale Service",
                     },

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -315,7 +315,7 @@ export class ServiceManifest extends DataModelBase<IRawServiceManifest> {
             // let $xml = $($.parseXML(this.raw.Manifest));
             let packType = xml.getElementsByTagName('CodePackage');
 
-            const packages: any[] = [];
+            const packages: ServiceTypePackage[] = [];
             Array.from(packType).forEach( (item: any) => {
                 packages.push(new ServiceTypePackage(this.data, 'Code', item.getAttribute('Name'), item.getAttribute('Version')));
             });

--- a/src/SfxWeb/src/app/Models/DataModels/Service.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Service.ts
@@ -378,7 +378,7 @@ export class CreateServiceDescription {
              
             flags ^= 0x80;
         } else {
-            delete (descriptionCloned as any).AuxiliaryReplicaCount;
+            delete (descriptionCloned as Partial<typeof descriptionCloned>).AuxiliaryReplicaCount;
             if (this.raw.ServiceLoadMetrics !== null && this.raw.ServiceLoadMetrics.length > 0) {
                 descriptionCloned.ServiceLoadMetrics.forEach(metric => delete metric.AuxiliaryDefaultLoad);
             }

--- a/src/SfxWeb/src/app/Models/DataModels/Shared.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Shared.ts
@@ -82,7 +82,7 @@ export class LoadMetricInformation extends DataModelBase<IRawLoadMetricInformati
     }
 
     public get hasCapacity(): boolean {
-        return !!this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0;
+        return (this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0) as unknown as boolean;
     }
 
     public get isResourceGovernanceMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Shared.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Shared.ts
@@ -13,10 +13,10 @@ import { Utils } from 'src/app/Utils/Utils';
 
 export class HealthEvaluation extends DataModelBase<IRawHealthEvaluation> {
     public viewPathUrl = '';
-    public children: any[];
-    public displayName: string;
-    public constructor(raw: IRawHealthEvaluation, public level: number = 0, parent: HealthEvaluation = null, viewPathUrl: string = '') {
-        super(null, raw, parent);
+    public children!: any[];
+    public displayName!: string;
+    public constructor(raw: IRawHealthEvaluation, public level: number = 0, parent: HealthEvaluation | null = null, viewPathUrl: string = '') {
+        super(null!, raw, parent);
         this.viewPathUrl = viewPathUrl;
     }
 
@@ -34,7 +34,7 @@ export class HealthEvaluation extends DataModelBase<IRawHealthEvaluation> {
 
     public get uniqueId(): string {
         // Explicitly set this to null to allow detail-list directive to use angular build-in parameter $id to track the list.
-        return null;
+        return null!;
     }
 
     public get sourceTimeStamp(): string {
@@ -71,18 +71,18 @@ export class LoadMetricInformation extends DataModelBase<IRawLoadMetricInformati
         ]
     };
 
-    public selected: boolean;
+    public selected!: boolean;
 
     public get minNodeLoadId(): string {
-        return this.raw.MinNodeLoadId.Id;
+        return this.raw.MinNodeLoadId!.Id;
     }
 
     public get maxNodeLoadId(): string {
-        return this.raw.MaxNodeLoadId.Id;
+        return this.raw.MaxNodeLoadId!.Id;
     }
 
     public get hasCapacity(): boolean {
-        return this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0;
+        return !!this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0;
     }
 
     public get isResourceGovernanceMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/Shared.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Shared.ts
@@ -13,7 +13,7 @@ import { Utils } from 'src/app/Utils/Utils';
 
 export class HealthEvaluation extends DataModelBase<IRawHealthEvaluation> {
     public viewPathUrl = '';
-    public children!: any[];
+    public children!: HealthEvaluation[];
     public displayName!: string;
     public constructor(raw: IRawHealthEvaluation, public level: number = 0, parent: HealthEvaluation | null = null, viewPathUrl: string = '') {
         super(null!, raw, parent);

--- a/src/SfxWeb/src/app/Models/DataModels/Shared.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/Shared.ts
@@ -82,7 +82,7 @@ export class LoadMetricInformation extends DataModelBase<IRawLoadMetricInformati
     }
 
     public get hasCapacity(): boolean {
-        return (this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0) as unknown as boolean;
+        return !!this.raw.ClusterCapacity && +this.raw.ClusterCapacity > 0;
     }
 
     public get isResourceGovernanceMetric(): boolean {

--- a/src/SfxWeb/src/app/Models/DataModels/cluster.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/cluster.spec.ts
@@ -16,7 +16,7 @@ describe('Cluster', () => {
         apps: {
             ensureInitialized: () => of(null)
         }
-    } as DataService;
+    } as unknown as DataService;
 
     describe('manifest', () => {
 

--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -47,8 +47,8 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
     protected valueResolver: ValueResolver = new ValueResolver();
 
     private appendOnly: boolean;
-    private hash: Record<string, T>;
-    private refreshingPromise: Subject<any>;
+    private hash!: Record<string, T>;
+    private refreshingPromise: Subject<any> | null = null;
 
     public get viewPath(): string {
         return '';
@@ -92,8 +92,8 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
                     this.collection = [];
                 }
                 this.lastRefreshWasSuccessful = success;
-                this.refreshingPromise.next(success);
-                this.refreshingPromise.complete();
+                this.refreshingPromise!.next(success);
+                this.refreshingPromise!.complete();
                 this.refreshingPromise = null;
             });
             // , error => {
@@ -161,7 +161,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         if (this.hash) {
             return this.hash[uniqueId];
         }
-        return null;
+        return null!;
     }
 
     public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
@@ -182,7 +182,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         healthChunkList: IHealthStateChunkList<P>,
         newIdSelector: (item: P) => string): Observable<any> {
 
-        if (!CollectionUtils.compareCollectionsByKeys(this.collection, healthChunkList.Items, item => item[this.indexPropery], newIdSelector)) {
+        if (!CollectionUtils.compareCollectionsByKeys(this.collection, healthChunkList.Items, item => (item as any)[this.indexPropery], newIdSelector)) {
             if (!this.isRefreshing) {
                 // If the health chunk data has different set of keys, refresh the entire collection
                 // to get full information of the new items.
@@ -193,11 +193,11 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         }
 
         // Merge health chunk data
-        const updatePromises = [];
+        const updatePromises: any[] = [];
         CollectionUtils.updateCollection<T, P>(
             this.collection,
             healthChunkList.Items,
-            item => item[this.indexPropery],
+            item => (item as any)[this.indexPropery],
             newIdSelector,
             null, // no need to create object because a full refresh will be scheduled when new object is returned by health chunk API,
             // which is needed because the information returned by the health chunk api is not enough for us to create a full data object.
@@ -210,6 +210,6 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
 
     // Derived class should implement this if it is going to use details-view directive as child and call showDetails(itemId).
     protected getDetailsList(item: any): IDataModelCollection<any> {
-        return null;
+        return null!;
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -48,7 +48,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
 
     private appendOnly: boolean;
     private hash!: Record<string, T>;
-    private refreshingPromise: Subject<any> | null = null;
+    private refreshingPromise?: Subject<any> | null;
 
     public get viewPath(): string {
         return '';

--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -62,7 +62,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         return !!this.refreshingPromise;
     }
 
-    protected get indexPropery(): string {
+    protected get indexPropery(): keyof IDataModel<any> {
         // index the collection by "uniqueId" by default
         return 'uniqueId';
     }
@@ -182,7 +182,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         healthChunkList: IHealthStateChunkList<P>,
         newIdSelector: (item: P) => string): Observable<any> {
 
-        if (!CollectionUtils.compareCollectionsByKeys(this.collection, healthChunkList.Items, item => (item as any)[this.indexPropery], newIdSelector)) {
+        if (!CollectionUtils.compareCollectionsByKeys(this.collection, healthChunkList.Items, item => item[this.indexPropery], newIdSelector)) {
             if (!this.isRefreshing) {
                 // If the health chunk data has different set of keys, refresh the entire collection
                 // to get full information of the new items.
@@ -193,11 +193,11 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         }
 
         // Merge health chunk data
-        const updatePromises: any[] = [];
+        const updatePromises: Observable<any>[] = [];
         CollectionUtils.updateCollection<T, P>(
             this.collection,
             healthChunkList.Items,
-            item => (item as any)[this.indexPropery],
+            item => item[this.indexPropery],
             newIdSelector,
             null, // no need to create object because a full refresh will be scheduled when new object is returned by health chunk API,
             // which is needed because the information returned by the health chunk api is not enough for us to create a full data object.

--- a/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/CollectionBase.ts
@@ -62,7 +62,7 @@ export class DataModelCollectionBase<T extends IDataModel<any>> implements IData
         return !!this.refreshingPromise;
     }
 
-    protected get indexPropery(): keyof IDataModel<any> {
+    protected get indexPropery(): keyof T & string {
         // index the collection by "uniqueId" by default
         return 'uniqueId';
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -62,7 +62,7 @@ export class ApplicationCollection extends DataModelCollectionBase<Application> 
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
-        return this.data.restClient.getApplications(!!this.data.readOnlyHeader, messageHandler).pipe(map(items => {
+        return this.data.restClient.getApplications(this.data.readOnlyHeader!, messageHandler).pipe(map(items => {
             return items.map(raw => new Application(this.data, raw));
         }));
     }
@@ -106,7 +106,7 @@ export class ApplicationTypeGroupCollection extends DataModelCollectionBase<Appl
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
-        return this.data.restClient.getApplicationTypes(undefined, messageHandler).pipe(map(response => {
+        return this.data.restClient.getApplicationTypes(null!, messageHandler).pipe(map(response => {
             this.appTypeCount = response.length;
             const appTypes = response.map(item => new ApplicationType(this.data, item));
             const groups = groupBy(appTypes, item => item.raw.Name);
@@ -397,7 +397,7 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
     }
 
     public resetDateWindow(): boolean {
-        return this.setDateWindow(undefined, undefined);
+        return this.setDateWindow(null!, null!);
     }
 
     public reload(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -40,7 +40,7 @@ export class BackupPolicyCollection extends DataModelCollectionBase<BackupPolicy
 
 export class ApplicationCollection extends DataModelCollectionBase<Application> {
     public upgradingAppCount = 0;
-    public healthState: ITextAndBadge;
+    public healthState!: ITextAndBadge;
 
     public constructor(data: DataService) {
         super(data);
@@ -62,7 +62,7 @@ export class ApplicationCollection extends DataModelCollectionBase<Application> 
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
-        return this.data.restClient.getApplications(this.data.readOnlyHeader, messageHandler).pipe(map(items => {
+        return this.data.restClient.getApplications(!!this.data.readOnlyHeader, messageHandler).pipe(map(items => {
             return items.map(raw => new Application(this.data, raw));
         }));
     }
@@ -74,10 +74,10 @@ export class ApplicationCollection extends DataModelCollectionBase<Application> 
     }
 
     private updateAppsHealthState(): void {
-        this.collection.map(app => HealthStateConstants.Values[app.healthState.text]);
+        this.collection.map(app => (HealthStateConstants.Values as any)[app.healthState.text]);
         // calculates the applications health state which is the max state value of all applications
         this.healthState = this.length > 0
-            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => HealthStateConstants.Values[app.healthState.text]) as number[]).toString())
+            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => (HealthStateConstants.Values as any)[app.healthState.text]) as number[]).toString())
             : ValueResolver.healthStatuses[1];
     }
 
@@ -106,7 +106,7 @@ export class ApplicationTypeGroupCollection extends DataModelCollectionBase<Appl
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
-        return this.data.restClient.getApplicationTypes(null, messageHandler).pipe(map(response => {
+        return this.data.restClient.getApplicationTypes(undefined, messageHandler).pipe(map(response => {
             this.appTypeCount = response.length;
             const appTypes = response.map(item => new ApplicationType(this.data, item));
             const groups = groupBy(appTypes, item => item.raw.Name);
@@ -117,8 +117,8 @@ export class ApplicationTypeGroupCollection extends DataModelCollectionBase<Appl
     public getAppTypeUsage(): Observable<IAppTypeUsage> {
       return this.data.getApps(true).pipe(map(() => {
           // check on refresh which appTypes are being used by at least one application
-          const activeAppTypes = [];
-          const inactiveAppTypes = [];
+          const activeAppTypes: any[] = [];
+          const inactiveAppTypes: any[] = [];
           this.collection.forEach(appTypeGroup => appTypeGroup.appTypes.forEach(appType => {
             if (appType.isInUse) {
               activeAppTypes.push(appType);
@@ -167,8 +167,8 @@ export class PartitionBackupCollection extends DataModelCollectionBase<Partition
     public endDate: Date;
     public constructor(data: DataService, public parent: PartitionBackupInfo) {
         super(data, parent);
-        this.startDate = null;
-        this.endDate = null;
+        this.startDate = null!;
+        this.endDate = null!;
     }
 
     public retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {
@@ -352,8 +352,8 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
     public readonly defaultDateWindowInDays: number = 7;
     protected readonly optionalColsStartIndex: number = 2;
 
-    private iStartDate: Date;
-    private iEndDate: Date;
+    private iStartDate!: Date;
+    private iEndDate!: Date;
     protected eventsTypesFilter: string[] = [];
 
     public get startDate() {
@@ -397,7 +397,7 @@ export abstract class EventListBase<T extends FabricEventBase> extends DataModel
     }
 
     public resetDateWindow(): boolean {
-        return this.setDateWindow(null, null);
+        return this.setDateWindow(undefined, undefined);
     }
 
     public reload(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -74,10 +74,10 @@ export class ApplicationCollection extends DataModelCollectionBase<Application> 
     }
 
     private updateAppsHealthState(): void {
-        this.collection.map(app => HealthStateConstants.Values[app.healthState.text as keyof typeof HealthStateConstants.Values]);
+        this.collection.map(app => HealthStateConstants.getValue(app.healthState.text));
         // calculates the applications health state which is the max state value of all applications
         this.healthState = this.length > 0
-            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => HealthStateConstants.Values[app.healthState.text as keyof typeof HealthStateConstants.Values])).toString())
+            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => HealthStateConstants.getValue(app.healthState.text))).toString())
             : ValueResolver.healthStatuses[1];
     }
 

--- a/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/Collections.ts
@@ -74,10 +74,10 @@ export class ApplicationCollection extends DataModelCollectionBase<Application> 
     }
 
     private updateAppsHealthState(): void {
-        this.collection.map(app => (HealthStateConstants.Values as any)[app.healthState.text]);
+        this.collection.map(app => HealthStateConstants.Values[app.healthState.text as keyof typeof HealthStateConstants.Values]);
         // calculates the applications health state which is the max state value of all applications
         this.healthState = this.length > 0
-            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => (HealthStateConstants.Values as any)[app.healthState.text]) as number[]).toString())
+            ? this.valueResolver.resolveHealthStatus(Math.max(...this.collection.map(app => HealthStateConstants.Values[app.healthState.text as keyof typeof HealthStateConstants.Values])).toString())
             : ValueResolver.healthStatuses[1];
     }
 
@@ -117,8 +117,8 @@ export class ApplicationTypeGroupCollection extends DataModelCollectionBase<Appl
     public getAppTypeUsage(): Observable<IAppTypeUsage> {
       return this.data.getApps(true).pipe(map(() => {
           // check on refresh which appTypes are being used by at least one application
-          const activeAppTypes: any[] = [];
-          const inactiveAppTypes: any[] = [];
+          const activeAppTypes: ApplicationType[] = [];
+          const inactiveAppTypes: ApplicationType[] = [];
           this.collection.forEach(appTypeGroup => appTypeGroup.appTypes.forEach(appType => {
             if (appType.isInUse) {
               activeAppTypes.push(appType);

--- a/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
@@ -22,6 +22,7 @@ export class DeployedApplicationCollection extends DataModelCollectionBase<Deplo
                 nodeHealthChunk.DeployedApplicationHealthStateChunks,
                 item => IdGenerator.deployedApp(IdUtils.nameToId(item.ApplicationName)));
         }
+        return of(true);
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
@@ -15,14 +15,14 @@ export class DeployedApplicationCollection extends DataModelCollectionBase<Deplo
         super(data, parent);
     }
 
-    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
+    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any>;
+    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> | undefined {
         const nodeHealthChunk = clusterHealthChunk.NodeHealthStateChunks.Items.find(chunk => chunk.NodeName === this.parent.name);
         if (nodeHealthChunk) {
             return this.updateCollectionFromHealthChunkList<IDeployedApplicationHealthStateChunk>(
                 nodeHealthChunk.DeployedApplicationHealthStateChunks,
                 item => IdGenerator.deployedApp(IdUtils.nameToId(item.ApplicationName)));
         }
-        return of(true);
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/DeployedApplicationCollection.ts
@@ -15,14 +15,14 @@ export class DeployedApplicationCollection extends DataModelCollectionBase<Deplo
         super(data, parent);
     }
 
-    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any>;
-    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> | undefined {
+    public mergeClusterHealthStateChunk(clusterHealthChunk: IClusterHealthChunk): Observable<any> {
         const nodeHealthChunk = clusterHealthChunk.NodeHealthStateChunks.Items.find(chunk => chunk.NodeName === this.parent.name);
         if (nodeHealthChunk) {
             return this.updateCollectionFromHealthChunkList<IDeployedApplicationHealthStateChunk>(
                 nodeHealthChunk.DeployedApplicationHealthStateChunks,
                 item => IdGenerator.deployedApp(IdUtils.nameToId(item.ApplicationName)));
         }
+        return of(true);
     }
 
     protected retrieveNewCollection(messageHandler?: IResponseMessageHandler): Observable<any> {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/InfrastructureDocCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/InfrastructureDocCollection.ts
@@ -13,7 +13,7 @@ export interface IInfrastructureDocumentCollectionItem {
 }
 
 export class InfrastructureDocumentCollectionItem extends DataModelBase<IInfrastructureDocumentCollectionItem> {
-    InfrastructureServiceName: string;
+    InfrastructureServiceName!: string;
     InfrastructureDocuments: InfrastructureDoc[] = [];
 
     constructor(public data: DataService, public raw: IInfrastructureDocumentCollectionItem) {

--- a/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
@@ -11,8 +11,8 @@ import { HealthStateConstants, NodeStatusConstants, StatusWarningLevel, BannerWa
 import { DataModelCollectionBase } from './CollectionBase';
 import { RoutesService } from 'src/app/services/routes.service';
 
-
 const upgradeDomainNameComparer = new Intl.Collator(undefined, { numeric: true });
+
 
 export interface INodesStatusDetails {
   nodeType: string;
@@ -67,14 +67,14 @@ export class NodeStatusDetails implements INodesStatusDetails {
 export class NodeCollection extends DataModelCollectionBase<Node> {
     // make sure we only check once per session and this object will get destroyed/recreated
     private static checkedOneNodeScenario = false;
-    public healthState: ITextAndBadge;
-    public upgradeDomains: string[];
-    public faultDomains: string[];
-    public healthySeedNodes: string;
-    public seedNodeCount: number;
-    public disabledAndDisablingCount: number;
-    public disabledAndDisablingNodes: Node[];
-    public nodeTypes: string[];
+    public healthState!: ITextAndBadge;
+    public upgradeDomains!: string[];
+    public faultDomains!: string[];
+    public healthySeedNodes!: string;
+    public seedNodeCount!: number;
+    public disabledAndDisablingCount!: number;
+    public disabledAndDisablingNodes!: Node[];
+    public nodeTypes!: string[];
     public upNodes: Node[] = [];
 
     public constructor(data: DataService) {
@@ -114,9 +114,9 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
                 seedNodes.add(node);
             }
             if (!(node.raw.Type in counts)) {
-                counts[node.raw.Type] = new NodeStatusDetails(node.raw.Type);
+                (counts as any)[node.raw.Type] = new NodeStatusDetails(node.raw.Type);
             }
-            counts[node.raw.Type].add(node);
+            (counts as any)[node.raw.Type].add(node);
             allNodes.add(node);
         });
 
@@ -130,7 +130,7 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
             resultList.push(seedNodes);
         }
 
-        const nodeTypes = Object.keys(counts).map(key => counts[key]).sort((a: INodesStatusDetails, b: INodesStatusDetails) => a.nodeType.localeCompare(b.nodeType));
+        const nodeTypes = Object.keys(counts).map(key => (counts as any)[key]).sort((a: INodesStatusDetails, b: INodesStatusDetails) => a.nodeType.localeCompare(b.nodeType));
 
         return resultList.concat(nodeTypes);
     }
@@ -164,9 +164,9 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
         let disabledNodes = 0;
         let disablingNodes = 0;
 
-        const disabled = [];
-        const disabling = [];
-        const up = [];
+        const disabled: any[] = [];
+        const disabling: any[] = [];
+        const up: any[] = [];
         this.collection.forEach(node => {
             if (node.raw.NodeStatus === NodeStatusConstants.Up) {
                 up.push(node);
@@ -236,6 +236,6 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
 
     private updateNodesHealthState(): void {
         // calculates the nodes health state which is the max state value of all nodes
-        this.healthState = this.valueResolver.resolveHealthStatus(Utils.max(this.collection.map(node => HealthStateConstants.Values[node.healthState.text])).toString());
+        this.healthState = this.valueResolver.resolveHealthStatus(Utils.max(this.collection.map(node => (HealthStateConstants.Values as any)[node.healthState.text])).toString());
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
@@ -165,9 +165,9 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
         let disabledNodes = 0;
         let disablingNodes = 0;
 
-        const disabled: any[] = [];
-        const disabling: any[] = [];
-        const up: any[] = [];
+        const disabled: Node[] = [];
+        const disabling: Node[] = [];
+        const up: Node[] = [];
         this.collection.forEach(node => {
             if (node.raw.NodeStatus === NodeStatusConstants.Up) {
                 up.push(node);

--- a/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
@@ -9,6 +9,7 @@ import { Observable, of } from 'rxjs';
 import { Utils } from 'src/app/Utils/Utils';
 import { HealthStateConstants, NodeStatusConstants, StatusWarningLevel, BannerWarningID } from 'src/app/Common/Constants';
 import { DataModelCollectionBase } from './CollectionBase';
+import { IDataModel } from '../Base';
 import { RoutesService } from 'src/app/services/routes.service';
 
 const upgradeDomainNameComparer = new Intl.Collator(undefined, { numeric: true });
@@ -135,7 +136,7 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
         return resultList.concat(nodeTypes);
     }
 
-    protected get indexPropery(): string {
+    protected get indexPropery(): keyof IDataModel<any> {
         // node should be indexed by name
         return 'name';
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
@@ -106,7 +106,7 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
     }
 
     public getNodeStateCounts(includeAllNodes: boolean = true, includeSeedNoddes: boolean = true): INodesStatusDetails[] {
-        const counts = {};
+        const counts: Record<string, NodeStatusDetails> = {};
         const allNodes = new NodeStatusDetails(NodeStatusDetails.allNodeText);
         const seedNodes = new NodeStatusDetails(NodeStatusDetails.allSeedNodesText);
 
@@ -115,9 +115,9 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
                 seedNodes.add(node);
             }
             if (!(node.raw.Type in counts)) {
-                (counts as any)[node.raw.Type] = new NodeStatusDetails(node.raw.Type);
+                counts[node.raw.Type] = new NodeStatusDetails(node.raw.Type);
             }
-            (counts as any)[node.raw.Type].add(node);
+            counts[node.raw.Type].add(node);
             allNodes.add(node);
         });
 
@@ -131,7 +131,7 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
             resultList.push(seedNodes);
         }
 
-        const nodeTypes = Object.keys(counts).map(key => (counts as any)[key]).sort((a: INodesStatusDetails, b: INodesStatusDetails) => a.nodeType.localeCompare(b.nodeType));
+        const nodeTypes = Object.keys(counts).map(key => counts[key]).sort((a: INodesStatusDetails, b: INodesStatusDetails) => a.nodeType.localeCompare(b.nodeType));
 
         return resultList.concat(nodeTypes);
     }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/NodeCollection.ts
@@ -237,6 +237,6 @@ export class NodeCollection extends DataModelCollectionBase<Node> {
 
     private updateNodesHealthState(): void {
         // calculates the nodes health state which is the max state value of all nodes
-        this.healthState = this.valueResolver.resolveHealthStatus(Utils.max(this.collection.map(node => (HealthStateConstants.Values as any)[node.healthState.text])).toString());
+        this.healthState = this.valueResolver.resolveHealthStatus(Utils.max(this.collection.map(node => HealthStateConstants.getValue(node.healthState.text))).toString());
     }
 }

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -15,8 +15,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     completedRepairTasks: RepairTask[] = [];
     jobsOfInterest: RepairTask[] = [];
 
-    public longRunningApprovalJob: RepairTask;
-    public longestExecutingJob: RepairTask;
+    public longRunningApprovalJob: RepairTask | null = null;
+    public longestExecutingJob: RepairTask | null = null;
 
     public constructor(data: DataService) {
         super(data, parent);
@@ -34,8 +34,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     }
 
     protected updateInternal(): Observable<any> {
-        let longRunningApprovalRepairTask: RepairTask = null;
-        let longRunningExecutingRepairTask: RepairTask = null;
+        let longRunningApprovalRepairTask: RepairTask | null = null;
+        let longRunningExecutingRepairTask: RepairTask | null = null;
 
         this.repairTasks = [];
         this.completedRepairTasks = [];
@@ -67,15 +67,15 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
       this.longRunningApprovalJob = longRunningApprovalRepairTask;
       this.longestExecutingJob = longRunningExecutingRepairTask;
 
-      return forkJoin(this.repairTasks.map(task => task.updateInternal())).pipe(defaultIfEmpty([]), map(() => {
+      return forkJoin(this.repairTasks.map(task => task.updateInternal())).pipe(defaultIfEmpty<any[]>([]), map(() => {
         try {
           this.jobsOfInterest = this.repairTasks.filter(task => task.concerningJobInfo);
 
           const stuckJobTypeMap: Record<string, RepairTask[]> = {};
           this.jobsOfInterest.forEach(job => {
-            const jobList = (stuckJobTypeMap[job.concerningJobInfo.type] || []);
+            const jobList = (stuckJobTypeMap[job.concerningJobInfo!.type] || []);
             jobList.push(job);
-            stuckJobTypeMap[job.concerningJobInfo.type] = jobList;
+            stuckJobTypeMap[job.concerningJobInfo!.type] = jobList;
           })
 
           const messageTypes = [RepairTaskMessages.longExecutingId,

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -15,8 +15,8 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
     completedRepairTasks: RepairTask[] = [];
     jobsOfInterest: RepairTask[] = [];
 
-    public longRunningApprovalJob: RepairTask | null = null;
-    public longestExecutingJob: RepairTask | null = null;
+    public longRunningApprovalJob?: RepairTask | null;
+    public longestExecutingJob?: RepairTask | null;
 
     public constructor(data: DataService) {
         super(data, parent);

--- a/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/RepairTaskCollection.ts
@@ -67,7 +67,7 @@ export class RepairTaskCollection extends DataModelCollectionBase<RepairTask> {
       this.longRunningApprovalJob = longRunningApprovalRepairTask;
       this.longestExecutingJob = longRunningExecutingRepairTask;
 
-      return forkJoin(this.repairTasks.map(task => task.updateInternal())).pipe(defaultIfEmpty<any[]>([]), map(() => {
+      return forkJoin(this.repairTasks.map(task => task.updateInternal())).pipe(defaultIfEmpty<void[]>([]), map(() => {
         try {
           this.jobsOfInterest = this.repairTasks.filter(task => task.concerningJobInfo);
 

--- a/src/SfxWeb/src/app/Models/DataModels/collections/infrastructureCollection.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/collections/infrastructureCollection.ts
@@ -39,7 +39,7 @@ export class InfrastructureCollectionItem extends DataModelBase<IInfrastructureC
 export class InfrastructureCollection extends DataModelCollectionBase<InfrastructureCollectionItem> {
   static readonly bannerThrottledJobs = 'throttled-banner';
   static readonly CoordinatedPrefix = "Coordinated_";
-  public throttledJobs: InfrastructureJob[];
+  public throttledJobs!: InfrastructureJob[];
 
   public constructor(data: DataService) {
     super(data, parent);

--- a/src/SfxWeb/src/app/Models/DataModels/infrastructureJob.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/infrastructureJob.ts
@@ -5,10 +5,10 @@ import { of } from 'rxjs';
 
 export class InfrastructureJob extends DataModelBase<IRawInfrastructureJob> {
 
-    Id: string;
-    RepairTask: InfraRepairTask;
-    VmImpact: string[];
-    NodeImpact: string[];
+    Id!: string;
+    RepairTask!: InfraRepairTask;
+    VmImpact!: string[];
+    NodeImpact!: string[];
 
    public get id(): string {
        return this.raw.Id;

--- a/src/SfxWeb/src/app/Models/DataModels/networkDebugger.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/networkDebugger.ts
@@ -24,7 +24,7 @@ export interface IRequestsData {
 export class NetworkDebugger {
     public slowOrResponsiveNetwork = false;
     public stopRecordingRequests = false;
-    public overall: IRequestsData;
+    public overall!: IRequestsData;
     public maxRequests = 10;
     public slowAverageResponse = 100;
 
@@ -62,7 +62,7 @@ export class NetworkDebugger {
             failureCount: 0,
             requestCount: 1,
             averageDuration: 0,
-            requests: [],
+            requests: [] as IRequest[],
             isSecondRowCollapsed: true
         } as IRequestsData;
 

--- a/src/SfxWeb/src/app/Models/DataModels/networkDebugger.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/networkDebugger.ts
@@ -56,15 +56,16 @@ export class NetworkDebugger {
             return;
         }
         // add to overall list
-        const individualRequests = this.individualRequests[data.apiDesc] || {
+        const individualRequests: IRequestsData = this.individualRequests[data.apiDesc] || {
             apiDesc: data.apiDesc,
             failureRate: '',
             failureCount: 0,
             requestCount: 1,
             averageDuration: 0,
-            requests: [] as IRequest[],
-            isSecondRowCollapsed: true
-        } as IRequestsData;
+            requests: [],
+            isSecondRowCollapsed: true,
+            isSlowOrUnresponsive: false
+        };
 
         Utils.addToArrayAndTrim(individualRequests.requests, data, this.maxRequests,
             (item) => {

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.spec.ts
@@ -160,7 +160,7 @@ describe('RepairTask', () => {
             RestoringHealthCheckEndUtcTimestamp: '0001-01-01T00:00:00.000Z'
         };
         const task = new RepairTask(dataService, testData);
-        expect(task.concerningJobInfo.type).toBe("longExecuting");
+        expect(task.concerningJobInfo!.type).toBe("longExecuting");
       })
 
       fit("seed node", () => {
@@ -196,7 +196,7 @@ describe('RepairTask', () => {
           NodeName: 'testnode'
         }]
         const task = new RepairTask(dataService, testData);
-        expect(task.concerningJobInfo.type).toBe("seedNode");
+        expect(task.concerningJobInfo!.type).toBe("seedNode");
       })
 
       fit("health check (not seed node)", () => {
@@ -232,7 +232,7 @@ describe('RepairTask', () => {
           NodeName: 'testnode'
         }]
         const task = new RepairTask(dataService, testData);
-        expect(task.concerningJobInfo.type).toBe("safetychecks");
+        expect(task.concerningJobInfo!.type).toBe("safetychecks");
       })
 
       fit("stuck preparing", () => {
@@ -260,7 +260,7 @@ describe('RepairTask', () => {
         };
 
         const task = new RepairTask(dataService, testData);
-        expect(task.concerningJobInfo.type).toBe("clusterhealthcheck");
+        expect(task.concerningJobInfo!.type).toBe("clusterhealthcheck");
       })
 
     })

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -79,15 +79,15 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
     public couldParseExecutorData = false;
     public inProgress = true;
 
-    public duration: number;
-    public displayDuration: string;
+    public duration!: number;
+    public displayDuration!: string;
 
-    public historyPhases: IRepairTaskPhase[];
+    public historyPhases!: IRepairTaskPhase[];
 
     public executorData: any;
     public eventInstanceId: string;
     public eventProperties = {};
-    public concerningJobInfo: IConcerningJobInfo = null;
+    public concerningJobInfo: IConcerningJobInfo | null = null;
 
     constructor(public dataService: DataService, public raw: IRawRepairTask, private dateRef?: Date) {
         super(dataService, raw);
@@ -100,8 +100,8 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
     WIll use created at timestamp instead of
     */
     public get startTime(): Date {
-        return new Date(this.raw.History.ExecutingUtcTimestamp === RepairTask.NonStartedTimeStamp ? this.raw.History.CreatedUtcTimestamp :
-            this.raw.History.ExecutingUtcTimestamp);
+        return new Date(this.raw.History!.ExecutingUtcTimestamp === RepairTask.NonStartedTimeStamp ? this.raw.History!.CreatedUtcTimestamp! :
+            this.raw.History!.ExecutingUtcTimestamp!);
     }
 
     private getRefDate() {
@@ -110,17 +110,17 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
 
     private parseHistory() {
         let history = [
-            { timestamp: this.raw.History.CreatedUtcTimestamp, phase: 'Created' },
-            { timestamp: this.raw.History.ClaimedUtcTimestamp, phase: 'Claimed' },
-            { timestamp: this.raw.History.PreparingUtcTimestamp, phase: 'Preparing' },
-            { timestamp: this.raw.History.PreparingHealthCheckStartUtcTimestamp, phase: 'Preparing Health Check Start' },
-            { timestamp: this.raw.History.PreparingHealthCheckEndUtcTimestamp, phase: 'Preparing Health Check End' },
-            { timestamp: this.raw.History.ApprovedUtcTimestamp, phase: 'Approved' },
-            { timestamp: this.raw.History.ExecutingUtcTimestamp, phase: 'Executing' },
-            { timestamp: this.raw.History.RestoringUtcTimestamp, phase: 'Restoring' },
-            { timestamp: this.raw.History.RestoringHealthCheckStartUtcTimestamp, phase: 'Restoring Health Check Start' },
-            { timestamp: this.raw.History.RestoringHealthCheckEndUtcTimestamp, phase: 'Restoring Health Check End' },
-            { timestamp: this.raw.History.CompletedUtcTimestamp, phase: 'Completed' },
+            { timestamp: this.raw.History!.CreatedUtcTimestamp, phase: 'Created' },
+            { timestamp: this.raw.History!.ClaimedUtcTimestamp, phase: 'Claimed' },
+            { timestamp: this.raw.History!.PreparingUtcTimestamp, phase: 'Preparing' },
+            { timestamp: this.raw.History!.PreparingHealthCheckStartUtcTimestamp, phase: 'Preparing Health Check Start' },
+            { timestamp: this.raw.History!.PreparingHealthCheckEndUtcTimestamp, phase: 'Preparing Health Check End' },
+            { timestamp: this.raw.History!.ApprovedUtcTimestamp, phase: 'Approved' },
+            { timestamp: this.raw.History!.ExecutingUtcTimestamp, phase: 'Executing' },
+            { timestamp: this.raw.History!.RestoringUtcTimestamp, phase: 'Restoring' },
+            { timestamp: this.raw.History!.RestoringHealthCheckStartUtcTimestamp, phase: 'Restoring Health Check Start' },
+            { timestamp: this.raw.History!.RestoringHealthCheckEndUtcTimestamp, phase: 'Restoring Health Check End' },
+            { timestamp: this.raw.History!.CompletedUtcTimestamp, phase: 'Completed' },
         ];
 
         // if the job has been cancelled there shouldnt be Approved or executing phases anymore
@@ -139,11 +139,11 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
                 // if the next phase has a timestamp then this phase is finished
                 // otherwise if this phase has a timestamp it would be the active one
                 if (nextPhase.timestamp !== RepairTask.NonStartedTimeStamp) {
-                    phaseDuration = new Date(nextPhase.timestamp).getTime() - new Date(phase.timestamp).getTime();
+                    phaseDuration = new Date(nextPhase.timestamp!).getTime() - new Date(phase.timestamp!).getTime();
                     duration = TimeUtils.formatDurationAsAspNetTimespan(phaseDuration);
                     status = Status.finsihed;
                 } else if (phase.timestamp !== RepairTask.NonStartedTimeStamp) {
-                    phaseDuration = this.getRefDate().getTime() - new Date(phase.timestamp).getTime();
+                    phaseDuration = this.getRefDate().getTime() - new Date(phase.timestamp!).getTime();
                     duration = TimeUtils.formatDurationAsAspNetTimespan(phaseDuration);
                     status = Status.inProgress;
                 }
@@ -159,7 +159,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
             return {
                 // ...phase,
                 name: phase.phase,
-                timestamp: phase.timestamp === RepairTask.NonStartedTimeStamp ? '' : phase.timestamp,
+                timestamp: phase.timestamp === RepairTask.NonStartedTimeStamp ? '' : phase.timestamp!,
                 duration,
                 textRight: duration,
                 status,
@@ -233,9 +233,9 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
         };
     }
 
-  private checkAndSetConcerningJob(): Observable<IConcerningJobInfo> {
+  private checkAndSetConcerningJob(): Observable<IConcerningJobInfo | null> {
     return new Observable(observer => {
-      const emit = (data: IConcerningJobInfo) => {
+      const emit = (data: IConcerningJobInfo | null) => {
         observer.next(data);
         observer.complete();
       }
@@ -249,11 +249,11 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
         forkJoin(this.impactedNodes.map(id => {
           return this.dataService.getNode(id, true).pipe(catchError(err => { console.log(err); return of(null) }));
         })).pipe(
-          defaultIfEmpty([]),
-        ).subscribe((data: Node[]) => {
-          data = data.filter(node => node);
-          const nodesWithSeedNodeWarnings = data.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node.raw.NodeDeactivationInfo));
-          const nodesWithSafetyChecks = data.filter(node => node.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
+          defaultIfEmpty<(Node | null)[]>([]),
+        ).subscribe((data: (Node | null)[]) => {
+          const nodes = data.filter((node): node is Node => !!node);
+          const nodesWithSeedNodeWarnings = nodes.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node.raw.NodeDeactivationInfo));
+          const nodesWithSafetyChecks = nodes.filter(node => node.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
 
           //seed node related
           if (nodesWithSeedNodeWarnings.length > 0) {
@@ -299,7 +299,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
               return name;
             });
         }
-        this.timeStamp = new Date(this.raw.History.CreatedUtcTimestamp).toISOString();
+        this.timeStamp = new Date(this.raw.History!.CreatedUtcTimestamp!).toISOString();
         this.inProgress = this.raw.State !== 'Completed';
 
         const start = new Date(this.timeStamp).getTime();
@@ -307,12 +307,12 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
             const now = this.getRefDate().getTime();
             this.duration = now - start;
         } else {
-            this.duration = new Date(this.raw.History.CompletedUtcTimestamp).getTime() - start;
+            this.duration = new Date(this.raw.History!.CompletedUtcTimestamp!).getTime() - start;
         }
         this.displayDuration = TimeUtils.formatDurationAsAspNetTimespan(this.duration);
 
         try {
-            this.executorData = JSON.parse(this.raw.ExecutorData);
+            this.executorData = JSON.parse(this.raw.ExecutorData!);
 
             this.couldParseExecutorData = true;
         } catch (e) {
@@ -339,7 +339,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
     }
 
     public getPhase(phase: string): IRepairTaskHistoryPhase {
-        return this.history.find(historyPhase => historyPhase.name === phase);
+        return this.history.find(historyPhase => historyPhase.name === phase)!;
     }
 
     public tooltipInfo() {
@@ -364,7 +364,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
     }
 
     public getHistoryPhase(phase: string): IRepairTaskPhase {
-        return this.historyPhases.find(historyPhase => historyPhase.name === phase);
+        return this.historyPhases.find(historyPhase => historyPhase.name === phase)!;
     }
 
     public changePhaseCollapse(phase: string, state: boolean) {

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -251,9 +251,9 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
         })).pipe(
           defaultIfEmpty<(Node | null)[]>([]),
         ).subscribe((data: (Node | null)[]) => {
-          const nodes = data.filter((node): node is Node => !!node);
-          const nodesWithSeedNodeWarnings = nodes.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node.raw.NodeDeactivationInfo));
-          const nodesWithSafetyChecks = nodes.filter(node => node.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
+          data = data.filter(node => node) as Node[];
+          const nodesWithSeedNodeWarnings = data.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node!.raw.NodeDeactivationInfo));
+          const nodesWithSafetyChecks = data.filter(node => node!.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
 
           //seed node related
           if (nodesWithSeedNodeWarnings.length > 0) {

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -287,7 +287,7 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
     })
   }
 
-    updateInternal(): Observable<any> {
+    updateInternal(): Observable<void> {
         if (this.raw.Impact && this.raw.Impact.Kind === 'Node' && Array.isArray((this.raw.Impact as IRawNodeRepairImpactDescription).NodeImpactList)) {
             const nodeImpactList = (this.raw.Impact as IRawNodeRepairImpactDescription).NodeImpactList;
             this.impactedNodes = nodeImpactList.map(node => node.NodeName);

--- a/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
+++ b/src/SfxWeb/src/app/Models/DataModels/repairTask.ts
@@ -249,11 +249,11 @@ export class RepairTask extends DataModelBase<IRawRepairTask> implements IRCAIte
         forkJoin(this.impactedNodes.map(id => {
           return this.dataService.getNode(id, true).pipe(catchError(err => { console.log(err); return of(null) }));
         })).pipe(
-          defaultIfEmpty<(Node | null)[]>([]),
-        ).subscribe((data: (Node | null)[]) => {
-          data = data.filter(node => node) as Node[];
-          const nodesWithSeedNodeWarnings = data.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node!.raw.NodeDeactivationInfo));
-          const nodesWithSafetyChecks = data.filter(node => node!.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
+          map(nodes => nodes.filter((node): node is Node => !!node)),
+          defaultIfEmpty<Node[]>([]),
+        ).subscribe((data: Node[]) => {
+          const nodesWithSeedNodeWarnings = data.filter(node => DeactivationUtils.hasSeedNodeSafetyCheck(node.raw.NodeDeactivationInfo));
+          const nodesWithSafetyChecks = data.filter(node => node.raw.NodeDeactivationInfo.PendingSafetyChecks.length > 0);
 
           //seed node related
           if (nodesWithSeedNodeWarnings.length > 0) {

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -176,7 +176,7 @@ export class ListColumnSetting {
     public template?: Type<DetailBaseComponent>;
 
     public get hasFilters(): boolean {
-        return !!(this.config!.enableFilter && this.filterValues.length > 0);
+        return (this.config!.enableFilter && this.filterValues.length > 0)!;
     }
 
     public get hasEffectiveFilters(): boolean {

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -40,7 +40,7 @@ export class ListSettings {
     }
 
     public get hasEnabledFilters(): boolean {
-        return this.columnSettings.some(cs => cs.config.enableFilter);
+        return this.columnSettings.some(cs => cs.config!.enableFilter);
     }
 
     public get currentPage(): number {
@@ -92,7 +92,7 @@ export class ListSettings {
         public columnSettings: ListColumnSetting[],
         public secondRowColumnSettings: ListColumnSetting[] = [],
         public secondRowCollapsible: boolean = false,
-        public showSecondRow: (item) => boolean = (item) => true,
+        public showSecondRow: (item: any) => boolean = (item: any) => true,
         public searchable: boolean = true,
         public showRowExpander: boolean = true,
         public rowClass: (item: any) => string = () => '') {
@@ -106,7 +106,7 @@ export class ListSettings {
     }
 
     public isSortedByColumn(columnSetting: ListColumnSetting): boolean {
-        return Utils.arraysAreEqual(this.sortPropertyPaths, columnSetting.config.sortPropertyPaths);
+        return Utils.arraysAreEqual(this.sortPropertyPaths, columnSetting.config!.sortPropertyPaths!);
     }
 
     public reset(): void {
@@ -120,11 +120,11 @@ export class ListSettings {
     public getPluckedObject(item: any): any {
         if (this.columnSettings.length > 0) {
             const newObj = {};
-            Utils.unique(this.columnSettings.concat(this.secondRowColumnSettings)).forEach(column => newObj[column.propertyPath] = column.getTextValue(item));
+            Utils.unique(this.columnSettings.concat(this.secondRowColumnSettings)).forEach(column => (newObj as any)[column.propertyPath] = column.getTextValue(item));
 
             if(this.additionalSearchableProperties) {
               this.additionalSearchableProperties.forEach(path => {
-                newObj[path] = Utils.result(item, path);
+                (newObj as any)[path] = Utils.result(item, path);
               })
             }
 
@@ -155,9 +155,9 @@ export interface IListColumnAdditionalSettings {
     enableFilter?: boolean;
     cssClasses?: string,
     colspan?: number;
-    clickEvent?: (item) => void;
+    clickEvent?: (item: any) => void;
     canNotExport?: boolean;
-    alternateExportFormat?: (item) => string;
+    alternateExportFormat?: (item: any) => string;
     id?: string;
     cellId?: (item: any) => string;
 }
@@ -176,7 +176,7 @@ export class ListColumnSetting {
     public template?: Type<DetailBaseComponent>;
 
     public get hasFilters(): boolean {
-        return this.config.enableFilter && this.filterValues.length > 0;
+        return !!(this.config!.enableFilter && this.filterValues.length > 0);
     }
 
     public get hasEffectiveFilters(): boolean {
@@ -184,7 +184,7 @@ export class ListColumnSetting {
     }
 
     public get sortable(): boolean {
-        return this.config.sortPropertyPaths.length > 0;
+        return this.config!.sortPropertyPaths!.length > 0;
     }
 
     public get allChecked() {
@@ -196,7 +196,7 @@ export class ListColumnSetting {
     }
 
     public get id() {
-        return this.config.id;
+        return this.config!.id;
     }
     /**
      * Create a column setting
@@ -211,7 +211,7 @@ export class ListColumnSetting {
         const internalConfig: IListColumnAdditionalSettings = {
             enableFilter: false,
             colspan: 1,
-            clickEvent: (item) => null,
+            clickEvent: (item: any) => null,
             canNotExport: false,
             sortPropertyPaths: [propertyPath],
             cssClasses: "",

--- a/src/SfxWeb/src/app/Models/ListSettings.ts
+++ b/src/SfxWeb/src/app/Models/ListSettings.ts
@@ -117,14 +117,14 @@ export class ListSettings {
         this.currentPage = 1;
     }
 
-    public getPluckedObject(item: any): any {
+    public getPluckedObject<T>(item: T): Record<string, string> | T {
         if (this.columnSettings.length > 0) {
-            const newObj = {};
-            Utils.unique(this.columnSettings.concat(this.secondRowColumnSettings)).forEach(column => (newObj as any)[column.propertyPath] = column.getTextValue(item));
+            const newObj: Record<string, string> = {};
+            Utils.unique(this.columnSettings.concat(this.secondRowColumnSettings)).forEach(column => newObj[column.propertyPath] = column.getTextValue(item));
 
             if(this.additionalSearchableProperties) {
               this.additionalSearchableProperties.forEach(path => {
-                (newObj as any)[path] = Utils.result(item, path);
+                newObj[path] = Utils.result(item, path);
               })
             }
 

--- a/src/SfxWeb/src/app/Models/PowershellCommand.ts
+++ b/src/SfxWeb/src/app/Models/PowershellCommand.ts
@@ -25,14 +25,14 @@ export class PowershellCommand{
             else if (param.type === CommandParamTypes.string) {
                 value = `"${param.value}"`;
             }
-            else value = param.value.toString();
+            else value = param.value!.toString();
      
             return { name, value };
         })
     }
     
     getParam(name: string): PowershellCommandParameter {
-        return this.parameters.find(param => param.name === name);
+        return this.parameters.find(param => param.name === name)!;
     }
 
     getScript(): string {

--- a/src/SfxWeb/src/app/Models/RawDataTypes.ts
+++ b/src/SfxWeb/src/app/Models/RawDataTypes.ts
@@ -25,7 +25,7 @@ export interface IRawApplication {
         ApplicationMetadata?: IRawApplicationMetadata
     }
 export class IRawBackupEntity{
-    EntityKind: BackupEntityKind;
+    EntityKind!: BackupEntityKind;
 }
 export interface IRawApplicationBackupEntity extends IRawBackupEntity{
     ApplicationName: string;
@@ -350,9 +350,9 @@ export interface IRawLoadMetricInformation {
         RemainingBufferedCapacity: number;
         IsClusterCapacityViolation: boolean;
         MinNodeLoadValue: number;
-        MinNodeLoadId: IRawId;
+        MinNodeLoadId: IRawId | null;
         MaxNodeLoadValue: number;
-        MaxNodeLoadId: IRawId;
+        MaxNodeLoadId: IRawId | null;
     }
 
 export interface IRawDeployedApplicationHealthState {
@@ -669,34 +669,34 @@ export interface IRawDeployedReplicaStatus {
     }
 
 export class IRawReplicatorStatus {
-        Kind: string;
-        IsInBuild: boolean;
-        LastCopyOperationReceivedTimeUtc: string;
-        LastReplicationOperationReceivedTimeUtc: string;
-        LastAcknowledgementSentTimeUtc: string;
-        ReplicationQueueStatus: IRawReplicatorQueueStatus;
-        CopyQueueStatus: IRawReplicatorQueueStatus;
-        RemoteReplicators: IRawRemoteReplicatorStatus[];
+        Kind!: string;
+        IsInBuild!: boolean;
+        LastCopyOperationReceivedTimeUtc!: string;
+        LastReplicationOperationReceivedTimeUtc!: string;
+        LastAcknowledgementSentTimeUtc!: string;
+        ReplicationQueueStatus!: IRawReplicatorQueueStatus;
+        CopyQueueStatus!: IRawReplicatorQueueStatus;
+        RemoteReplicators!: IRawRemoteReplicatorStatus[];
     }
 
 export class IRawReplicatorQueueStatus {
-        QueueUtilizationPercentage: string;
-        QueueMemorySize: boolean;
-        FirstSequenceNumber: string;
-        CompletedSequenceNumber: string;
-        CommittedSequenceNumber: string;
-        LastSequenceNumber: string;
+        QueueUtilizationPercentage!: string;
+        QueueMemorySize!: boolean;
+        FirstSequenceNumber!: string;
+        CompletedSequenceNumber!: string;
+        CommittedSequenceNumber!: string;
+        LastSequenceNumber!: string;
     }
 
 export class IRawRemoteReplicatorStatus {
-        ReplicaId: string;
-        IsInBuild: boolean;
-        LastAcknowledgementProcessedTimeUtc: string;
-        LastReceivedReplicationSequenceNumber: string;
-        LastAppliedReplicationSequenceNumber: string;
-        LastReceivedCopySequenceNumber: string;
-        LastAppliedCopySequenceNumber: string;
-        RemoteReplicatorAcknowledgementStatus: IRemoteReplicatorAcknowledgementStatus;
+        ReplicaId!: string;
+        IsInBuild!: boolean;
+        LastAcknowledgementProcessedTimeUtc!: string;
+        LastReceivedReplicationSequenceNumber!: string;
+        LastAppliedReplicationSequenceNumber!: string;
+        LastReceivedCopySequenceNumber!: string;
+        LastAppliedCopySequenceNumber!: string;
+        RemoteReplicatorAcknowledgementStatus!: IRemoteReplicatorAcknowledgementStatus;
     }
 
 export interface IRemoteReplicatorAcknowledgementStatus {
@@ -870,9 +870,9 @@ export interface IRawServiceHealthState {
 export interface IRawServiceLoadMetricDescription {
         Name: string;
         Weight: string;
-        PrimaryDefaultLoad: number;
-        SecondaryDefaultLoad: number;
-        AuxiliaryDefaultLoad?: number;
+        PrimaryDefaultLoad: number | null;
+        SecondaryDefaultLoad: number | null;
+        AuxiliaryDefaultLoad?: number | null;
     }
 
 export interface IRawServiceType {
@@ -1016,9 +1016,9 @@ export interface IRawUpdateServiceDescription {
         MinReplicaSetSize?: number;
         AuxiliaryReplicaCount?: number;
         InstanceCount?: number;
-        ReplicaRestartWaitDurationSeconds?: number;
-        QuorumLossWaitDurationSeconds?: number;
-        StandByReplicaKeepDurationSeconds?: number;
+        ReplicaRestartWaitDurationSeconds?: number | null;
+        QuorumLossWaitDurationSeconds?: number | null;
+        StandByReplicaKeepDurationSeconds?: number | null;
     }
 
 export interface IRawCreateServiceDescription extends IRawCreateServiceFromTemplateDescription, IRawUpdateServiceDescription {

--- a/src/SfxWeb/src/app/Models/eventstore/Events.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/Events.ts
@@ -19,15 +19,15 @@ export interface IEventPropertiesCollection {
 }
 
 export abstract class FabricEventBase implements IFabricEventMetadata, IEventPropertiesCollection {
-    public hasCorrelatedEvents: boolean;
+    public hasCorrelatedEvents!: boolean;
     public eventProperties: { [key: string]: any; } = {};
-    public kind: string;
-    public eventInstanceId: string;
-    public timeStamp: string;
-    public category: string;
+    public kind!: string;
+    public eventInstanceId!: string;
+    public timeStamp!: string;
+    public category!: string;
     public raw: { [key: string]: any; } = {};
     public get timeStampString() {  return TimeUtils.datetimeToString(this.timeStamp); }
-    public time: Date;
+    public time!: Date;
 
     public fillFromJSON(responseItem: any) {
         this.raw = responseItem;
@@ -79,7 +79,7 @@ export class FabricEventInstanceModel<T extends FabricEventBase> extends DataMod
     public get uniqueId() { return this.raw.kind + this.raw.eventInstanceId + this.raw.timeStamp; }
     public get id() { return this.raw.eventInstanceId; }
     public get name() { return `${this.raw.kind} (${this.raw.eventInstanceId})`; }
-    public eventInstanceId: string;
+    public eventInstanceId!: string;
 }
 
 export class FabricEvent extends FabricEventBase {
@@ -89,7 +89,7 @@ export class ClusterEvent extends FabricEventBase {
 }
 
 export class NodeEvent extends FabricEventBase {
-    public nodeName: string;
+    public nodeName!: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -109,7 +109,7 @@ export class NodeEvent extends FabricEventBase {
 }
 
 export class ApplicationEvent extends FabricEventBase {
-    public applicationId: string;
+    public applicationId!: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -129,7 +129,7 @@ export class ApplicationEvent extends FabricEventBase {
 }
 
 export class ServiceEvent extends FabricEventBase {
-    public serviceId: string;
+    public serviceId!: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -149,7 +149,7 @@ export class ServiceEvent extends FabricEventBase {
 }
 
 export class PartitionEvent extends FabricEventBase {
-    public partitionId: string;
+    public partitionId!: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {
@@ -169,8 +169,8 @@ export class PartitionEvent extends FabricEventBase {
 }
 
 export class ReplicaEvent extends FabricEventBase {
-    public partitionId: string;
-    public replicaId: string;
+    public partitionId!: string;
+    public replicaId!: string;
 
     protected extractField(name: string, value: any): boolean {
         if (super.extractField(name, value)) {

--- a/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
@@ -204,8 +204,8 @@ const APE: IRelevantEventsConfig[] = [
 ]
 
 Object.keys(APEmap).forEach(key => {
-  APE.push(generateConfig(key, APEmap[key]));
-  APE.push(generateConfig(forceKillPrefix + key, APEmap[key], 'but not graceful shutdown'));
+  APE.push(generateConfig(key, (APEmap as any)[key]));
+  APE.push(generateConfig(forceKillPrefix + key, (APEmap as any)[key], 'but not graceful shutdown'));
 })
 
 

--- a/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/RelatedEventsConfigs.ts
@@ -204,8 +204,8 @@ const APE: IRelevantEventsConfig[] = [
 ]
 
 Object.keys(APEmap).forEach(key => {
-  APE.push(generateConfig(key, (APEmap as any)[key]));
-  APE.push(generateConfig(forceKillPrefix + key, (APEmap as any)[key], 'but not graceful shutdown'));
+  APE.push(generateConfig(key, APEmap[key as keyof typeof APEmap]));
+  APE.push(generateConfig(forceKillPrefix + key, APEmap[key as keyof typeof APEmap], 'but not graceful shutdown'));
 })
 
 

--- a/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
@@ -124,7 +124,7 @@ const generateItems = ( property: IDiffProperty, states: IRCAItem[], startDate: 
 
   let groups: DataGroup[] = Array.from(uniqueValues).map(value => {
     return {
-      id: String(value), content: String(value)
+      id: (value as any).toString(), content: (value as any).toString()
     }
   })
 

--- a/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
@@ -7,11 +7,11 @@ import { DataSet } from 'vis-data';
 import { DataGroup } from 'vis-timeline';
 
 export function mergeTimelineData(combinedData: ITimelineData, data: ITimelineData) {
-  data.items.forEach(item => combinedData.items.add(item));
+  data.items!.forEach(item => combinedData.items!.add(item));
 
-  data.groups.forEach(group => {
-    if(!combinedData.groups.get(group.id)) {
-      combinedData.groups.add(group)
+  data.groups!.forEach(group => {
+    if(!combinedData.groups!.get(group.id)) {
+      combinedData.groups!.add(group)
     }
   });
 
@@ -59,7 +59,7 @@ export const generateTimelineData = (items: IRCAItem[], config: IDiffAnalysis, s
       nestedGroups: []
     }
     result.groups.forEach(group => {
-      majorGroup.nestedGroups.push(group.id);
+      majorGroup.nestedGroups!.push(group.id);
     })
     result.groups.add(majorGroup);
   }
@@ -124,7 +124,7 @@ const generateItems = ( property: IDiffProperty, states: IRCAItem[], startDate: 
 
   let groups: DataGroup[] = Array.from(uniqueValues).map(value => {
     return {
-      id: value.toString(), content: value.toString()
+      id: String(value), content: String(value)
     }
   })
 

--- a/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/periodicEventParser.ts
@@ -124,7 +124,7 @@ const generateItems = ( property: IDiffProperty, states: IRCAItem[], startDate: 
 
   let groups: DataGroup[] = Array.from(uniqueValues).map(value => {
     return {
-      id: (value as any).toString(), content: (value as any).toString()
+      id: String(value), content: String(value)
     }
   })
 
@@ -161,6 +161,6 @@ const getValues = (item: IRCAItem, property:IDiffProperty): any[] => {
   if (values && property.delimiter) {
     return (values as string).split(property.delimiter);
   } else {
-    return values as any[];
+    return values;
   }
 }

--- a/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
@@ -34,7 +34,7 @@ export interface IConcurrentEventsConfig {
 }
 
 export interface IConcurrentEvents extends IRCAItem {
-  reason: IConcurrentEvents | null // possibly related events now this could be recursive, i.e a node is down but that node down concurrent event would have its own info on whether it was due to a restart or a cluster upgrade
+  reason: IConcurrentEvents | null | undefined // possibly related events now this could be recursive, i.e a node is down but that node down concurrent event would have its own info on whether it was due to a restart or a cluster upgrade
   reasonForEvent: string;
   inputEvent: IRCAItem;
 }
@@ -90,7 +90,7 @@ export const getSimultaneousEventsForEvent = (configs: IConcurrentEventsConfig[]
 
     let action = "";
     let reasonForEvent = "";
-    let reason: IConcurrentEvents | null = null;
+    let reason: IConcurrentEvents | null | undefined = null;
     let moreSpecificReason = "";
 
     // iterate through all configurations
@@ -144,7 +144,7 @@ export const getSimultaneousEventsForEvent = (configs: IConcurrentEventsConfig[]
                       simulEvents.push(event)
                     }
                   })
-                  reason = reasons.find(e => e.eventInstanceId === targetEvent.eventInstanceId) ?? null;
+                  reason = reasons.find(e => e.eventInstanceId === targetEvent.eventInstanceId);
                 }
               }
             }

--- a/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
@@ -34,7 +34,7 @@ export interface IConcurrentEventsConfig {
 }
 
 export interface IConcurrentEvents extends IRCAItem {
-  reason: IConcurrentEvents // possibly related events now this could be recursive, i.e a node is down but that node down concurrent event would have its own info on whether it was due to a restart or a cluster upgrade
+  reason: IConcurrentEvents | null // possibly related events now this could be recursive, i.e a node is down but that node down concurrent event would have its own info on whether it was due to a restart or a cluster upgrade
   reasonForEvent: string;
   inputEvent: IRCAItem;
 }
@@ -90,7 +90,7 @@ export const getSimultaneousEventsForEvent = (configs: IConcurrentEventsConfig[]
 
     let action = "";
     let reasonForEvent = "";
-    let reason = null;
+    let reason: IConcurrentEvents | null = null;
     let moreSpecificReason = "";
 
     // iterate through all configurations
@@ -144,7 +144,7 @@ export const getSimultaneousEventsForEvent = (configs: IConcurrentEventsConfig[]
                       simulEvents.push(event)
                     }
                   })
-                  reason = reasons.find(e => e.eventInstanceId === targetEvent.eventInstanceId);
+                  reason = reasons.find(e => e.eventInstanceId === targetEvent.eventInstanceId) ?? null;
                 }
               }
             }
@@ -172,7 +172,7 @@ export const getPeriodicEvent = (configs: IDiffAnalysis[], inputEvents: IRCAItem
   const results = configs.map(config => {
     return {
       config,
-      events: []
+      events: [] as IRCAItem[]
     }
   })
 

--- a/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/rcaEngine.ts
@@ -169,10 +169,10 @@ export const getSimultaneousEventsForEvent = (configs: IConcurrentEventsConfig[]
 }
 
 export const getPeriodicEvent = (configs: IDiffAnalysis[], inputEvents: IRCAItem[]): IAnalysisResultDiff[] => {
-  const results = configs.map(config => {
+  const results = configs.map((config): IAnalysisResultDiff => {
     return {
       config,
-      events: [] as IRCAItem[]
+      events: []
     }
   })
 

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerator.spec.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerator.spec.ts
@@ -1,4 +1,4 @@
-import { NodeTimelineGenerator, EventStoreUtils, ApplicationTimelineGenerator } from './timelineGenerators';
+import { NodeTimelineGenerator, EventStoreUtils, ApplicationTimelineGenerator, ITimelineData } from './timelineGenerators';
 import { ApplicationEvent, NodeEvent } from './Events';
 
 
@@ -43,7 +43,7 @@ describe('TimelineGenerators', () => {
 
         fit('node started down and goes up', () => {
             const data = [upEvent];
-            const events = generator.consume(data, startDate, endDate);
+            const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
 
             const someId = '0' + id2;
             expect(events.items.length).toBe(1);
@@ -68,7 +68,7 @@ describe('TimelineGenerators', () => {
 
         fit('node started up and goes down', () => {
             const data = [downEvent];
-            const events = generator.consume(data, startDate, endDate);
+            const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
 
             const someId = '0' + id;
 
@@ -94,7 +94,7 @@ describe('TimelineGenerators', () => {
 
         fit('node goes down and up', () => {
             const data = [upEvent, downEvent];
-            const events = generator.consume(data, startDate, endDate);
+            const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
             const someId = '1' + id;
 
             expect(events.items.length).toBe(1);
@@ -129,7 +129,7 @@ describe('TimelineGenerators', () => {
             down4.fillFromJSON({...upEvent.raw, EventInstanceId: '4', NodeName: '4', NodeInstance: 4});
             const data = [downEvent, down1, down2, down3, down4];
 
-            const events = generator.consume(data, startDate, endDate);
+            const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
             expect(events.items.length).toBe(5);
 
             expect(events.groups.length).toBe(1);
@@ -155,7 +155,7 @@ describe('TimelineGenerators', () => {
 
 
             const data = [upEvent, downEvent, secondUpEvent];
-            const events = generator.consume(data, startDate, endDate);
+            const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
 
             expect(events.items.length).toBe(2);
             expect(events.items.get('2' + id)).toEqual({
@@ -225,7 +225,7 @@ describe('TimelineGenerators', () => {
 
             const data = [deactivate, down];
 
-            const events = generator.consume(data, startDate, endDateRange);
+            const events = generator.consume(data, startDate, endDateRange) as Required<ITimelineData>;
             expect(events.items.length).toBe(1);
             expect(events.potentiallyMissingEvents).toBeFalse();
         });
@@ -254,7 +254,7 @@ describe('TimelineGenerators', () => {
 
           const data = [openFailed];
 
-          const events = generator.consume(data, startDate, endDateRange);
+          const events = generator.consume(data, startDate, endDateRange) as Required<ITimelineData>;
           expect(events.items.length).toBe(1);
           expect(events.groups.length).toBe(2);
         });
@@ -318,7 +318,7 @@ describe('TimelineGenerators', () => {
 
         const data = [addedToClusterEvent, nodeUpevent, nodeDownEvent, nodeUpevent2];
 
-        const events = generator.consume(data, startDate, endDateRange);
+        const events = generator.consume(data, startDate, endDateRange) as Required<ITimelineData>;
         //the trailing NodeUp carries LastNodeDownAt = 1601 FILETIME sentinel (never been down),
         //so no synthetic down bar is generated for it - only the "added to cluster" marker remains
         expect(events.items.length).toBe(1);
@@ -359,7 +359,7 @@ describe('TimelineGenerators', () => {
 
             const data = [nodeDownEvent, removed];
 
-            const events = generator.consume(data, startDate, endDateRange);
+            const events = generator.consume(data, startDate, endDateRange) as Required<ITimelineData>;
             const content = "Node test_node down and removed from the cluster";
             const itemId = "1" + id2;
 
@@ -411,7 +411,7 @@ describe('TimelineGenerators', () => {
         })
 
         const data = [containerExitEvent];
-        const events = generator.consume(data, startDate, endDateRange);
+        const events = generator.consume(data, startDate, endDateRange) as Required<ITimelineData>;
         expect(events.items.length).toBe(1);
         expect(events.potentiallyMissingEvents).toBeFalse();
     });
@@ -452,7 +452,7 @@ describe('TimelineGenerators', () => {
 
 
       const data = [end, startUpgrade];
-      const events = generator.consume(data, startDate, endDate);
+      const events = generator.consume(data, startDate, endDate) as Required<ITimelineData>;
       const content = "Upgrade rolling forward to 25.0.0";
 
       expect(events.items.length).toBe(1);

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -80,7 +80,7 @@ export class EventStoreUtils {
     /*
     Produces an html string used for vis.js timeline tooltips.
     */
-    public static tooltipFormat = (data: Record<string, any> , start: string, end: string = '', title: string= ''): string => {
+    public static tooltipFormat = (data: Record<string, any> , start: string, end: string | null = '', title: string= ''): string => {
 
         const outline = EventStoreUtils.internalToolTipFormatterObject(data);
         return `<div class="inner-tooltip">
@@ -224,8 +224,8 @@ export abstract class TimeLineGeneratorBase<T> {
     }
 
     generateTimeLineData(events: T[], startOfRange?: Date, endOfRange?: Date, nestedGroupLabel?: string): ITimelineData {
-        const data = this.consume(events, startOfRange, endOfRange);
-        EventStoreUtils.addSubGroups(data.groups);
+        const data = this.consume(events, startOfRange!, endOfRange!);
+        EventStoreUtils.addSubGroups(data.groups!);
         /*
             When we have more than one event type on the timeline we should group them by type to make it easier to visualize.
             If we set a nestedGroupLabel a group with the name of the event type will be created and gather all of its events.
@@ -239,16 +239,16 @@ export abstract class TimeLineGeneratorBase<T> {
 
             // We should not add the already nested groups to the new event type one.
             let groupsAlreadyNested: IdType[] = [];
-            data.groups.forEach(group => {
-                nestedElementGroup.nestedGroups.push(group.id);
+            data.groups!.forEach(group => {
+                nestedElementGroup.nestedGroups!.push(group.id);
                 if (group.nestedGroups){
                     groupsAlreadyNested = groupsAlreadyNested.concat(group.nestedGroups);
                 }
             });
             // If the group is already nested, we remove it from the nested groups of the new one.
-            nestedElementGroup.nestedGroups = nestedElementGroup.nestedGroups.filter(group => !groupsAlreadyNested.includes(group));
+            nestedElementGroup.nestedGroups = nestedElementGroup.nestedGroups!.filter(group => !groupsAlreadyNested.includes(group));
 
-            data.groups.add(nestedElementGroup);
+            data.groups!.add(nestedElementGroup);
         }
         return data;
     }
@@ -267,7 +267,7 @@ export class ClusterTimelineGenerator extends TimeLineGeneratorBase<ClusterEvent
         // state necessary for some events
         let previousClusterHealthReport: ClusterEvent;
         let previousClusterUpgrade: ClusterEvent;
-        let upgradeClusterStarted: ClusterEvent;
+        let upgradeClusterStarted: ClusterEvent | null = null;
         const clusterRollBacks: Record<string, {complete: ClusterEvent, start?: ClusterEvent}> = {};
 
         events.forEach((event, index) => {
@@ -299,7 +299,7 @@ export class ClusterTimelineGenerator extends TimeLineGeneratorBase<ClusterEvent
         Object.keys(clusterRollBacks).forEach(eventInstanceId => {
             const data = clusterRollBacks[eventInstanceId];
             // this.parseClusterUpgradeAndRollback(data.complete, data.start, items, startOfRange);
-            EventStoreUtils.parseUpgradeAndRollback(data.complete, events.indexOf(data.complete), data.start, items, startOfRange,
+            EventStoreUtils.parseUpgradeAndRollback(data.complete, events.indexOf(data.complete), data.start!, items, startOfRange,
                                                             ClusterTimelineGenerator.clusterUpgradeLabel, 'TargetClusterVersion');
         });
 
@@ -447,11 +447,11 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
           const nodeEvents = nodeEventMap[nodeName];
 
           //hold onto the last "state" node i.e up or down to put bounds on unexpected down events
-          let lastTransitionEvent: NodeEvent = null;
+          let lastTransitionEvent: NodeEvent | null = null;
 
-          let lastUpEvent: NodeEvent;
-          let lastDownEvent: {event: NodeEvent, end: string} = null;
-          let lastRemoved: NodeEvent;
+          let lastUpEvent: NodeEvent | null = null;
+          let lastDownEvent: {event: NodeEvent, end: string} | null = null;
+          let lastRemoved: NodeEvent | null = null;
           //repeat item filter
           const seenIds = new Set();
 
@@ -544,15 +544,17 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
             }
           })
 
-          if(lastDownEvent) {
-            items.add(this.generateDownNodeEvent(lastDownEvent.event, events.indexOf(lastDownEvent.event), lastDownEvent.event.timeStamp, lastDownEvent.end));
+          const finalDownEvent = lastDownEvent as {event: NodeEvent, end: string} | null;
+          if(finalDownEvent) {
+            items.add(this.generateDownNodeEvent(finalDownEvent.event, events.indexOf(finalDownEvent.event), finalDownEvent.event.timeStamp, finalDownEvent.end));
           }
 
-          if(lastUpEvent) {
-            const lastDown = lastUpEvent.eventProperties.LastNodeDownAt;
+          const finalUpEvent = lastUpEvent as NodeEvent | null;
+          if(finalUpEvent) {
+            const lastDown = finalUpEvent.eventProperties.LastNodeDownAt;
             //skip the synthetic down bar when LastNodeDownAt is the FILETIME epoch sentinel ("never been down")
             if(lastDown && lastDown !== NodeTimelineGenerator.FileTimeEpochSentinel) {
-              items.add(this.generateDownNodeEvent(lastUpEvent, events.indexOf(lastUpEvent), lastDown, lastUpEvent.timeStamp));
+              items.add(this.generateDownNodeEvent(finalUpEvent, events.indexOf(finalUpEvent), lastDown, finalUpEvent.timeStamp));
             }
           }
         })
@@ -598,7 +600,7 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
 
         // state necessary for some events
         let previousApplicationUpgrade: ApplicationEvent;
-        let upgradeApplicationStarted: ApplicationEvent;
+        let upgradeApplicationStarted: ApplicationEvent | null = null;
 
         const applicationRollBacks: Record<string, {complete: ApplicationEvent, start?: ApplicationEvent}> = {};
         const processExitedGroups: Record<string, DataGroup> = {};
@@ -634,7 +636,7 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
         // we gather them up and add them at the end so we can get corresponding events
         Object.keys(applicationRollBacks).forEach(eventInstanceId => {
             const data = applicationRollBacks[eventInstanceId];
-            EventStoreUtils.parseUpgradeAndRollback(data.complete, events.indexOf(data.complete), data.start, items, startOfRange, ApplicationTimelineGenerator.applicationUpgradeLabel, 'ApplicationTypeVersion');
+            EventStoreUtils.parseUpgradeAndRollback(data.complete, events.indexOf(data.complete), data.start!, items, startOfRange, ApplicationTimelineGenerator.applicationUpgradeLabel, 'ApplicationTypeVersion');
         });
 
         // Display a pending upgrade
@@ -653,7 +655,7 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
             content: ApplicationTimelineGenerator.applicationPrcoessExitedLabel,
         };
         Object.keys(processExitedGroups).forEach(groupName => {
-            nestedApplicationProcessExited.nestedGroups.push(groupName);
+            nestedApplicationProcessExited.nestedGroups!.push(groupName);
             groups.add(processExitedGroups[groupName]);
         });
 
@@ -666,7 +668,7 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
         };
 
           Object.keys(containerExitedGroups).forEach(groupName => {
-            nestedContainerProcessExited.nestedGroups.push(groupName);
+            nestedContainerProcessExited.nestedGroups!.push(groupName);
             groups.add(containerExitedGroups[groupName]);
         });
 
@@ -758,11 +760,11 @@ export class PartitionTimelineGenerator extends TimeLineGeneratorBase<PartitionE
 
         periodicEventResults.forEach(result => {
           const timelineData = generateTimelineData(result.events, result.config, startOfRange, endOfRange);
-          timelineData.groups.forEach(group => {
+          timelineData.groups!.forEach(group => {
             groups.add(group)
           })
 
-          timelineData.items.forEach(event => {
+          timelineData.items!.forEach(event => {
             items.add(event);
           })
         })
@@ -822,14 +824,14 @@ export class RepairTaskTimelineGenerator extends TimeLineGeneratorBase<RepairTas
                     id: `${index}---${task.raw.TaskId}`,
                     content: task.raw.TaskId,
                     start: task.startTime ,
-                    end: task.inProgress ? new Date() : new Date(task.raw.History.CompletedUtcTimestamp),
+                    end: task.inProgress ? new Date() : new Date(task.raw.History!.CompletedUtcTimestamp!),
                     type: 'range',
                     kind: "RepairJob",
                     group: 'job',
                     subgroup: 'stack',
                     className: task.inProgress ? 'blue' : task.raw.ResultStatus === 'Succeeded' ? 'green' : 'red',
-                    title: EventStoreUtils.tooltipFormat(task.raw, new Date(task.raw.History.ExecutingUtcTimestamp).toLocaleString(),
-                                                                new Date(task.raw.History.CompletedUtcTimestamp).toLocaleString()),
+                    title: EventStoreUtils.tooltipFormat(task.raw, new Date(task.raw.History!.ExecutingUtcTimestamp!).toLocaleString(),
+                                                                new Date(task.raw.History!.CompletedUtcTimestamp!).toLocaleString()),
                 });
             }
         });

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -267,7 +267,7 @@ export class ClusterTimelineGenerator extends TimeLineGeneratorBase<ClusterEvent
         // state necessary for some events
         let previousClusterHealthReport: ClusterEvent;
         let previousClusterUpgrade: ClusterEvent;
-        let upgradeClusterStarted: ClusterEvent | null = null;
+        let upgradeClusterStarted!: ClusterEvent;
         const clusterRollBacks: Record<string, {complete: ClusterEvent, start?: ClusterEvent}> = {};
 
         events.forEach((event, index) => {
@@ -449,9 +449,9 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
           //hold onto the last "state" node i.e up or down to put bounds on unexpected down events
           let lastTransitionEvent: NodeEvent | null = null;
 
-          let lastUpEvent: NodeEvent | null = null;
-          let lastDownEvent: {event: NodeEvent, end: string} | null = null;
-          let lastRemoved: NodeEvent | null = null;
+          let lastUpEvent!: NodeEvent | null;
+          let lastDownEvent = null as {event: NodeEvent, end: string} | null;
+          let lastRemoved!: NodeEvent | null;
           //repeat item filter
           const seenIds = new Set();
 
@@ -544,17 +544,15 @@ export class NodeTimelineGenerator extends TimeLineGeneratorBase<NodeEvent> {
             }
           })
 
-          const finalDownEvent = lastDownEvent as {event: NodeEvent, end: string} | null;
-          if(finalDownEvent) {
-            items.add(this.generateDownNodeEvent(finalDownEvent.event, events.indexOf(finalDownEvent.event), finalDownEvent.event.timeStamp, finalDownEvent.end));
+          if(lastDownEvent) {
+            items.add(this.generateDownNodeEvent(lastDownEvent.event, events.indexOf(lastDownEvent.event), lastDownEvent.event.timeStamp, lastDownEvent.end));
           }
 
-          const finalUpEvent = lastUpEvent as NodeEvent | null;
-          if(finalUpEvent) {
-            const lastDown = finalUpEvent.eventProperties.LastNodeDownAt;
+          if(lastUpEvent) {
+            const lastDown = lastUpEvent.eventProperties.LastNodeDownAt;
             //skip the synthetic down bar when LastNodeDownAt is the FILETIME epoch sentinel ("never been down")
             if(lastDown && lastDown !== NodeTimelineGenerator.FileTimeEpochSentinel) {
-              items.add(this.generateDownNodeEvent(finalUpEvent, events.indexOf(finalUpEvent), lastDown, finalUpEvent.timeStamp));
+              items.add(this.generateDownNodeEvent(lastUpEvent, events.indexOf(lastUpEvent), lastDown, lastUpEvent.timeStamp));
             }
           }
         })
@@ -600,7 +598,7 @@ export class ApplicationTimelineGenerator extends TimeLineGeneratorBase<Applicat
 
         // state necessary for some events
         let previousApplicationUpgrade: ApplicationEvent;
-        let upgradeApplicationStarted: ApplicationEvent | null = null;
+        let upgradeApplicationStarted!: ApplicationEvent | null;
 
         const applicationRollBacks: Record<string, {complete: ApplicationEvent, start?: ApplicationEvent}> = {};
         const processExitedGroups: Record<string, DataGroup> = {};

--- a/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
+++ b/src/SfxWeb/src/app/Models/eventstore/timelineGenerators.ts
@@ -902,7 +902,7 @@ function parseAndAddGroupIdByString(event: FabricEvent, groupIds: any, query: st
 
 export function parseEventsGenerically(events: FabricEvent[], textSearch: string, idPrefix: string = Math.random().toString()): ITimelineData {
   const items = new DataSet<ITimelineItem>();
-  const groupIds: any[] = [];
+  const groupIds: DataGroup[] = [];
 
     events.forEach( (event, index) => {
        const groupId = parseAndAddGroupIdByString(event, groupIds, textSearch, idPrefix);

--- a/src/SfxWeb/src/app/Utils/HtmlUtils.ts
+++ b/src/SfxWeb/src/app/Utils/HtmlUtils.ts
@@ -24,7 +24,7 @@ export class EventTypesUtil {
         'ReplicatorFaulted',
         'SecondaryReplicationQueueFull',
         'SecondaryReplicationQueueWarning'],
-        item => item.split('-')[0].replace(/\*/g, '') );
+        item => (item.split('-')[0] as any).replaceAll('*', '') );
     private ErrorEventTypes = Utils.keyByFromFunction( [
         '*HealthReportCreated-HealthState:Error',
         '*NewHealthReport-HealthState:Error',
@@ -32,11 +32,11 @@ export class EventTypesUtil {
         'NodeOpenFailed',
         'NodeAborted',
         'TStoreError' ],
-        item => item.split('-')[0].replace(/\*/g, '') );
+        item => (item.split('-')[0] as any).replaceAll('*', '') );
     private ResolvedEventTypes = Utils.keyByFromFunction( [
         '*HealthReportCreated-HealthState:Ok',
         '*NewHealthReport-HealthState:Ok' ],
-        item => item.split('-')[0].replace(/\*/g, '') );
+        item => (item.split('-')[0] as any).replaceAll('*', '') );
 
     private warningEventsRegExp = EventTypesUtil.constructRegExp(
         Object.keys(this.WarningEventTypes).map(e => this.WarningEventTypes[e]));

--- a/src/SfxWeb/src/app/Utils/HtmlUtils.ts
+++ b/src/SfxWeb/src/app/Utils/HtmlUtils.ts
@@ -24,7 +24,7 @@ export class EventTypesUtil {
         'ReplicatorFaulted',
         'SecondaryReplicationQueueFull',
         'SecondaryReplicationQueueWarning'],
-        item => item.split('-')[0].replaceAll('*', '') );
+        item => item.split('-')[0].replace(/\*/g, '') );
     private ErrorEventTypes = Utils.keyByFromFunction( [
         '*HealthReportCreated-HealthState:Error',
         '*NewHealthReport-HealthState:Error',
@@ -32,11 +32,11 @@ export class EventTypesUtil {
         'NodeOpenFailed',
         'NodeAborted',
         'TStoreError' ],
-        item => item.split('-')[0].replaceAll('*', '') );
+        item => item.split('-')[0].replace(/\*/g, '') );
     private ResolvedEventTypes = Utils.keyByFromFunction( [
         '*HealthReportCreated-HealthState:Ok',
         '*NewHealthReport-HealthState:Ok' ],
-        item => item.split('-')[0].replaceAll('*', '') );
+        item => item.split('-')[0].replace(/\*/g, '') );
 
     private warningEventsRegExp = EventTypesUtil.constructRegExp(
         Object.keys(this.WarningEventTypes).map(e => this.WarningEventTypes[e]));
@@ -71,7 +71,7 @@ export class EventTypesUtil {
         if (match) {
             return match.filter(i => i)[1];
         }
-        return result;
+        return result!;
     }
 
     private static isPropertyMatching(event: FabricEventBase, lookupString: string): boolean {

--- a/src/SfxWeb/src/app/Utils/HtmlUtils.ts
+++ b/src/SfxWeb/src/app/Utils/HtmlUtils.ts
@@ -24,6 +24,7 @@ export class EventTypesUtil {
         'ReplicatorFaulted',
         'SecondaryReplicationQueueFull',
         'SecondaryReplicationQueueWarning'],
+        // `as any`: es2018 lib lacks String.replaceAll — dropped in part 3 (pr/3-build-vitest) when es2018 is removed
         item => (item.split('-')[0] as any).replaceAll('*', '') );
     private ErrorEventTypes = Utils.keyByFromFunction( [
         '*HealthReportCreated-HealthState:Error',

--- a/src/SfxWeb/src/app/Utils/IdUtils.ts
+++ b/src/SfxWeb/src/app/Utils/IdUtils.ts
@@ -13,7 +13,7 @@ export class IdUtils {
       if (route != null) {
         const param = route.params[key];
         if (param === undefined) {
-          return IdUtils.getParam(route.parent, key);
+          return IdUtils.getParam(route.parent!, key);
         } else {
           return param;
         }

--- a/src/SfxWeb/src/app/Utils/Transforms.ts
+++ b/src/SfxWeb/src/app/Utils/Transforms.ts
@@ -35,7 +35,7 @@ export class Transforms {
 
   public static nullIfEmptyString(parsed: string): string {
     if(parsed === "") {
-      return null
+      return null!
     }else {
       return parsed;
     }

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -34,9 +34,9 @@ export class Utils {
     public static groupByFunc<T>(list: T[], keyFunction: (item: T) => string): Record<string, T[]> {
         return list.reduce( (previous, current) => { const key = keyFunction(current);
                                                      if (key in previous){
-                                                        previous[key].push(current);
+                                                        (previous as any)[key].push(current);
                                                      }else{
-                                                        previous[key] = [current];
+                                                        (previous as any)[key] = [current];
                                                      }
                                                     //  previous[key] = (previous[key] || []).push(current);
                                                      return previous; }, {});
@@ -47,7 +47,7 @@ export class Utils {
      * @param key key for value
      */
     public static groupBy<T>(list: T[], key: string): Record<string, T[]> {
-        return list.reduce( (previous, current) => { const itemKey = Utils.result(current, key) ;previous[itemKey] = (previous[itemKey] || []).push(current) ; return previous; }, {});
+        return list.reduce( (previous, current) => { const itemKey = Utils.result(current, key) ;(previous as any)[itemKey] = ((previous as any)[itemKey] || []).push(current) ; return previous; }, {});
     }
 
     /**
@@ -55,15 +55,15 @@ export class Utils {
      * @param key key for value
      */
     public static keyBy<T>(list: T[], key: string): Record<string, T> {
-        return list.reduce( (previous, current) => { previous[current[key]] = current; return previous; }, {});
+        return list.reduce( (previous, current) => { (previous as any)[(current as any)[key]] = current; return previous; }, {});
     }
 
     /**
      * implements lodash keyBy in es6. returns a dictionary of lists
      * @param keyFunction function to return a key based string for each entry.
      */
-    public static keyByFromFunction<T>(list: T[], keyFunction: (T) => string): Record<string, T> {
-        return list.reduce( (previous, current) => { previous[keyFunction(current)] = current; return previous; }, {});
+    public static keyByFromFunction<T>(list: T[], keyFunction: (item: T) => string): Record<string, T> {
+        return list.reduce( (previous, current) => { (previous as any)[keyFunction(current)] = current; return previous; }, {});
     }
 
     /**
@@ -131,7 +131,7 @@ export class Utils {
     }
 
     // Convert a hex string to a byte array
-    public static hexToBytes(hex) {
+    public static hexToBytes(hex: any) {
         const bytes = [];
         for (let c = 0; c < hex.length; c += 2) {
             const value = parseInt(hex.substr(c, 2), 16);
@@ -190,7 +190,7 @@ export class Utils {
         return text;
     }
 
-    public static addToArrayAndTrim<T>(list: T[], data: T, maxLength: number, onRemoval = (item: T) => null, onAddition = (item: T) => null) {
+    public static addToArrayAndTrim<T>(list: T[], data: T, maxLength: number, onRemoval: (item: T) => void = () => {}, onAddition: (item: T) => void = () => {}) {
         if (list.length >= maxLength) {
             const r = list.splice(maxLength - 1, 1);
             onRemoval(r[0]);
@@ -227,10 +227,10 @@ export class Counter {
     private counts = {};
 
     public add(key: string | number, incrementalValue: number = 1): void {
-        if (this.counts[key] === undefined) {
-            this.counts[key]  = 0;
+        if ((this.counts as any)[key] === undefined) {
+            (this.counts as any)[key]  = 0;
         }
-        this.counts[key] += incrementalValue;
+        (this.counts as any)[key] += incrementalValue;
     }
 
     public clearAll(): void {
@@ -241,7 +241,7 @@ export class Counter {
         const l = Object.keys(this.counts).map(key => {
             return {
                 key,
-                value: this.counts[key]
+                value: (this.counts as any)[key]
             };
         });
         return l.sort(this.sortFunction);
@@ -255,7 +255,7 @@ export class Counter {
       return Object.keys(this.counts).map(key => {
           return {
               key,
-              value: this.counts[key]
+              value: (this.counts as any)[key]
           };
       });
     }

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -190,7 +190,7 @@ export class Utils {
         return text;
     }
 
-    public static addToArrayAndTrim<T>(list: T[], data: T, maxLength: number, onRemoval: (item: T) => void = () => {}, onAddition: (item: T) => void = () => {}) {
+    public static addToArrayAndTrim<T>(list: T[], data: T, maxLength: number, onRemoval: (item: T) => void = (item: T) => null, onAddition: (item: T) => void = (item: T) => null) {
         if (list.length >= maxLength) {
             const r = list.splice(maxLength - 1, 1);
             onRemoval(r[0]);

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -131,7 +131,7 @@ export class Utils {
     }
 
     // Convert a hex string to a byte array
-    public static hexToBytes(hex: any) {
+    public static hexToBytes(hex: string) {
         const bytes = [];
         for (let c = 0; c < hex.length; c += 2) {
             const value = parseInt(hex.substr(c, 2), 16);

--- a/src/SfxWeb/src/app/Utils/Utils.ts
+++ b/src/SfxWeb/src/app/Utils/Utils.ts
@@ -32,11 +32,11 @@ export class Utils {
      * implements lodash groupBy in es6. returns a dictionary of lists
      */
     public static groupByFunc<T>(list: T[], keyFunction: (item: T) => string): Record<string, T[]> {
-        return list.reduce( (previous, current) => { const key = keyFunction(current);
+        return list.reduce<Record<string, T[]>>( (previous, current) => { const key = keyFunction(current);
                                                      if (key in previous){
-                                                        (previous as any)[key].push(current);
+                                                        previous[key].push(current);
                                                      }else{
-                                                        (previous as any)[key] = [current];
+                                                        previous[key] = [current];
                                                      }
                                                     //  previous[key] = (previous[key] || []).push(current);
                                                      return previous; }, {});
@@ -47,7 +47,7 @@ export class Utils {
      * @param key key for value
      */
     public static groupBy<T>(list: T[], key: string): Record<string, T[]> {
-        return list.reduce( (previous, current) => { const itemKey = Utils.result(current, key) ;(previous as any)[itemKey] = ((previous as any)[itemKey] || []).push(current) ; return previous; }, {});
+        return Utils.groupByFunc(list, current => Utils.result(current, key));
     }
 
     /**
@@ -55,7 +55,7 @@ export class Utils {
      * @param key key for value
      */
     public static keyBy<T>(list: T[], key: string): Record<string, T> {
-        return list.reduce( (previous, current) => { (previous as any)[(current as any)[key]] = current; return previous; }, {});
+        return list.reduce<Record<string, T>>( (previous, current) => { previous[Utils.result(current, key)] = current; return previous; }, {});
     }
 
     /**
@@ -63,7 +63,7 @@ export class Utils {
      * @param keyFunction function to return a key based string for each entry.
      */
     public static keyByFromFunction<T>(list: T[], keyFunction: (item: T) => string): Record<string, T> {
-        return list.reduce( (previous, current) => { (previous as any)[keyFunction(current)] = current; return previous; }, {});
+        return list.reduce<Record<string, T>>( (previous, current) => { previous[keyFunction(current)] = current; return previous; }, {});
     }
 
     /**
@@ -224,13 +224,10 @@ export interface ICounterMostCommonEntry {
 }
 
 export class Counter {
-    private counts = {};
+    private counts: Record<string | number, number> = {};
 
     public add(key: string | number, incrementalValue: number = 1): void {
-        if ((this.counts as any)[key] === undefined) {
-            (this.counts as any)[key]  = 0;
-        }
-        (this.counts as any)[key] += incrementalValue;
+        this.counts[key] = (this.counts[key] || 0) + incrementalValue;
     }
 
     public clearAll(): void {
@@ -241,7 +238,7 @@ export class Counter {
         const l = Object.keys(this.counts).map(key => {
             return {
                 key,
-                value: (this.counts as any)[key]
+                value: this.counts[key]
             };
         });
         return l.sort(this.sortFunction);
@@ -255,7 +252,7 @@ export class Counter {
       return Object.keys(this.counts).map(key => {
           return {
               key,
-              value: (this.counts as any)[key]
+              value: this.counts[key]
           };
       });
     }

--- a/src/SfxWeb/src/app/Utils/ValueResolver.ts
+++ b/src/SfxWeb/src/app/Utils/ValueResolver.ts
@@ -33,7 +33,7 @@ export class ValueResolver {
         return this.resolve(value, ValueResolver.healthStatus, ValueResolver.healthStatus[ValueResolver.length - 1]);
     }
 
-    public resolve(value: string, options: ITextAndBadge[], defaultValue: ITextAndBadge = null): ITextAndBadge {
+    public resolve(value: string, options: ITextAndBadge[], defaultValue: ITextAndBadge | null = null): ITextAndBadge {
 
         if (Utils.isNumeric(value)) {
             const enumValue = +value;

--- a/src/SfxWeb/src/app/Utils/healthUtils.ts
+++ b/src/SfxWeb/src/app/Utils/healthUtils.ts
@@ -24,7 +24,7 @@ export interface IViewPathData {
 }
 
 export class HealthUtils {
-    public static getParsedHealthEvaluations(rawUnhealthyEvals: IRawUnhealthyEvaluation[], level: number = 0, parent: HealthEvaluation = null, data: DataService): HealthEvaluation[] {
+    public static getParsedHealthEvaluations(rawUnhealthyEvals: IRawUnhealthyEvaluation[], level: number = 0, parent: HealthEvaluation | null = null, data: DataService): HealthEvaluation[] {
         let healthEvals: HealthEvaluation[] = new Array(0);
         const children: HealthEvaluation[] = new Array(0);
         if (rawUnhealthyEvals) {

--- a/src/SfxWeb/src/app/ViewModels/DashboardViewModels.ts
+++ b/src/SfxWeb/src/app/ViewModels/DashboardViewModels.ts
@@ -77,7 +77,7 @@ export class DashboardViewModel implements IDashboardViewModel {
         private routes?: RoutesService,
         viewPath?: string) {
 
-        this.viewPath = viewPath;
+        this.viewPath = viewPath!;
         this.count = dataPoints.reduce((sum, d) => sum + d.count, 0);
         this.adjustCount();
         this.acessibilityText = `${title} has ${dataPoints[0].count} in error, ${dataPoints[1].count} in warning and ${dataPoints[2].count} are healthy.`

--- a/src/SfxWeb/src/app/ViewModels/MetricsViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/MetricsViewModel.ts
@@ -24,11 +24,11 @@ export class MetricsViewModel implements IMetricsViewModel {
     public iShowSystemMetrics = false;
     public iNormalizeMetricsData = true;
 
-    public metricsWithCapacities = [];
-    public metricsWithoutCapacities = [];
-    public systemMetrics = [];
+    public metricsWithCapacities: LoadMetricInformation[] = [];
+    public metricsWithoutCapacities: LoadMetricInformation[] = [];
+    public systemMetrics: LoadMetricInformation[] = [];
 
-    private iMetrics: LoadMetricInformation[] = null;
+    private iMetrics: LoadMetricInformation[] | null = null;
 
     private static ensureResourceGovernanceMetrics(metrics: LoadMetricInformation[]): LoadMetricInformation[] {
         let cpuCapacityAvailable = false;
@@ -42,7 +42,7 @@ export class MetricsViewModel implements IMetricsViewModel {
             return m;
         });
         if (!cpuCapacityAvailable) {
-            const zeroCpuCapacity: LoadMetricInformation = new LoadMetricInformation(null, {
+            const zeroCpuCapacity: LoadMetricInformation = new LoadMetricInformation(null!, {
                 Name: 'servicefabric:/_CpuCores',
                 IsBalancedBefore: true,
                 IsBalancedAfter: true,
@@ -67,7 +67,7 @@ export class MetricsViewModel implements IMetricsViewModel {
             metricsWithResourceGov.unshift(zeroCpuCapacity);
         }
         if (!memoryCapacityAvailable) {
-            const zeroMemoryCapacity: LoadMetricInformation = new LoadMetricInformation(null, {
+            const zeroMemoryCapacity: LoadMetricInformation = new LoadMetricInformation(null!, {
                 Name: 'servicefabric:/_MemoryInMB',
                 IsBalancedBefore: true,
                 IsBalancedAfter: true,

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.spec.ts
@@ -13,7 +13,7 @@ describe('Tree Node', () => {
 
     let child: ITreeNode;
 
-    const parent = null;
+    const parent = null!;
     let childQuery: ITreeNode[];
 
     beforeEach((() => {

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -239,7 +239,7 @@ export class TreeNodeGroupViewModel implements ITreeNode {
     public childrenLoaded = false;
 
     private internalIsExpanded = false;
-    private currentGetChildrenPromise: Subject<any> | null = null;
+    private currentGetChildrenPromise?: Subject<any> | null;
     private prevPageNode!: TreeNodeGroupViewModel;
     private nextPageNode!: TreeNodeGroupViewModel;
     private firstPageNode!: TreeNodeGroupViewModel;

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -108,29 +108,29 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         this.tree = tree;
         this.node = node;
         this.parent = parent;
-        this.listSettings = node.listSettings;
+        this.listSettings = node.listSettings!;
 
         if(this.listSettings){
             const nextPage = {
-                displayName: () => 'Next ' + this.node.listSettings.limit + ' items',
+                displayName: () => 'Next ' + this.node.listSettings!.limit + ' items',
                 nodeId: PaginationId.nextPage,
                 selectAction: () => this.pageDown()
             };
     
             const prevPage = {
-                displayName: () => 'Previous ' + this.node.listSettings.limit + ' items',
+                displayName: () => 'Previous ' + this.node.listSettings!.limit + ' items',
                 nodeId: PaginationId.prevPage,
                 selectAction: () => this.pageUp()
             };
     
             const firstPage = {
-                displayName: () => 'First ' + this.node.listSettings.limit + ' items',
+                displayName: () => 'First ' + this.node.listSettings!.limit + ' items',
                 nodeId: PaginationId.firstPage,
                 selectAction: () => this.pageFirst()
             };
     
             const lastPage = {
-                displayName: () => 'Last ' + this.node.listSettings.limit + ' items',
+                displayName: () => 'Last ' + this.node.listSettings!.limit + ' items',
                 nodeId: PaginationId.lastPage,
                 selectAction: () => this.pageLast()
             };
@@ -161,7 +161,7 @@ export class TreeNodeGroupViewModel implements ITreeNode {
                        !badgeState?.badgeClass;
 
        if (!isVisible) {
-           switch (badgeState.badgeClass) {
+           switch (badgeState!.badgeClass) {
                case BadgeConstants.BadgeUnknown:
                case BadgeConstants.BadgeOK:
                    isVisible = this.tree.showOkItems;
@@ -221,14 +221,14 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         }
     }
     public parent: TreeNodeGroupViewModel;
-    public sortBy: () => any[];
+    public sortBy!: () => any[];
     public selected = false;
     public focused = false;
-    public leafNode: boolean;
+    public leafNode!: boolean;
     public displayName: () => string;
     public listSettings: ListSettings;
-    public badge: () => ITextAndBadge;
-    public actions: ActionCollection;
+    public badge!: () => ITextAndBadge;
+    public actions!: ActionCollection;
     public canExpandAll = false;
 
     public tree: TreeViewModel;
@@ -239,11 +239,11 @@ export class TreeNodeGroupViewModel implements ITreeNode {
     public childrenLoaded = false;
 
     private internalIsExpanded = false;
-    private currentGetChildrenPromise: Subject<any>;
-    private prevPageNode: TreeNodeGroupViewModel;
-    private nextPageNode: TreeNodeGroupViewModel;
-    private firstPageNode: TreeNodeGroupViewModel;
-    private lastPageNode: TreeNodeGroupViewModel;
+    private currentGetChildrenPromise: Subject<any> | null = null;
+    private prevPageNode!: TreeNodeGroupViewModel;
+    private nextPageNode!: TreeNodeGroupViewModel;
+    private firstPageNode!: TreeNodeGroupViewModel;
+    private lastPageNode!: TreeNodeGroupViewModel;
 
     public toggle(): Observable<any> {
         this.internalIsExpanded = !this.internalIsExpanded;
@@ -347,15 +347,15 @@ export class TreeNodeGroupViewModel implements ITreeNode {
                     this.node.listSettings.count = this.children.length;
                 }
 
-                this.currentGetChildrenPromise.next();
-                this.currentGetChildrenPromise.complete();
+                this.currentGetChildrenPromise!.next();
+                this.currentGetChildrenPromise!.complete();
                 this.currentGetChildrenPromise = null;
                 this.loadingChildren = false;
 
             },
             () => {
-                this.currentGetChildrenPromise.next();
-                this.currentGetChildrenPromise.complete();
+                this.currentGetChildrenPromise!.next();
+                this.currentGetChildrenPromise!.complete();
                 this.currentGetChildrenPromise = null;
                 this.loadingChildren = false;
             });
@@ -468,10 +468,10 @@ export class TreeNodeGroupViewModel implements ITreeNode {
     }
 
     // helper function for typeAheadSearch; returns the first element that starts with the given letter
-    private depthFirstSearch(letter: string, skipCurrent: boolean = false, stoppingNode?: TreeNodeGroupViewModel): TreeNodeGroupViewModel {
+    private depthFirstSearch(letter: string, skipCurrent: boolean = false, stoppingNode?: TreeNodeGroupViewModel): TreeNodeGroupViewModel | null {
 
         if(!skipCurrent){
-            if (this.displayName().toLowerCase().startsWith(letter.toLowerCase()) && !PaginationId[this.nodeId]) {
+            if (this.displayName().toLowerCase().startsWith(letter.toLowerCase()) && !(PaginationId as any)[this.nodeId]) {
                 return this;
             }
         }
@@ -532,10 +532,10 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         this.displayName = this.node.displayName;
         this.leafNode = !this.node.childrenQuery;
         this.sortBy = node.sortBy ? node.sortBy : () => [];
-        this.listSettings = this.node.listSettings;
-        this.actions = this.node.actions;
-        this.badge = this.node.badge || null;
-        this.canExpandAll = node.canExpandAll;
+        this.listSettings = this.node.listSettings!;
+        this.actions = this.node.actions!;
+        this.badge = (this.node.badge || null)!;
+        this.canExpandAll = node.canExpandAll!;
     }
 
 
@@ -579,7 +579,7 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         listSettings.currentPage = listSettings.pageCount;
     }
 
-    private moveToNextSibling(): TreeNodeGroupViewModel {
+    private moveToNextSibling(): TreeNodeGroupViewModel | null {
         const parentsChildren = this.getParentsChildren();
         const myIndex = parentsChildren.indexOf(this);
 

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -221,7 +221,7 @@ export class TreeNodeGroupViewModel implements ITreeNode {
         }
     }
     public parent: TreeNodeGroupViewModel;
-    public sortBy!: () => any[];
+    public sortBy!: () => (string | number)[];
     public selected = false;
     public focused = false;
     public leafNode!: boolean;

--- a/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeNodeGroupViewModel.ts
@@ -471,7 +471,7 @@ export class TreeNodeGroupViewModel implements ITreeNode {
     private depthFirstSearch(letter: string, skipCurrent: boolean = false, stoppingNode?: TreeNodeGroupViewModel): TreeNodeGroupViewModel | null {
 
         if(!skipCurrent){
-            if (this.displayName().toLowerCase().startsWith(letter.toLowerCase()) && !(PaginationId as any)[this.nodeId]) {
+            if (this.displayName().toLowerCase().startsWith(letter.toLowerCase()) && !PaginationId[this.nodeId as keyof typeof PaginationId]) {
                 return this;
             }
         }

--- a/src/SfxWeb/src/app/ViewModels/TreeTypes.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeTypes.ts
@@ -17,7 +17,7 @@ export interface ITreeNode {
     badge?: () => ITextAndBadge;
     alwaysVisible?: boolean;
     startExpanded?: boolean;
-    sortBy?: () => any[];
+    sortBy?: () => (string | number)[];
     listSettings?: ListSettings;
     actions?: ActionCollection;
     // If current node is expanded, update the health chunk query to include health status queries for its children.

--- a/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
+++ b/src/SfxWeb/src/app/ViewModels/TreeViewModel.ts
@@ -9,8 +9,8 @@ import { Observable } from 'rxjs';
 // -----------------------------------------------------------------------------
 
 export class TreeViewModel {
-    public childGroupViewModel: TreeNodeGroupViewModel;
-    public selectedNode: TreeNodeGroupViewModel;
+    public childGroupViewModel!: TreeNodeGroupViewModel;
+    public selectedNode!: TreeNodeGroupViewModel;
 
     public showOkItems = true;
     public showWarningItems = true;
@@ -45,7 +45,7 @@ export class TreeViewModel {
         const baseNode: ITreeNode = {childrenQuery: this.childrenQuery,
                                      displayName: () => '',
                                     nodeId: 'base'};
-        this.childGroupViewModel = new TreeNodeGroupViewModel(this, baseNode, null);
+        this.childGroupViewModel = new TreeNodeGroupViewModel(this, baseNode, null!);
         if (this.childGroupViewModel.isCollapsed) {
             this.childGroupViewModel.toggle().subscribe(() => {
                 if (this.childGroupViewModel.children.length > 0) {
@@ -138,7 +138,7 @@ export class TreeViewModel {
                 return;
             }
 
-            let node: TreeNodeGroupViewModel = null;
+            let node: TreeNodeGroupViewModel | null = null;
             const nodes = group.children;
             for (const n of nodes) {
                 if (n.nodeId === path[currIndex]) {

--- a/src/SfxWeb/src/app/app-initializers.ts
+++ b/src/SfxWeb/src/app/app-initializers.ts
@@ -1,5 +1,5 @@
 import { AdalService } from './services/adal.service';
-import { StandaloneIntegrationService } from './services/standalone-integration.service';
+import { StandaloneIntegrationService, IntegrationConfig } from './services/standalone-integration.service';
 import Highcharts from 'highcharts';
 import Accessibility from 'highcharts/modules/accessibility';
 import HighchartsSankey from "highcharts/modules/sankey";
@@ -8,11 +8,17 @@ Accessibility(Highcharts);
 HighchartsSankey(Highcharts);
 HighchartsOrganization(Highcharts);
 
+declare global {
+  interface Window {
+    SFXintegrationConfiguration?: IntegrationConfig;
+  }
+}
+
 export function initApp(aadService: AdalService, standaloneIntegrationService: StandaloneIntegrationService) {
   return async () => {
     try {
       if("SFXintegrationConfiguration" in window) {
-        standaloneIntegrationService.setConfiguration((window as any).SFXintegrationConfiguration);
+        standaloneIntegrationService.setConfiguration(window.SFXintegrationConfiguration!);
       }
       if(standaloneIntegrationService.isStandalone()) {
         return;

--- a/src/SfxWeb/src/app/app.component.ts
+++ b/src/SfxWeb/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent implements OnInit{
   private focusService = inject(FocusService);
 
 
-  @ViewChild('main') main: ElementRef;
+  @ViewChild('main') main!: ElementRef;
 
   smallScreenSize = false;
   smallScreenLeftPanelWidth = '0%';

--- a/src/SfxWeb/src/app/error-handling.ts
+++ b/src/SfxWeb/src/app/error-handling.ts
@@ -6,7 +6,7 @@ export class AppInsightsErrorHandler implements ErrorHandler {
 private telemetry = inject(TelemetryService);
 
 
-    handleError(error) {
+    handleError(error: any) {
         console.error(error);
         this.telemetry.appInsights.trackException(error);
     }

--- a/src/SfxWeb/src/app/http-interceptor.spec.ts
+++ b/src/SfxWeb/src/app/http-interceptor.spec.ts
@@ -112,7 +112,7 @@ describe('Http interceptors', () => {
     });
 
     fit('standalone interceptor does not fire', () => {
-      standaloneService.setConfiguration(null);
+      standaloneService.setConfiguration(null!);
 
       spyOn(standaloneService, 'getIntegrationCaller');
 
@@ -126,7 +126,7 @@ describe('Http interceptors', () => {
     standaloneService.setConfiguration({passObjectAsString : true, handleAsCallBack : true, windowPath: "path"});
 
     spyOn(standaloneService, 'getIntegrationCaller').and.returnValue(
-      (integrationData) => {
+      (integrationData: any) => {
         integrationData.Callback(JSON.stringify({
           "statusMessage": "OK",
           "statusCode": "200",

--- a/src/SfxWeb/src/app/http-interceptor.ts
+++ b/src/SfxWeb/src/app/http-interceptor.ts
@@ -42,14 +42,14 @@ export class ReadOnlyHeaderInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<any>, next: HttpHandler):
     Observable<HttpEvent<any>> {
-        return next.handle(req).pipe(map(res => {
+        return next.handle(req).pipe(map((res: any) => {
             if (res instanceof HttpResponse) {
                 if ( res.headers.has(Constants.SfxReadonlyHeaderName)) {
                     this.dataService.readOnlyHeader =  (res.headers.get(Constants.SfxReadonlyHeaderName) || res.headers.get(Constants.SfxReadonlyHeaderName.toLowerCase()) )  === '1';
                 }
 
                 if (res.headers.has(Constants.SfxClusterNameHeaderName)) {
-                    this.dataService.clusterNameMetadata = (res.headers.get(Constants.SfxClusterNameHeaderName) || res.headers.get(Constants.SfxClusterNameHeaderName).toLowerCase());
+                    this.dataService.clusterNameMetadata = (res.headers.get(Constants.SfxClusterNameHeaderName) || res.headers.get(Constants.SfxClusterNameHeaderName)!.toLowerCase());
                 }
 
               }
@@ -83,7 +83,7 @@ export class StandAloneInterceptor implements HttpInterceptor {
     const data: IHttpRequest = {
       url: req.url,
       method: req.method,
-      headers: req.headers.keys().map(key => ({name: key, value: req.headers.get(key)})),
+      headers: req.headers.keys().map(key => ({name: key, value: req.headers.get(key)!})),
       body: req.body
     }
 
@@ -92,7 +92,7 @@ export class StandAloneInterceptor implements HttpInterceptor {
       const requestData = integration.passObjectAsString ? JSON.stringify(data) : data;
       const caller = this.standaloneIntegration.getIntegrationCaller();
 
-      const handleResponse = (responseData) => {
+      const handleResponse = (responseData: any) => {
         if(integration.passObjectAsString) {
           responseData = JSON.parse(responseData);
         }
@@ -119,7 +119,7 @@ export class StandAloneInterceptor implements HttpInterceptor {
       if(integration.handleAsCallBack) {
         try {
           console.log(requestData)
-          caller({"data": requestData, "Callback": (response) => {
+          caller({"data": requestData, "Callback": (response: any) => {
             handleResponse(response);
           }
         })
@@ -132,9 +132,9 @@ export class StandAloneInterceptor implements HttpInterceptor {
           subscriber.complete();
         }
       }else{
-        caller(requestData).then((response, res) => {
+        caller(requestData).then((response: any, res: any) => {
           handleResponse(response);
-        }).catch(err => {
+        }).catch((err: any) => {
           console.log(err)
           const r = new HttpErrorResponse({
             status: 500,

--- a/src/SfxWeb/src/app/http-interceptor.ts
+++ b/src/SfxWeb/src/app/http-interceptor.ts
@@ -6,7 +6,7 @@ import { finalize, map, mergeMap } from 'rxjs/operators';
 import { DataService } from './services/data.service';
 import { Constants } from './Common/Constants';
 import { environment } from 'src/environments/environment';
-import { IHttpRequest, StandaloneIntegrationService } from './services/standalone-integration.service';
+import { IHttpRequest, IHttpResponse, StandaloneIntegrationService } from './services/standalone-integration.service';
 
 /*
 The will intercept and allow the modification of every http request going in and out.
@@ -42,7 +42,7 @@ export class ReadOnlyHeaderInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<any>, next: HttpHandler):
     Observable<HttpEvent<any>> {
-        return next.handle(req).pipe(map((res: any) => {
+        return next.handle(req).pipe(map((res: HttpEvent<any>) => {
             if (res instanceof HttpResponse) {
                 if ( res.headers.has(Constants.SfxReadonlyHeaderName)) {
                     this.dataService.readOnlyHeader =  (res.headers.get(Constants.SfxReadonlyHeaderName) || res.headers.get(Constants.SfxReadonlyHeaderName.toLowerCase()) )  === '1';
@@ -92,24 +92,22 @@ export class StandAloneInterceptor implements HttpInterceptor {
       const requestData = integration.passObjectAsString ? JSON.stringify(data) : data;
       const caller = this.standaloneIntegration.getIntegrationCaller();
 
-      const handleResponse = (responseData: any) => {
-        if(integration.passObjectAsString) {
-          responseData = JSON.parse(responseData);
-        }
+      const handleResponse = (responseData: IHttpResponse | string) => {
+        const response: IHttpResponse = typeof responseData === 'string' ? JSON.parse(responseData) : responseData;
 
-        if(responseData.statusCode.toString().startsWith("2")) {
+        if(response.statusCode.toString().startsWith("2")) {
           const httpResponse = new HttpResponse({
             url: req.url,
-            status: responseData.statusCode,
-            body: responseData.data
+            status: response.statusCode,
+            body: response.data
           })
           subscriber.next(httpResponse);
           subscriber.complete();
         }else{
           const r = new HttpErrorResponse({
-            status: responseData.statusCode,
-            statusText: responseData.statusMessage,
-            error: responseData.data
+            status: response.statusCode,
+            statusText: response.statusMessage,
+            error: response.data
           });
           subscriber.error(r);
           subscriber.complete();

--- a/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.html
+++ b/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.html
@@ -1,6 +1,6 @@
 <form class="action-modal">
-    <div [class]="'modal-header ' + data.modalTitle.class">
-        <h1 class="modal-title">{{data.modalTitle.title}}</h1>
+    <div [class]="'modal-header ' + data.modalTitle?.class">
+        <h1 class="modal-title">{{data.modalTitle?.title}}</h1>
     </div>
     <div class="modal-body"> 
         <ng-template appDialogBody></ng-template>

--- a/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.html
+++ b/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.html
@@ -1,6 +1,6 @@
 <form class="action-modal">
-    <div [class]="'modal-header ' + data.modalTitle?.class">
-        <h1 class="modal-title">{{data.modalTitle?.title}}</h1>
+    <div [class]="'modal-header ' + data.modalTitle!.class">
+        <h1 class="modal-title">{{data.modalTitle!.title}}</h1>
     </div>
     <div class="modal-body"> 
         <ng-template appDialogBody></ng-template>

--- a/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/action-dialog/action-dialog.component.ts
@@ -18,13 +18,13 @@ export class ActionDialogComponent implements AfterViewInit {
   data = inject<IModalData>(MAT_DIALOG_DATA);
 
 
-  @ViewChild(DialogBodyDirective) body: DialogBodyDirective;
+  @ViewChild(DialogBodyDirective) body!: DialogBodyDirective;
   disableSubmit = false;
-  modalBody: DialogBodyComponent;
+  modalBody!: DialogBodyComponent;
 
   ngAfterViewInit() {
     if (!this.data.modalBody?.template) {
-      this.modalBody = ActionDialogUtils.createChildComponent(this.body, this.data.modalBody.inputs, MessageWithConfirmationComponent, (value) => { this.setSumbitDisable(value) });
+      this.modalBody = ActionDialogUtils.createChildComponent(this.body, this.data.modalBody!.inputs, MessageWithConfirmationComponent, (value) => { this.setSumbitDisable(value) });
     }
     else {
       this.modalBody = ActionDialogUtils.createChildComponent(this.body, this.data.modalBody.inputs, this.data.modalBody.template, (value) => { this.setSumbitDisable(value) });

--- a/src/SfxWeb/src/app/modules/action-dialog/message-with-confirmation/message-with-confirmation.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-with-confirmation/message-with-confirmation.component.ts
@@ -11,7 +11,7 @@ import { Subscription } from 'rxjs';
 })
 export class MessageWithConfirmationComponent implements OnInit, OnDestroy, DialogBodyComponent {
 
-  @Input() inputs: {message?: string, confirmationKeyword?: string};
+  @Input() inputs!: {message?: string, confirmationKeyword?: string};
   @Output() disableSubmit = new EventEmitter<boolean>();
  
   disableSubmitSubscription: Subscription = new Subscription();
@@ -24,7 +24,7 @@ export class MessageWithConfirmationComponent implements OnInit, OnDestroy, Dial
     this.userInputChange(this.userInput);
   }
 
-  userInputChange(value) {
+  userInputChange(value: any) {
     if (this.inputs.confirmationKeyword && this.inputs.confirmationKeyword !== value.trim()) {
       this.disableSubmit.emit(true);
     }

--- a/src/SfxWeb/src/app/modules/action-dialog/message-with-confirmation/message-with-confirmation.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-with-confirmation/message-with-confirmation.component.ts
@@ -24,7 +24,7 @@ export class MessageWithConfirmationComponent implements OnInit, OnDestroy, Dial
     this.userInputChange(this.userInput);
   }
 
-  userInputChange(value: any) {
+  userInputChange(value: string) {
     if (this.inputs.confirmationKeyword && this.inputs.confirmationKeyword !== value.trim()) {
       this.disableSubmit.emit(true);
     }

--- a/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.html
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.html
@@ -2,7 +2,7 @@
   <div [class]="'modal-header error'">
     <h1 class="modal-title">
       <img src="assets/badge-warning.svg" style="width: 25px;">
-    {{data.modalTitle?.title}}</h1>
+    {{data.modalTitle!.title}}</h1>
   </div>
   <div class="modal-body">
     <div style="text-align: center;">

--- a/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.html
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.html
@@ -2,7 +2,7 @@
   <div [class]="'modal-header error'">
     <h1 class="modal-title">
       <img src="assets/badge-warning.svg" style="width: 25px;">
-    {{data.modalTitle.title}}</h1>
+    {{data.modalTitle?.title}}</h1>
   </div>
   <div class="modal-body">
     <div style="text-align: center;">

--- a/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-with-wait-confirmation/message-with-wait-confirmation.component.ts
@@ -27,7 +27,7 @@ export class MessageWithWaitConfirmationComponent implements OnInit, DialogBodyC
   checked = false;
   countDown = false;
   countDownLeft = this.countdownTime;
-  timerSubscription: Subscription;
+  timerSubscription!: Subscription;
 
   ngOnInit(): void {
     this.dialogRef.beforeClosed().subscribe(() => {

--- a/src/SfxWeb/src/app/modules/action-dialog/message-wth-warning/message-with-warning.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-wth-warning/message-with-warning.component.ts
@@ -13,20 +13,20 @@ import { ActionDialogUtils } from '../utils';
 })
 export class MessageWithWarningComponent implements AfterViewInit, OnDestroy, DialogBodyComponent {
 
-  @ViewChild(DialogBodyDirective) body: DialogBodyDirective;
-  @Input() inputs: {description: string, link: string, linkText: string, template?: Type<DialogBodyComponent>};
+  @ViewChild(DialogBodyDirective) body!: DialogBodyDirective;
+  @Input() inputs!: {description: string, link: string, linkText: string, template?: Type<DialogBodyComponent>};
   @Output() disableSubmit = new EventEmitter<boolean>();
   disableSubmitSubscription: Subscription = new Subscription();
 
-  instance: DialogBodyComponent;
+  instance!: DialogBodyComponent;
 
   ngAfterViewInit(): void {
     if (this.inputs.template) {
-      this.instance = ActionDialogUtils.createChildComponent(this.body, this.inputs, this.inputs.template, (value) => { this.emitEvent(value) });
+      this.instance = ActionDialogUtils.createChildComponent(this.body, this.inputs, this.inputs.template, (value: any) => { this.emitEvent(value) });
     }  
   }
 
-  emitEvent(value) {
+  emitEvent(value: any) {
     this.disableSubmit.emit(value);
   }
 

--- a/src/SfxWeb/src/app/modules/action-dialog/message-wth-warning/message-with-warning.component.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/message-wth-warning/message-with-warning.component.ts
@@ -26,7 +26,7 @@ export class MessageWithWarningComponent implements AfterViewInit, OnDestroy, Di
     }  
   }
 
-  emitEvent(value: any) {
+  emitEvent(value: boolean) {
     this.disableSubmit.emit(value);
   }
 

--- a/src/SfxWeb/src/app/modules/action-dialog/utils.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/utils.ts
@@ -23,7 +23,7 @@ export class ActionDialogUtils {
         if (child.disableSubmit && disableSubmit) {
             try {
                 const sub = child.disableSubmit.subscribe((value: boolean) => disableSubmit(value));
-                child.disableSubmitSubscription.add(sub);
+                child.disableSubmitSubscription!.add(sub);
             }
             catch (e){
                 throw new Error(`The template must have disableSubmit and disableSubmitSubscription, and unsubscribe from disableSubmitSubscription in ngOnDestroy, else there will be potential memory leaks.\nOriginal error: ${e}`);
@@ -45,13 +45,13 @@ export class ActionDialogUtils {
       },
       MessageWithWaitConfirmationComponent,
       () => true,
-      null,
+      undefined,
       {
         title: `Confirm ${title} - Potential Data Loss`,
         class: 'error'
       },
       {
-        template: null,
+        template: undefined,
         inputs: {
           description
         }

--- a/src/SfxWeb/src/app/modules/action-dialog/utils.ts
+++ b/src/SfxWeb/src/app/modules/action-dialog/utils.ts
@@ -45,13 +45,13 @@ export class ActionDialogUtils {
       },
       MessageWithWaitConfirmationComponent,
       () => true,
-      undefined,
+      null!,
       {
         title: `Confirm ${title} - Potential Data Loss`,
         class: 'error'
       },
       {
-        template: undefined,
+        template: null!,
         inputs: {
           description
         }

--- a/src/SfxWeb/src/app/modules/apptypes-viewer/apptype-viewer/apptype-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/apptypes-viewer/apptype-viewer/apptype-viewer.component.ts
@@ -16,11 +16,11 @@ export class ApptypeViewerComponent implements OnChanges {
   private settings = inject(SettingsService);
 
 
-  @Input() activeAppTypes: ApplicationType[];
-  @Input() inactiveAppTypes: ApplicationType[];
-  allAppTypes: ApplicationType[];
-  allAppTypesListSettings: ListSettings;
-  appTypesListSettings: ListSettings;
+  @Input() activeAppTypes!: ApplicationType[];
+  @Input() inactiveAppTypes!: ApplicationType[];
+  allAppTypes!: ApplicationType[];
+  allAppTypesListSettings!: ListSettings;
+  appTypesListSettings!: ListSettings;
 
   ngOnChanges(): void { 
     this.allAppTypesListSettings = this.settings.getNewOrExistingAppTypeListSettings(true);

--- a/src/SfxWeb/src/app/modules/backup-restore/get-backup-enabled-entities/get-backup-enabled-entities.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/get-backup-enabled-entities/get-backup-enabled-entities.component.ts
@@ -31,7 +31,7 @@ export class GetBackupEnabledEntitiesComponent implements OnInit {
 
   ngOnInit(){
     this.rawdata = this.data.data.backupEntity;
-    this.backupEnabledEntitiesInfoListSettings = new ListSettings(10, [], 'Back up enabled entities', [
+    this.backupEnabledEntitiesInfoListSettings = new ListSettings(10, null!, 'Back up enabled entities', [
       new ListColumnSetting('EntityKind', 'Entity Kind'),
       new ListColumnSetting('ApplicationName', 'Application Name'),
       new ListColumnSetting('ServiceName', 'Service Name'),

--- a/src/SfxWeb/src/app/modules/backup-restore/get-backup-enabled-entities/get-backup-enabled-entities.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/get-backup-enabled-entities/get-backup-enabled-entities.component.ts
@@ -25,13 +25,13 @@ export class GetBackupEnabledEntitiesComponent implements OnInit {
   data = inject<IsolatedAction>(MAT_DIALOG_DATA);
   dataService = inject(DataService);
 
-  rawdata: IRawBackupEntity[];
+  rawdata!: IRawBackupEntity[];
   response = '';
-  backupEnabledEntitiesInfoListSettings: ListSettings;
+  backupEnabledEntitiesInfoListSettings!: ListSettings;
 
   ngOnInit(){
     this.rawdata = this.data.data.backupEntity;
-    this.backupEnabledEntitiesInfoListSettings = new ListSettings(10, null, 'Back up enabled entities', [
+    this.backupEnabledEntitiesInfoListSettings = new ListSettings(10, [], 'Back up enabled entities', [
       new ListColumnSetting('EntityKind', 'Entity Kind'),
       new ListColumnSetting('ApplicationName', 'Application Name'),
       new ListColumnSetting('ServiceName', 'Service Name'),

--- a/src/SfxWeb/src/app/modules/backup-restore/partition-disable-back-up/partition-disable-back-up.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/partition-disable-back-up/partition-disable-back-up.component.ts
@@ -22,7 +22,7 @@ export class PartitionDisableBackUpComponent {
     this.data.data.enable(this.cleanBackup).subscribe( () => {
       this.dialogRef.close(false);
     },
-    err => {
+    (err: any) => {
       console.log(err);
     });
   }

--- a/src/SfxWeb/src/app/modules/backup-restore/partition-enable-back-up/partition-enable-back-up.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/partition-enable-back-up/partition-enable-back-up.component.ts
@@ -26,7 +26,7 @@ export class PartitionEnableBackUpComponent implements OnInit {
     this.data.data.enable(this.backupPolicyName).subscribe( () => {
       this.dialogRef.close(false);
     },
-    err => {
+    (err: any) => {
       console.log(err);
     });
   }

--- a/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/storage-form/storage-form.component.ts
@@ -12,11 +12,11 @@ export class StorageFormComponent implements OnInit {
   private formBuilder = inject(UntypedFormBuilder);
 
 
-  @Input() form: UntypedFormGroup;
+  @Input() form!: UntypedFormGroup;
   @Input() data: any;
   @Input() required = true;
 
-  localForm: UntypedFormGroup;
+  localForm!: UntypedFormGroup;
 
   ngOnInit() {
     this.localForm = this.formBuilder.group({
@@ -38,17 +38,17 @@ export class StorageFormComponent implements OnInit {
 
     this.form.addControl('Storage', this.localForm);
 
-    this.localForm.get('StorageKind').valueChanges.subscribe(storageKind => {
+    this.localForm.get('StorageKind')!.valueChanges.subscribe(storageKind => {
       if (this.required) {
         this.updateStorageKindValidators(this.localForm, storageKind);
       }
     });
-    this.localForm.get('IsEmptyPrimaryCredential').valueChanges.subscribe(IsEmptyPrimaryCredential => {
+    this.localForm.get('IsEmptyPrimaryCredential')!.valueChanges.subscribe(IsEmptyPrimaryCredential => {
       if (this.required) {
         this.updateStorageKindValidatorsPrimaryCredentials(this.localForm, IsEmptyPrimaryCredential);
       }
     });
-    this.localForm.get('IsEmptySecondaryCredential').valueChanges.subscribe(IsEmptySecondaryCredential => {
+    this.localForm.get('IsEmptySecondaryCredential')!.valueChanges.subscribe(IsEmptySecondaryCredential => {
       if (this.required) {
         this.updateStorageKindValidatorsSecondaryCredentials(this.localForm, IsEmptySecondaryCredential);
       }
@@ -72,106 +72,106 @@ export class StorageFormComponent implements OnInit {
     };
     this.localForm.patchValue(this.data);
     if (this.required) {
-      this.localForm.get('ContainerName').setValidators(null);
-      this.localForm.get('ConnectionString').setValidators(null);
-      this.localForm.get('Path').setValidators(null);
+      this.localForm.get('ContainerName')!.setValidators(null);
+      this.localForm.get('ConnectionString')!.setValidators(null);
+      this.localForm.get('Path')!.setValidators(null);
     }
     else{
-      this.localForm.get('StorageKind').setValidators(null);
-      this.localForm.get('StorageKind').setValue('');
+      this.localForm.get('StorageKind')!.setValidators(null);
+      this.localForm.get('StorageKind')!.setValue('');
     }
   }
 
   updateStorageKindValidators(storage: AbstractControl, storageKind: string) {
     if (storageKind === 'AzureBlobStore') {
-      storage.get('ContainerName').setValidators([Validators.required]);
-      storage.get('ConnectionString').setValidators([Validators.required]);
+      storage.get('ContainerName')!.setValidators([Validators.required]);
+      storage.get('ConnectionString')!.setValidators([Validators.required]);
 
-      storage.get('Path').setValidators(null);
+      storage.get('Path')!.setValidators(null);
       this.updateStorageKindValidatorsPrimaryCredentials(storage, true);
       this.updateStorageKindValidatorsSecondaryCredentials(storage, true);
 
-      storage.get('BlobServiceUri').setValidators(null);
-      storage.get('ManagedIdentityType').setValidators(null);
-      storage.get('ManagedIdentityClientId').setValidators(null);
+      storage.get('BlobServiceUri')!.setValidators(null);
+      storage.get('ManagedIdentityType')!.setValidators(null);
+      storage.get('ManagedIdentityClientId')!.setValidators(null);
     }
 
     if (storageKind === 'FileShare') {
-      storage.get('ContainerName').setValidators(null);
-      storage.get('ConnectionString').setValidators(null);
+      storage.get('ContainerName')!.setValidators(null);
+      storage.get('ConnectionString')!.setValidators(null);
 
-      storage.get('Path').setValidators([Validators.required]);
-      storage.get('IsEmptyPrimaryCredential').setValue(false);
-      storage.get('IsEmptySecondaryCredential').setValue(false);
+      storage.get('Path')!.setValidators([Validators.required]);
+      storage.get('IsEmptyPrimaryCredential')!.setValue(false);
+      storage.get('IsEmptySecondaryCredential')!.setValue(false);
       this.updateStorageKindValidatorsPrimaryCredentials(storage, false);
       this.updateStorageKindValidatorsSecondaryCredentials(storage, false);
 
-      storage.get('BlobServiceUri').setValidators(null);
-      storage.get('ManagedIdentityType').setValidators(null);
-      storage.get('ManagedIdentityClientId').setValidators(null);
+      storage.get('BlobServiceUri')!.setValidators(null);
+      storage.get('ManagedIdentityType')!.setValidators(null);
+      storage.get('ManagedIdentityClientId')!.setValidators(null);
     }
 
     if (storageKind === 'ManagedIdentityAzureBlobStore')
     {
-      storage.get('ConnectionString').setValidators(null);
+      storage.get('ConnectionString')!.setValidators(null);
 
-      storage.get('Path').setValidators(null);
+      storage.get('Path')!.setValidators(null);
       this.updateStorageKindValidatorsPrimaryCredentials(storage, true);
       this.updateStorageKindValidatorsSecondaryCredentials(storage, true);
 
-      storage.get('BlobServiceUri').setValidators([Validators.required]);
-      storage.get('ManagedIdentityType').setValidators([Validators.required]);
-      storage.get('ContainerName').setValidators([Validators.required]);
-      storage.get('ManagedIdentityClientId').setValidators(null);
+      storage.get('BlobServiceUri')!.setValidators([Validators.required]);
+      storage.get('ManagedIdentityType')!.setValidators([Validators.required]);
+      storage.get('ContainerName')!.setValidators([Validators.required]);
+      storage.get('ManagedIdentityClientId')!.setValidators(null);
     }
 
-    storage.get('ContainerName').updateValueAndValidity();
-    storage.get('ConnectionString').updateValueAndValidity();
-    storage.get('Path').updateValueAndValidity();
-    storage.get('BlobServiceUri').updateValueAndValidity();
-    storage.get('ManagedIdentityType').updateValueAndValidity();
-    storage.get('ManagedIdentityClientId').updateValueAndValidity();
+    storage.get('ContainerName')!.updateValueAndValidity();
+    storage.get('ConnectionString')!.updateValueAndValidity();
+    storage.get('Path')!.updateValueAndValidity();
+    storage.get('BlobServiceUri')!.updateValueAndValidity();
+    storage.get('ManagedIdentityType')!.updateValueAndValidity();
+    storage.get('ManagedIdentityClientId')!.updateValueAndValidity();
   }
 
   updateStorageKindValidatorsPrimaryCredentials(storage: AbstractControl, IsEmptyPrimaryCredential: boolean) {
     if (IsEmptyPrimaryCredential)
     {
-      storage.get('PrimaryUserName').setValidators(null);
-      storage.get('PrimaryPassword').setValidators(null);
-      storage.get('PrimaryUserName').setValue('');
-      storage.get('PrimaryPassword').setValue('');
-      storage.get('PrimaryUserName').disable();
-      storage.get('PrimaryPassword').disable();
+      storage.get('PrimaryUserName')!.setValidators(null);
+      storage.get('PrimaryPassword')!.setValidators(null);
+      storage.get('PrimaryUserName')!.setValue('');
+      storage.get('PrimaryPassword')!.setValue('');
+      storage.get('PrimaryUserName')!.disable();
+      storage.get('PrimaryPassword')!.disable();
     }
     else
     {
-      storage.get('PrimaryUserName').setValidators([Validators.required]);
-      storage.get('PrimaryPassword').setValidators([Validators.required]);
-      storage.get('PrimaryUserName').enable();
-      storage.get('PrimaryPassword').enable();
+      storage.get('PrimaryUserName')!.setValidators([Validators.required]);
+      storage.get('PrimaryPassword')!.setValidators([Validators.required]);
+      storage.get('PrimaryUserName')!.enable();
+      storage.get('PrimaryPassword')!.enable();
     }
-    storage.get('PrimaryUserName').updateValueAndValidity();
-    storage.get('PrimaryPassword').updateValueAndValidity();
+    storage.get('PrimaryUserName')!.updateValueAndValidity();
+    storage.get('PrimaryPassword')!.updateValueAndValidity();
   }
 
   updateStorageKindValidatorsSecondaryCredentials(storage: AbstractControl, IsEmptySecondaryCredential: boolean) {
     if (IsEmptySecondaryCredential)
     {
-      storage.get('SecondaryUserName').setValidators(null);
-      storage.get('SecondaryPassword').setValidators(null);
-      storage.get('SecondaryUserName').setValue('');
-      storage.get('SecondaryPassword').setValue('');
-      storage.get('SecondaryUserName').disable();
-      storage.get('SecondaryPassword').disable();
+      storage.get('SecondaryUserName')!.setValidators(null);
+      storage.get('SecondaryPassword')!.setValidators(null);
+      storage.get('SecondaryUserName')!.setValue('');
+      storage.get('SecondaryPassword')!.setValue('');
+      storage.get('SecondaryUserName')!.disable();
+      storage.get('SecondaryPassword')!.disable();
     }
     else
     {
-      storage.get('SecondaryUserName').setValidators([Validators.required]);
-      storage.get('SecondaryPassword').setValidators([Validators.required]);
-      storage.get('SecondaryUserName').enable();
-      storage.get('SecondaryPassword').enable();
+      storage.get('SecondaryUserName')!.setValidators([Validators.required]);
+      storage.get('SecondaryPassword')!.setValidators([Validators.required]);
+      storage.get('SecondaryUserName')!.enable();
+      storage.get('SecondaryPassword')!.enable();
     }
-    storage.get('SecondaryUserName').updateValueAndValidity();
-    storage.get('SecondaryPassword').updateValueAndValidity();
+    storage.get('SecondaryUserName')!.updateValueAndValidity();
+    storage.get('SecondaryPassword')!.updateValueAndValidity();
   }
 }

--- a/src/SfxWeb/src/app/modules/backup-restore/view-backup/view-backup.component.ts
+++ b/src/SfxWeb/src/app/modules/backup-restore/view-backup/view-backup.component.ts
@@ -27,8 +27,8 @@ export class ViewBackupComponent implements OnInit {
   dataService = inject(DataService);
 
 
-  backUpData: IViewBackUpData;
-  action: IsolatedAction;
+  backUpData!: IViewBackUpData;
+  action!: IsolatedAction;
 
   ngOnInit() {
     this.backUpData = this.data.data;

--- a/src/SfxWeb/src/app/modules/charts/bar-chart/bar-chart.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/bar-chart/bar-chart.component.ts
@@ -11,14 +11,14 @@ import { Chart, Options, chart, SeriesOptionsType, TooltipFormatterCallbackFunct
 })
 export class BarChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
-  @Input() xAxisCategories: string[];
+  @Input() xAxisCategories!: string[];
   @Input() dataSet: any[] = [];
   @Input() title = '';
   @Input() subtitle = '';
-  @Input() tooltip: TooltipFormatterCallbackFunction;
+  @Input() tooltip!: TooltipFormatterCallbackFunction;
 
-  private chart: Chart;
-  @ViewChild('container') private container: ElementRef;
+  private chart!: Chart;
+  @ViewChild('container') private container!: ElementRef;
 
   fontColor = {
                 color: '#fff'

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-scale-tile/dashboard-text-scale-tile.component.ts
@@ -10,8 +10,8 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 export class DashboardTextScaleTileComponent {
 
   @Input() barClass = '';
-  @Input() title: string;
-  @Input() link: string;
+  @Input() title!: string;
+  @Input() link!: string;
   @Input() text: string[] = [];
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-text-tile/dashboard-text-tile.component.ts
@@ -10,9 +10,9 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 export class DashboardTextTileComponent {
 
   @Input() barClass = '';
-  @Input() title: string;
-  @Input() count: string | number;
-  @Input() link: string;
+  @Input() title!: string;
+  @Input() count!: string | number;
+  @Input() link!: string;
   @Input() middleMargin = '15px 0';
   @Input() helpTextLink = '';
   constructor() { }

--- a/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
@@ -11,11 +11,11 @@ import { Chart, Options, chart, PointOptionsObject, SeriesPieOptions } from 'hig
 })
 export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges {
 
-  @Input() data: IDashboardViewModel;
+  @Input() data!: IDashboardViewModel;
 
-  @ViewChild('chart') private chartContainer: ElementRef;
+  @ViewChild('chart') private chartContainer!: ElementRef;
 
-  private chart: Chart;
+  private chart!: Chart;
 
   fontColor = {
     color: '#fff'
@@ -24,7 +24,7 @@ export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges 
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null,
+      backgroundColor: null as any,
       borderRadius: 0,
     },
     title: {
@@ -105,20 +105,20 @@ export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges 
   ngOnInit() {
     const margin = 3;
     const width = (this.data.largeTile ? 230 : 150) + margin * 2;
-    this.options.chart.height = width;
-    this.options.chart.width = width;
+    this.options.chart!.height = width;
+    this.options.chart!.width = width;
 
-    this.options.title.text = this.data.displayTitle;
-    this.options.subtitle.text = this.data.count.toString();
+    this.options.title!.text = this.data.displayTitle;
+    this.options.subtitle!.text = this.data.count.toString();
 
     const data = this.getDataSet();
-    this.options.tooltip.enabled = data.length === 3;
-    (this.options.series[0] as SeriesPieOptions).data = data;
+    this.options.tooltip!.enabled = data.length === 3;
+    (this.options.series![0] as SeriesPieOptions).data = data;
 
     if (!this.data.largeTile) {
-      this.options.title.y = 9;
-      this.options.subtitle.style.fontSize = '14pt';
-      this.options.subtitle.y = 30;
+      this.options.title!.y = 9;
+      this.options.subtitle!.style!.fontSize = '14pt';
+      this.options.subtitle!.y = 30;
     }
   }
 
@@ -143,7 +143,7 @@ export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges 
       return {
         name: p.title,
         y: p.count,
-        color: colors[p.title]
+        color: (colors as any)[p.title]
       };
     });
 

--- a/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
@@ -143,7 +143,7 @@ export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges 
       return {
         name: p.title,
         y: p.count,
-        color: (colors as any)[p.title]
+        color: colors[p.title as keyof typeof colors]
       };
     });
 

--- a/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/dashboard-tile/dashboard-tile.component.ts
@@ -24,7 +24,7 @@ export class DashboardTileComponent implements OnInit, AfterViewInit, OnChanges 
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null as any,
+      backgroundColor: 'transparent',
       borderRadius: 0,
     },
     title: {

--- a/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.ts
@@ -20,7 +20,7 @@ interface IEssentialListItemInternal extends IEssentialListItem {
 export class EssentialTemplateDirective {
   templateRef = inject<TemplateRef<any>>(TemplateRef);
 
-  @Input() id: string;
+  @Input() id!: string;
 
   public getId() {
     return this.id;
@@ -38,9 +38,9 @@ export class EssentialHealthTileComponent implements AfterViewInit, OnChanges {
   private detectorRef = inject(ChangeDetectorRef);
 
 
-  @Input() healthState;
+  @Input() healthState: any;
   @Input() listItems: IEssentialListItem[] = [];
-  @Input() templateRefs: Record<string, TemplateRef<any>>;
+  @Input() templateRefs!: Record<string, TemplateRef<any>>;
   @ContentChildren(EssentialTemplateDirective, { descendants: true } ) test!: QueryList<EssentialTemplateDirective>;
 
   internalList: IEssentialListItemInternal[] = [];

--- a/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/essential-health-tile/essential-health-tile.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, Directive, Input, OnChanges, OnInit, QueryList, TemplateRef, inject } from '@angular/core';
+import { ITextAndBadge } from 'src/app/Utils/ValueResolver';
 
 export interface IEssentialListItem {
   displayText?: string;
@@ -38,7 +39,7 @@ export class EssentialHealthTileComponent implements AfterViewInit, OnChanges {
   private detectorRef = inject(ChangeDetectorRef);
 
 
-  @Input() healthState: any;
+  @Input() healthState?: ITextAndBadge;
   @Input() listItems: IEssentialListItem[] = [];
   @Input() templateRefs!: Record<string, TemplateRef<any>>;
   @ContentChildren(EssentialTemplateDirective, { descendants: true } ) test!: QueryList<EssentialTemplateDirective>;

--- a/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
@@ -10,14 +10,14 @@ import { Chart, Options, chart, PointOptionsObject, SeriesPieOptions } from 'hig
     standalone: false
 })
 export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
-  @Input() data: IDashboardDataPointViewModel[];
+  @Input() data!: IDashboardDataPointViewModel[];
   @Input() width = '80';
   @Input() title: number | string = '';
   @Input() description: string = '';
 
-  @ViewChild('chart') private chartContainer: ElementRef;
+  @ViewChild('chart') private chartContainer!: ElementRef;
 
-  private chart: Chart;
+  private chart!: Chart;
 
   fontColor = {
     color: '#fff'
@@ -26,7 +26,7 @@ export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null,
+      backgroundColor: null as any,
       borderRadius: 0,
       margin: [0, 0, 0, 0],
       spacingTop: 0,
@@ -110,16 +110,16 @@ export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
   constructor() { }
 
   ngOnInit() {
-    this.options.chart.height = this.width;
-    this.options.chart.width = this.width;
-    this.options.title.text = this.description.toString();
-    this.options.subtitle.text = this.title.toString();
+    this.options.chart!.height = this.width;
+    this.options.chart!.width = this.width;
+    this.options.title!.text = this.description.toString();
+    this.options.subtitle!.text = this.title.toString();
 
     const data = this.getDataSet();
-    this.options.tooltip.enabled = data.length === 3;
-    (this.options.series[0] as SeriesPieOptions).data = data;
+    this.options.tooltip!.enabled = data.length === 3;
+    (this.options.series![0] as SeriesPieOptions).data = data;
 
-    this.options.subtitle.style.fontSize =  +this.width * .2 + 'pt';
+    this.options.subtitle!.style!.fontSize =  +this.width * .2 + 'pt';
   }
 
   ngAfterViewInit() {
@@ -137,7 +137,7 @@ export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
       return {
         name: p.title,
         y: p.count,
-        color: colors[p.title]
+        color: (colors as any)[p.title]
       };
     });
 

--- a/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
@@ -137,7 +137,7 @@ export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
       return {
         name: p.title,
         y: p.count,
-        color: (colors as any)[p.title]
+        color: colors[p.title as keyof typeof colors]
       };
     });
 

--- a/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/health-chart/health-chart.component.ts
@@ -26,7 +26,7 @@ export class HealthChartComponent implements OnInit, AfterViewInit, OnChanges {
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null as any,
+      backgroundColor: 'transparent',
       borderRadius: 0,
       margin: [0, 0, 0, 0],
       spacingTop: 0,

--- a/src/SfxWeb/src/app/modules/charts/resources-tile/resources-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/charts/resources-tile/resources-tile.component.ts
@@ -21,7 +21,7 @@ interface IResourceItemInternal extends IResourceItem {
 export class ResourcesTemplateDirective {
   templateRef = inject<TemplateRef<any>>(TemplateRef);
 
-  @Input() id: string;
+  @Input() id!: string;
 
   public getId() {
     return this.id;
@@ -40,7 +40,7 @@ export class ResourcesTileComponent implements AfterViewInit, OnChanges {
 
   
   @Input() listItems: IResourceItem[] = [];
-  @Input() templateRefs: Record<string, TemplateRef<any>>;
+  @Input() templateRefs!: Record<string, TemplateRef<any>>;
   @ContentChildren(ResourcesTemplateDirective, { descendants: true } ) test!: QueryList<ResourcesTemplateDirective>;
 
   internalList: IResourceItemInternal[] = [];

--- a/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
@@ -17,18 +17,18 @@ export class MapComponent extends BaseControllerDirective implements OnChanges {
 
   static readonly baseScale = 'scale(1)';
 
-  @Input() listTemplate: TemplateRef<any>;
+  @Input() listTemplate!: TemplateRef<any>;
   @Input() nodes: Node[] = [];
   @Input() groupByNodeType = false;
 
-  matrix: Record<string, Node[]>;
+  matrix!: Record<string, Node[]>;
 
   showScaleButton = false;
   scaleToFit = false;
   scale = MapComponent.baseScale;
 
-  @ViewChild('container') private container: ElementRef;
-  @ViewChild('map') private map: ElementRef;
+  @ViewChild('container') private container!: ElementRef;
+  @ViewChild('map') private map!: ElementRef;
 
   ngOnChanges() {
     this.updateNodes(this.nodes);
@@ -61,18 +61,18 @@ export class MapComponent extends BaseControllerDirective implements OnChanges {
       const matrix = {};
 
       this.data.nodes.faultDomains.forEach(fd => {
-        matrix[fd] = [];
+        (matrix as any)[fd] = [];
 
         this.data.nodes.upgradeDomains.forEach(ud => {
-          matrix[`${fd}${ud}`] = [];
-          matrix[ud] = [];
+          (matrix as any)[`${fd}${ud}`] = [];
+          (matrix as any)[ud] = [];
         });
       });
 
       nodes.forEach(node => {
-        matrix[node.faultDomain + node.upgradeDomain].push(node);
-        matrix[node.faultDomain].push(node);
-        matrix[node.upgradeDomain].push(node);
+        (matrix as any)[node.faultDomain + node.upgradeDomain].push(node);
+        (matrix as any)[node.faultDomain].push(node);
+        (matrix as any)[node.upgradeDomain].push(node);
       });
 
       this.matrix = matrix;
@@ -80,7 +80,7 @@ export class MapComponent extends BaseControllerDirective implements OnChanges {
 
   }
 
-  trackByFn(index, udOrFd: string) {
+  trackByFn(index: any, udOrFd: string) {
     return udOrFd;
   }
 }

--- a/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
@@ -58,21 +58,21 @@ export class MapComponent extends BaseControllerDirective implements OnChanges {
 
   public updateNodes(nodes: Node[]) {
     this.data.nodes.ensureInitialized().subscribe(() => {
-      const matrix = {};
+      const matrix: Record<string, Node[]> = {};
 
       this.data.nodes.faultDomains.forEach(fd => {
-        (matrix as any)[fd] = [];
+        matrix[fd] = [];
 
         this.data.nodes.upgradeDomains.forEach(ud => {
-          (matrix as any)[`${fd}${ud}`] = [];
-          (matrix as any)[ud] = [];
+          matrix[`${fd}${ud}`] = [];
+          matrix[ud] = [];
         });
       });
 
       nodes.forEach(node => {
-        (matrix as any)[node.faultDomain + node.upgradeDomain].push(node);
-        (matrix as any)[node.faultDomain].push(node);
-        (matrix as any)[node.upgradeDomain].push(node);
+        matrix[node.faultDomain + node.upgradeDomain].push(node);
+        matrix[node.faultDomain].push(node);
+        matrix[node.upgradeDomain].push(node);
       });
 
       this.matrix = matrix;

--- a/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/map/map.component.ts
@@ -80,7 +80,7 @@ export class MapComponent extends BaseControllerDirective implements OnChanges {
 
   }
 
-  trackByFn(index: any, udOrFd: string) {
+  trackByFn(index: number, udOrFd: string) {
     return udOrFd;
   }
 }

--- a/src/SfxWeb/src/app/modules/clustermap/node-list/node-list.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/node-list/node-list.component.ts
@@ -10,16 +10,16 @@ import { environment } from 'src/environments/environment';
     standalone: false
 })
 export class NodeListComponent {
-  @Input() listTemplate: TemplateRef<any>;
+  @Input() listTemplate!: TemplateRef<any>;
 
   @Input() underlineLast = true;
-  @Input() nodes: Node[];
+  @Input() nodes!: Node[];
 
   public assetBase = environment.assetBase;
 
   constructor() { }
 
-  trackByFn(index, node: Node) {
+  trackByFn(index: any, node: Node) {
     return node.uniqueId;
   }
 }

--- a/src/SfxWeb/src/app/modules/clustermap/node-list/node-list.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/node-list/node-list.component.ts
@@ -19,7 +19,7 @@ export class NodeListComponent {
 
   constructor() { }
 
-  trackByFn(index: any, node: Node) {
+  trackByFn(index: number, node: Node) {
     return node.uniqueId;
   }
 }

--- a/src/SfxWeb/src/app/modules/clustermap/section-overview/section-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/section-overview/section-overview.component.ts
@@ -20,17 +20,17 @@ import { IEssentialListItem } from '../../charts/essential-health-tile/essential
 export class SectionOverviewComponent implements OnChanges {
   dataService = inject(DataService);
 
-  @Input() nodes: Node[];
-  @Input() repairJobs: RepairTaskCollection;
+  @Input() nodes!: Node[];
+  @Input() repairJobs!: RepairTaskCollection;
   @Input() title = '';
   @Input() moreInfo = true;
   @Input() vertical = true;
-  info: INodesStatusDetails;
+  info!: INodesStatusDetails;
   item: IEssentialListItem[] = [];
 
   dataPoints: IDashboardDataPointViewModel[] = [];
   public constants = NodeStatusConstants;
-  repairInfo;
+  repairInfo: any;
 
   ngOnChanges(): void {
     const nodeInfo = new NodeStatusDetails('');

--- a/src/SfxWeb/src/app/modules/clustermap/section-overview/section-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/section-overview/section-overview.component.ts
@@ -30,7 +30,7 @@ export class SectionOverviewComponent implements OnChanges {
 
   dataPoints: IDashboardDataPointViewModel[] = [];
   public constants = NodeStatusConstants;
-  repairInfo: any;
+  repairInfo?: { inProgress: number; recent: number };
 
   ngOnChanges(): void {
     const nodeInfo = new NodeStatusDetails('');

--- a/src/SfxWeb/src/app/modules/clustermap/status-tile/status-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/status-tile/status-tile.component.ts
@@ -14,10 +14,10 @@ import { IEssentialListItem } from '../../charts/essential-health-tile/essential
 })
 export class StatusTileComponent implements OnChanges {
 
-  @Input() listTemplate: TemplateRef<any>;
+  @Input() listTemplate!: TemplateRef<any>;
 
-  @Input() nodes: Node[];
-  @Input() repairJobs: RepairTaskCollection;
+  @Input() nodes!: Node[];
+  @Input() repairJobs!: RepairTaskCollection;
   @Input() groupByNodeType = false;
   @Input() title = '';
   items: IEssentialListItem[] = [];
@@ -46,7 +46,7 @@ export class StatusTileComponent implements OnChanges {
     }
   }
 
-  trackByFn(index, node: any) {
+  trackByFn(index: any, node: any) {
     return node.key;
   }
 }

--- a/src/SfxWeb/src/app/modules/clustermap/status-tile/status-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/clustermap/status-tile/status-tile.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges, OnInit, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { KeyValue } from '@angular/common';
 import { NodeStatusConstants } from 'src/app/Common/Constants';
 import { NodeStatusDetails } from 'src/app/Models/DataModels/collections/NodeCollection';
 import { RepairTaskCollection } from 'src/app/Models/DataModels/collections/RepairTaskCollection';
@@ -46,7 +47,7 @@ export class StatusTileComponent implements OnChanges {
     }
   }
 
-  trackByFn(index: any, node: any) {
+  trackByFn(index: number, node: KeyValue<string, NodeStatusDetails>) {
     return node.key;
   }
 }

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/naming-viewer/naming-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/naming-viewer/naming-viewer.component.ts
@@ -29,10 +29,10 @@ export interface IOverviewPanel {
 export class NamingViewerComponent implements VisualizationComponent {
   private settings = inject(SettingsService);
 
-  public startDate: Date;
-  public endDate: Date;
-  public startDateMin: Date;
-  public startDateMax: Date;
+  public startDate!: Date;
+  public endDate!: Date;
+  public startDateMin!: Date;
+  public startDateMax!: Date;
 
   dataset: IParallelChartData = {
     dataSets: [],
@@ -58,11 +58,11 @@ export class NamingViewerComponent implements VisualizationComponent {
         yLabel: 'Count'
       }
     ],
-    listSettings: null
+    listSettings: null!
   }
 
   overviewPanels: IOverviewPanel[] = []
-  localData: VisUpdateData;
+  localData!: VisUpdateData;
 
   generateOverviewPanel(data: VisUpdateData) {
     const previousOverviewPanels = this.overviewPanels;

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
@@ -168,7 +168,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
   }
 
   reasonTreeToList(event: IConcurrentEvents): IConcurrentEvents[] {
-    let next: IConcurrentEvents | null = event;
+    let next: IConcurrentEvents | null | undefined = event;
     const list = [];
     while (next) {
       list.push(next)

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
@@ -20,18 +20,18 @@ interface ExtendedListItem extends IEssentialListItem {
     standalone: false
 })
 export class RcaOverviewComponent implements AfterViewInit, OnChanges {
-  @Input() type: string;
-  @Input() events: IConcurrentEvents[];
+  @Input() type!: string;
+  @Input() events!: IConcurrentEvents[];
 
-  @ViewChild('chart') private chartContainer: ElementRef;
-  private chart: Chart;
+  @ViewChild('chart') private chartContainer!: ElementRef;
+  private chart!: Chart;
   private preGeneratedColors = [...pregeneratedColors];
   public whiteLists = pregeneratedColors.map(c => "color-"+c).concat(['rca-summary-key']); //add all of the pregenerated safe timeline colors and the summary key item
 
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null,
+      backgroundColor: null as any,
       borderRadius: 0,
       spacingTop: 0,
       spacingBottom: 0,
@@ -58,7 +58,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
       pie: {
         borderWidth: 2,
         innerSize: '50%',
-        borderColor: null,
+        borderColor: null as any,
         allowPointSelect: true,
         cursor: 'pointer',
         dataLabels: {
@@ -72,14 +72,14 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
 
   public colorKey: Record<string, IPregeneratedColor> = {};
   public reasons: ExtendedListItem[] = [];
-  public timelineData: ITimelineData;
+  public timelineData!: ITimelineData;
 
   constructor() { }
 
   generateDataSet(listItems: ExtendedListItem[]) {
     return listItems.map(item => {
       return {
-        y: +item.displayText,
+        y: +item.displayText!,
         name: item.key,
         type: 'pie',
         dataLabels: {
@@ -168,7 +168,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
   }
 
   reasonTreeToList(event: IConcurrentEvents): IConcurrentEvents[] {
-    let next = event;
+    let next: IConcurrentEvents | null = event;
     const list = [];
     while (next) {
       list.push(next)

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
@@ -31,7 +31,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
   public options: Options = {
     chart: {
       type: 'pie',
-      backgroundColor: null as any,
+      backgroundColor: 'transparent',
       borderRadius: 0,
       spacingTop: 0,
       spacingBottom: 0,
@@ -58,7 +58,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
       pie: {
         borderWidth: 2,
         innerSize: '50%',
-        borderColor: null as any,
+        borderColor: 'transparent',
         allowPointSelect: true,
         cursor: 'pointer',
         dataLabels: {

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/rca-overview/rca-overview.component.ts
@@ -157,7 +157,7 @@ export class RcaOverviewComponent implements AfterViewInit, OnChanges {
 
     this.timelineData = {
       groups,
-      items: items as any,
+      items,
       allowClustering: true
     }
 

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/relation-viewer/relation-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/relation-viewer/relation-viewer.component.ts
@@ -9,9 +9,9 @@ import { Component, Input, OnChanges, OnInit, ChangeDetectionStrategy } from '@a
 })
 export class RelationViewerComponent implements OnChanges {
 
-  @Input() key: string;
+  @Input() key!: string;
 
-  split: string[];
+  split!: string[];
   constructor() { }
 
   ngOnChanges(): void {

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -48,16 +48,16 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   private settings = inject(SettingsService);
 
 
-  @Input() data: IParallelChartData;
-  @ViewChildren('container') private container: QueryList<ElementRef>;
+  @Input() data!: IParallelChartData;
+  @ViewChildren('container') private container!: QueryList<ElementRef>;
 
-  @ViewChild('inner') private inner: ElementRef<HTMLDivElement>;
+  @ViewChild('inner') private inner!: ElementRef<HTMLDivElement>;
 
   private charts: Chart[] = [];
   subscriptions: Subscription = new Subscription();
-  listSettings: ListSettings;
+  listSettings!: ListSettings;
 
-  currentItems: any[];
+  currentItems: any[] | null = null;
   currentIndex = 0;
   currentItemsWidth = 400;
   resizer = new Subject<any>();
@@ -68,7 +68,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
 
   public options: Options = {
     chart: {
-      backgroundColor: null,
+      backgroundColor: null as any,
       height: 200,
       zooming: {
         type: 'x'
@@ -159,7 +159,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   private generateCharts() {
     const data = this.generateChartData();
 
-    this.container.forEach((element, index) => {
+    this.container.forEach((element, index: any) => {
       const chart = this.charts[index];
       const chartData = data[index];
 
@@ -168,10 +168,10 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
           if (chartData.series.every(set => set.name !== series.name)) {
             series.remove();
           } else {
-            series.update(chartData.series.find(set => set.name === series.name));
+            series.update(chartData.series.find(set => set.name === series.name)!);
           }
         });
-        chartData.series.forEach(item => {
+        chartData.series.forEach((item: any) => {
           if (chart.series.every(set => set.name !== item.name)) {
             chart.addSeries(item);
           }
@@ -193,12 +193,12 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     const ref = this;
     const colorMap = {};
     this.data.dataSets.forEach(dataset => {
-      colorMap[dataset.name] = Utils.randomColor();
+      (colorMap as any)[dataset.name] = Utils.randomColor();
     })
 
-    return this.data.series.map((chartData, index) => {
+    return this.data.series.map((chartData, index: any) => {
       const dataSet: SeriesOptionsType[] = this.data.dataSets.map(dataset => {
-        const values: PointOptionsObject[] = dataset.values.map(item => {
+        const values: PointOptionsObject[] = dataset.values.map((item: any) => {
           const point = this.pickDataPoints(item, chartData);
 
           return {
@@ -206,7 +206,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
             y: point.y,
             itemData: item,
             events: {
-              click: function (e) {
+              click: function (e: any) {
                 const points = this.series.chart.series.map(series => {
                   return (series as any).searchPoint(e, true)
                 }).filter(point => !!point).map(p => {
@@ -238,7 +238,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
           dataLabels: {
             style: this.fontColor,
           },
-          color: colorMap[dataset.name]
+          color: (colorMap as any)[dataset.name]
         }
       })
 
@@ -252,11 +252,11 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       }
 
       if (chartData.yUnits) {
-        yAxis.labels.format = `{value} ${chartData.yUnits}`
+        yAxis.labels!.format = `{value} ${chartData.yUnits}`
       }
 
       if (chartData.yLabel) {
-        yAxis.title.text = chartData.yLabel
+        yAxis.title!.text = chartData.yLabel
       }
 
       const xAxis: XAxisOptions = {
@@ -269,11 +269,11 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       }
 
       if (chartData.xUnits) {
-        xAxis.labels.format = `{value} ${chartData.xUnits}`
+        xAxis.labels!.format = `{value} ${chartData.xUnits}`
       }
 
       if (chartData.xLabel) {
-        xAxis.title.text = chartData.xLabel
+        xAxis.title!.text = chartData.xLabel
       }
       return {
             ...this.options, series: dataSet, yAxis,
@@ -290,12 +290,12 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
 
   getSync() {
     const compRef = this;
-    return function syncExtremes(e) {
+    return function syncExtremes(this: any, e: any) {
       var thisChart = this.chart;
       if (e.trigger !== 'syncExtremes') { // Prevent feedback loop
         compRef.charts.forEach((chart) => {
           if (chart !== thisChart) {
-            if (chart.xAxis[0].setExtremes) { // It is null while updating
+            if ((chart.xAxis[0] as any).setExtremes) { // It is null while updating
               chart.xAxis[0].setExtremes(
                 e.min,
                 e.max,
@@ -339,11 +339,11 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       let closestSeries = closestPoint.series;
 
       this.charts.forEach(chart => {
-        const referencePoint = chart.series.find(series => series.name === closestSeries.name).data[closestPoint.index];
+        const referencePoint = chart.series.find(series => series.name === closestSeries.name)!.data[closestPoint.index];
         if (referencePoint) {
           referencePoint.onMouseOver(); // Show the hover marker
           chart.tooltip.refresh(referencePoint); // Show the tooltip
-          chart.xAxis[0].drawCrosshair(null, referencePoint); // Show the crosshair
+          chart.xAxis[0].drawCrosshair(undefined, referencePoint); // Show the crosshair
         }
       })
     }
@@ -361,7 +361,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     this.resizer.next(width);
   }
 
-  itemTrackBy(index, item) {
+  itemTrackBy(index: any, item: any) {
     return item.series.name;
   }
 }

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -57,7 +57,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   subscriptions: Subscription = new Subscription();
   listSettings!: ListSettings;
 
-  currentItems: any[] | null = null;
+  currentItems?: any[] | null;
   currentIndex = 0;
   currentItemsWidth = 400;
   resizer = new Subject<any>();
@@ -343,7 +343,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
         if (referencePoint) {
           referencePoint.onMouseOver(); // Show the hover marker
           chart.tooltip.refresh(referencePoint); // Show the tooltip
-          chart.xAxis[0].drawCrosshair(undefined, referencePoint); // Show the crosshair
+          chart.xAxis[0].drawCrosshair(null!, referencePoint); // Show the crosshair
         }
       })
     }

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -191,9 +191,9 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
 
   private generateChartData() {
     const ref = this;
-    const colorMap = {};
+    const colorMap: Record<string, string> = {};
     this.data.dataSets.forEach(dataset => {
-      (colorMap as any)[dataset.name] = Utils.randomColor();
+      colorMap[dataset.name] = Utils.randomColor();
     })
 
     return this.data.series.map((chartData, index: any) => {
@@ -238,7 +238,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
           dataLabels: {
             style: this.fontColor,
           },
-          color: (colorMap as any)[dataset.name]
+          color: colorMap[dataset.name]
         }
       })
 

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, ViewChildren, ElementRef, AfterViewInit, QueryList, ViewChild, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
-import { Chart, Options, chart, SeriesOptionsType, Pointer, PointOptionsObject, YAxisOptions, XAxisOptions } from 'highcharts';
+import { Chart, Options, chart, SeriesOptionsType, Pointer, PointOptionsObject, YAxisOptions, XAxisOptions, Axis } from 'highcharts';
 import { debounceTime } from 'rxjs/operators';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { SettingsService } from 'src/app/services/settings.service';
@@ -117,10 +117,10 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       }
     },
     tooltip: {
-      positioner: function () {
+      positioner: function (labelWidth) {
         return {
           // right aligned
-          x: this.chart.chartWidth - (this as any).label.width - 10,
+          x: this.chart.chartWidth - labelWidth - 10,
           y: 10 // align to title
         };
       },
@@ -208,6 +208,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
             events: {
               click: function (e: any) {
                 const points = this.series.chart.series.map(series => {
+                  // searchPoint is a Highcharts internal method absent from the public types
                   return (series as any).searchPoint(e, true)
                 }).filter(point => !!point).map(p => {
                   return {
@@ -295,7 +296,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       if (e.trigger !== 'syncExtremes') { // Prevent feedback loop
         compRef.charts.forEach((chart) => {
           if (chart !== thisChart) {
-            if ((chart.xAxis[0] as any).setExtremes) { // It is null while updating
+            if ((chart.xAxis[0] as Axis | undefined)?.setExtremes) { // It is null while updating
               chart.xAxis[0].setExtremes(
                 e.min,
                 e.max,
@@ -322,6 +323,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     const originChart = this.charts[chartIndex];
     const event = originChart.pointer.normalize(e);
     const points = originChart.series.map(series => {
+      // searchPoint is a Highcharts internal method absent from the public types
       return (series as any).searchPoint(event, false)
     }).filter(point => !!point);
 

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -68,7 +68,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
 
   public options: Options = {
     chart: {
-      backgroundColor: null as any,
+      backgroundColor: 'transparent',
       height: 200,
       zooming: {
         type: 'x'

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -1,10 +1,18 @@
 import { Component, Input, OnChanges, OnDestroy, ViewChildren, ElementRef, AfterViewInit, QueryList, ViewChild, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
-import { Chart, Options, chart, SeriesOptionsType, Pointer, PointOptionsObject, YAxisOptions, XAxisOptions, Axis } from 'highcharts';
+import { Chart, Options, chart, SeriesOptionsType, Pointer, PointOptionsObject, YAxisOptions, XAxisOptions, Axis, PointClickEventObject, Point, Series } from 'highcharts';
 import { debounceTime } from 'rxjs/operators';
 import { ListSettings } from 'src/app/Models/ListSettings';
 import { SettingsService } from 'src/app/services/settings.service';
 import { Utils } from 'src/app/Utils/Utils';
 import { Subscription, Subject, merge } from 'rxjs';
+
+declare module 'highcharts' {
+  // itemData: attached by us via the point's options; clientX: set at runtime by Series.searchPoint’s k-d-tree lookup
+  interface Point {
+    itemData?: any;
+    clientX: number;
+  }
+}
 
 export interface IdataFormatter {
   name: string;
@@ -25,6 +33,13 @@ export interface IParallelChartData {
   series: IdataFormatter[];
   dataSets: IDataSet[];
   listSettings: ListSettings;
+}
+
+interface ISelectedItem {
+  item: any;
+  pointData: Point;
+  series: Series;
+  tags: { x: number; y: number; label?: string }[];
 }
 
 Pointer.prototype.reset = function () {
@@ -57,10 +72,10 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   subscriptions: Subscription = new Subscription();
   listSettings!: ListSettings;
 
-  currentItems?: unknown[] | null;
+  currentItems?: ISelectedItem[] | null;
   currentIndex = 0;
   currentItemsWidth = 400;
-  resizer = new Subject<any>();
+  resizer = new Subject<number>();
 
   fontColor = {
     color: '#fff'
@@ -159,7 +174,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   private generateCharts() {
     const data = this.generateChartData();
 
-    this.container.forEach((element, index: any) => {
+    this.container.forEach((element, index: number) => {
       const chart = this.charts[index];
       const chartData = data[index];
 
@@ -182,7 +197,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     })
   }
 
-  private pickDataPoints(item: any, formatter: IdataFormatter) {
+  private pickDataPoints(item: any, formatter: IdataFormatter): { x: number; y: number } {
     return {
       x: Utils.result2(item, formatter.xProperty),
       y: Utils.result2(item, formatter.yProperty)
@@ -196,7 +211,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
       colorMap[dataset.name] = Utils.randomColor();
     })
 
-    return this.data.series.map((chartData, index: any) => {
+    return this.data.series.map((chartData, index: number) => {
       const dataSet: SeriesOptionsType[] = this.data.dataSets.map(dataset => {
         const values: PointOptionsObject[] = dataset.values.map((item: any) => {
           const point = this.pickDataPoints(item, chartData);
@@ -206,11 +221,10 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
             y: point.y,
             itemData: item,
             events: {
-              click: function (e: any) {
+              click: function (e: PointClickEventObject) {
                 const points = this.series.chart.series.map(series => {
-                  // searchPoint is a Highcharts internal method absent from the public types
-                  return (series as any).searchPoint(e, true)
-                }).filter(point => !!point).map(p => {
+                  return series.searchPoint(e, true)
+                }).filter((point): point is Point => !!point).map(p => {
                   return {
                     item: p.itemData,
                     pointData: p,
@@ -323,9 +337,8 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     const originChart = this.charts[chartIndex];
     const event = originChart.pointer.normalize(e);
     const points = originChart.series.map(series => {
-      // searchPoint is a Highcharts internal method absent from the public types
-      return (series as any).searchPoint(event, false)
-    }).filter(point => !!point);
+      return series.searchPoint(event, false)
+    }).filter((point): point is Point => !!point);
 
     if (points.length > 0) {
       let closestPoint = points[0];
@@ -363,7 +376,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
     this.resizer.next(width);
   }
 
-  itemTrackBy(index: any, item: any) {
+  itemTrackBy(index: number, item: ISelectedItem) {
     return item.series.name;
   }
 }

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/timeseries/timeseries.component.ts
@@ -57,7 +57,7 @@ export class TimeseriesComponent implements AfterViewInit, OnChanges, OnDestroy,
   subscriptions: Subscription = new Subscription();
   listSettings!: ListSettings;
 
-  currentItems?: any[] | null;
+  currentItems?: unknown[] | null;
   currentIndex = 0;
   currentItemsWidth = 400;
   resizer = new Subject<any>();

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-logo/visualization-logo.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-logo/visualization-logo.component.ts
@@ -13,9 +13,9 @@ import { environment } from 'src/environments/environment';
 })
 export class VisualizationLogoComponent implements OnInit, DetailBaseComponent {
 
-  visPresent: boolean;
-  item: IRCAItem;
-  listSetting: ListColumnSettingWithEmbeddedVis;
+  visPresent!: boolean;
+  item!: IRCAItem;
+  listSetting!: ListColumnSettingWithEmbeddedVis;
 
   public assetBase = environment.assetBase;
 

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
@@ -23,18 +23,18 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
   private eventTitleColor: string = "var(--font-primary-color)";
   private textColor: string = "var(--font-accent-color)";
 
-  private chart: Chart;
+  private chart!: Chart;
 
-  visEvents : IConcurrentEvents;
-  item : IRCAItem;
-  listSetting : ListColumnSettingWithEmbeddedVis;
+  visEvents !: IConcurrentEvents;
+  item !: IRCAItem;
+  listSetting !: ListColumnSettingWithEmbeddedVis;
 
-  @ViewChild('container') private container: ElementRef;
+  @ViewChild('container') private container!: ElementRef;
 
   public options: Options = {
       chart: {
         inverted: true,
-        backgroundColor: null,
+        backgroundColor: null as any,
         margin: [0, 0, 0, 0],
         spacingTop: 0,
         spacingBottom: 0,
@@ -71,7 +71,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
 
     this.options.series = [this.traverse()];
     const data = this.traverse();
-    this.options.chart.height = data.levels.length * 110 || 1;
+    this.options.chart!.height = data.levels!.length * 110 || 1;
     this.chart = chart(this.container.nativeElement, this.options);
   }
 
@@ -103,11 +103,11 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
           maxHeight = Math.max(currSize, maxHeight);
           for (let i = 0; i < currSize; i++) {
               let currEvent = queue.shift();
-              let action = currEvent.reasonForEvent ? "<b>Reason: </b>" + currEvent.reasonForEvent + "</br>" : "";
-              let timestamp = "<b>Timestamp: </b>" + currEvent.timeStamp;
+              let action = currEvent!.reasonForEvent ? "<b>Reason: </b>" + currEvent!.reasonForEvent + "</br>" : "";
+              let timestamp = "<b>Timestamp: </b>" + currEvent!.timeStamp;
               let newNodeComponent : SeriesSankeyNodesOptionsObject = {
-                  id: idPrefix + currEvent.eventInstanceId + "</p>",
-                  title: eventTitlePrefix + currEvent.kind + "</p>",
+                  id: idPrefix + currEvent!.eventInstanceId + "</p>",
+                  title: eventTitlePrefix + currEvent!.kind + "</p>",
                   description: descriptionPrefix + action + timestamp +"</p>",
                   layout: "hanging",
                   height: 80,
@@ -122,19 +122,19 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
               if (currSize == 1) {
                   delete newNodeComponent["layout"];
               }
-              config.nodes.push(newNodeComponent);
+              config.nodes!.push(newNodeComponent);
 
-              if (currEvent.reason) {
-                if (currEvent.reason.name == "self") {
-                  config.data.push({
-                    from: `${idPrefix}${currEvent.eventInstanceId}</p>`
+              if (currEvent!.reason) {
+                if (currEvent!.reason.name == "self") {
+                  config.data!.push({
+                    from: `${idPrefix}${currEvent!.eventInstanceId}</p>`
                   });
                 } else {
-                  config.data.push({
-                    to: `${idPrefix}${currEvent.eventInstanceId}</p>`,
-                    from: `${idPrefix}${currEvent.reason.eventInstanceId}</p>`
+                  config.data!.push({
+                    to: `${idPrefix}${currEvent!.eventInstanceId}</p>`,
+                    from: `${idPrefix}${currEvent!.reason.eventInstanceId}</p>`
                   });
-                  queue.push(currEvent.reason);
+                  queue.push(currEvent!.reason);
                 }
               }
           }
@@ -144,9 +144,9 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
       for (let i = 0; i < levels; i++) {
           let newLevelComponent = {
               level: i,
-              color: null,
+              color: null as any,
           }
-          config.levels.push(newLevelComponent);
+          config.levels!.push(newLevelComponent);
       }
     }
     return config;
@@ -156,7 +156,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
     if (this.chart) {
       const data = this.traverse();
       this.chart.series[0].update(data);
-      this.chart.setSize(undefined, data.levels.length * 100);
+      this.chart.setSize(undefined, data.levels!.length * 100);
     }
   }
 }

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
@@ -105,7 +105,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
               let currEvent = queue.shift();
               let action = currEvent!.reasonForEvent ? "<b>Reason: </b>" + currEvent!.reasonForEvent + "</br>" : "";
               let timestamp = "<b>Timestamp: </b>" + currEvent!.timeStamp;
-              let newNodeComponent : SeriesSankeyNodesOptionsObject = {
+              let newNodeComponent : SeriesSankeyNodesOptionsObject & { opacity: number } = {
                   id: idPrefix + currEvent!.eventInstanceId + "</p>",
                   title: eventTitlePrefix + currEvent!.kind + "</p>",
                   description: descriptionPrefix + action + timestamp +"</p>",
@@ -116,7 +116,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
                     enabled: true,
                     className: 'inner-tooltip'
                   }
-              } as any;
+              };
 
               // root node should not be hanging - this messes up the diagram
               if (currSize == 1) {

--- a/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
+++ b/src/SfxWeb/src/app/modules/concurrent-events-visualization/visualization-tool/visualization-tool.component.ts
@@ -34,7 +34,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
   public options: Options = {
       chart: {
         inverted: true,
-        backgroundColor: null as any,
+        backgroundColor: 'transparent',
         margin: [0, 0, 0, 0],
         spacingTop: 0,
         spacingBottom: 0,
@@ -144,7 +144,7 @@ export class VisualizationToolComponent implements OnChanges, AfterViewInit, Det
       for (let i = 0; i < levels; i++) {
           let newLevelComponent = {
               level: i,
-              color: null as any,
+              color: undefined,
           }
           config.levels!.push(newLevelComponent);
       }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/arm-managed/arm-managed.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/arm-managed/arm-managed.component.ts
@@ -12,16 +12,16 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 export class ArmManagedComponent implements OnInit, DetailBaseComponent {
 
   item: any;
-  listSetting: ListColumnSettingForArmManaged;
+  listSetting!: ListColumnSettingForArmManaged;
 
-  toolTip: string;
-  link: string;
+  toolTip!: string;
+  link!: string;
 
   constructor() { }
 
   ngOnInit(): void {
     this.toolTip = this.item.resourceId;
-    this.link = this.item.resourceId ? `https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${this.item.resourceId}/overview` : null;
+    this.link = this.item.resourceId ? `https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${this.item.resourceId}/overview` : null!;
   }
 
 }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/colored-node-name/colored-node-name.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/colored-node-name/colored-node-name.component.ts
@@ -12,8 +12,8 @@ import { environment } from 'src/environments/environment';
 })
 export class ColoredNodeNameComponent implements OnInit, DetailBaseComponent {
   item: any;
-  listSetting: ListColumnSetting;
-  value: string;
+  listSetting!: ListColumnSetting;
+  value!: string;
   assetBase = environment.assetBase;
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/copy-text/copy-text.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/copy-text/copy-text.component.ts
@@ -12,9 +12,9 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 export class CopyTextComponent implements DetailBaseComponent, OnInit {
 
   item: any;
-  listSetting: ListColumnSetting;
+  listSetting!: ListColumnSetting;
 
-  value: string;
+  value!: string;
   constructor() { }
 
   ngOnInit() {

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -36,7 +36,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   private dialog = inject(MatDialog);
 
 
-  @Input() listSettings: ListSettings;
+  @Input() listSettings!: ListSettings;
   @Input() searchText = 'Search list';
   @Input() isLoading = false;
   @Input() successfulLoad = true;
@@ -44,7 +44,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   @Output() sorted = new EventEmitter<any[]>();
   @Output() sortOrdering = new EventEmitter<ISortOrdering>();
   
-  private iList: any[];
+  private iList!: any[];
   public sortedFilteredList: any[] = []; // actual list displayed in html.
   
   page = 1;
@@ -53,14 +53,14 @@ export class DetailListComponent implements OnInit, OnDestroy {
   cache = {}; // is injected into each cell and allows for settings to persist between refreshs
 
   debounceHandler: Subject<any[]> = new Subject<any[]>();
-  debouncerHandlerSubscription: Subscription;
-  @ViewChildren(NgbDropdown) dropdowns: QueryList<NgbDropdown>;
+  debouncerHandlerSubscription!: Subscription;
+  @ViewChildren(NgbDropdown) dropdowns!: QueryList<NgbDropdown>;
 
   @Input()
   set list(data: any[] | DataModelCollectionBase<any>) {
     if (data instanceof DataModelCollectionBase){
       data.ensureInitialized().subscribe(() => {
-        this.iList = [].concat(data.collection);
+        this.iList = ([] as any[]).concat(data.collection);
         this.updateList();
       });
     }else{
@@ -117,7 +117,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   }
 
   sort(columnSetting: ListColumnSetting) {
-    this.listSettings.sort(columnSetting.config.sortPropertyPaths);
+    this.listSettings.sort(columnSetting.config!.sortPropertyPaths!);
     this.displayPath = columnSetting.propertyPath;
     this.updateList();
 
@@ -177,7 +177,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
 
     // Update each column filter values by scanning through the list and found out all unique values exist in current column
     listSettings.columnSettings.forEach((columnSetting: ListColumnSetting) => {
-        if (!columnSetting.config.enableFilter) {
+        if (!columnSetting.config!.enableFilter) {
             return;
         }
 
@@ -217,7 +217,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
             );
     });
 
-    pluckedList = filter(pluckedList, (item, index) => filterMark[index]);
+    pluckedList = filter(pluckedList, (item, index) => (filterMark as any)[index]);
     return pluckedList;
   }
 
@@ -235,7 +235,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
     this.debounceHandler.next(this.sortedFilteredList);
   }
 
-  updateCheckAll(columnSetting: ListColumnSetting, event) {
+  updateCheckAll(columnSetting: ListColumnSetting, event: any) {
     if(event.target.checked){
       columnSetting.checkAll();
     }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -60,7 +60,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
   set list(data: any[] | DataModelCollectionBase<any>) {
     if (data instanceof DataModelCollectionBase){
       data.ensureInitialized().subscribe(() => {
-        this.iList = ([] as any[]).concat(data.collection);
+        this.iList = data.collection.slice();
         this.updateList();
       });
     }else{

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -235,8 +235,8 @@ export class DetailListComponent implements OnInit, OnDestroy {
     this.debounceHandler.next(this.sortedFilteredList);
   }
 
-  updateCheckAll(columnSetting: ListColumnSetting, event: any) {
-    if(event.target.checked){
+  updateCheckAll(columnSetting: ListColumnSetting, event: Event) {
+    if((event.target as HTMLInputElement).checked){
       columnSetting.checkAll();
     }
     else{

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-list/detail-list.component.ts
@@ -217,7 +217,7 @@ export class DetailListComponent implements OnInit, OnDestroy {
             );
     });
 
-    pluckedList = filter(pluckedList, (item, index) => (filterMark as any)[index]);
+    pluckedList = filter(pluckedList, (item, index) => filterMark[+index]);
     return pluckedList;
   }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/detail-table-resolver/detail-table-resolver.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/detail-table-resolver/detail-table-resolver.component.ts
@@ -12,14 +12,14 @@ import { ListColumnSetting } from 'src/app/Models/ListSettings';
     standalone: false
 })
 export class DetailTableResolverComponent implements OnInit {
-  @Input() cache: Record<string, any>;
+  @Input() cache!: Record<string, any>;
 
   @Input() item: any;
-  @Input() setting: ListColumnSetting;
-  @Input() template: Type<any>;
+  @Input() setting!: ListColumnSetting;
+  @Input() template!: Type<any>;
   @Input() itemValue: any;
 
-  @ViewChild(ResolverDirective, {static: true}) templateHost: ResolverDirective;
+  @ViewChild(ResolverDirective, {static: true}) templateHost!: ResolverDirective;
 
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -13,15 +13,15 @@ export class ExportModalComponent implements OnInit {
   dialogRef = inject<MatDialogRef<ExportModalComponent>>(MatDialogRef);
 
 
-  public text = [];
+  public text: (string | string[])[] = [];
   public copyText = '';
   public selected: Record<string, boolean> = {};
 
   ngOnInit(): void {
-    this.selected = this.data.config.columnSettings.reduce((previous, current) => { previous[current.displayName] = true; return previous; }, {});
+    this.selected = this.data.config.columnSettings.reduce((previous, current) => { (previous as any)[current.displayName] = true; return previous; }, {});
   }
 
-  updateCheckAll(event) {
+  updateCheckAll(event: any) {
     if (event.target.checked) {
       this.selectAll();
     } else {

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -21,8 +21,8 @@ export class ExportModalComponent implements OnInit {
     this.selected = this.data.config.columnSettings.reduce<Record<string, boolean>>((previous, current) => { previous[current.displayName] = true; return previous; }, {});
   }
 
-  updateCheckAll(event: any) {
-    if (event.target.checked) {
+  updateCheckAll(event: Event) {
+    if ((event.target as HTMLInputElement).checked) {
       this.selectAll();
     } else {
       this.unselectAll();

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/export-modal.component.ts
@@ -18,7 +18,7 @@ export class ExportModalComponent implements OnInit {
   public selected: Record<string, boolean> = {};
 
   ngOnInit(): void {
-    this.selected = this.data.config.columnSettings.reduce((previous, current) => { (previous as any)[current.displayName] = true; return previous; }, {});
+    this.selected = this.data.config.columnSettings.reduce<Record<string, boolean>>((previous, current) => { previous[current.displayName] = true; return previous; }, {});
   }
 
   updateCheckAll(event: any) {

--- a/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/export-modal/utils.ts
@@ -9,7 +9,7 @@ export interface IExportInfo {
 const delimiter = ',';
 
 export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>) => {
-    const selectedColumns = info.config.columnSettings.filter(column => selected[column.displayName] && !column.config.canNotExport);
+    const selectedColumns = info.config.columnSettings.filter(column => selected[column.displayName] && !column.config!.canNotExport);
 
     const header = selectedColumns.map(column => column.displayName);
 
@@ -17,8 +17,8 @@ export const exportInfo = (info: IExportInfo, selected: Record<string, boolean>)
         const row = selectedColumns.map(column => {
             let value = Utils.result(item, column.propertyPath);
 
-            if (column.config.alternateExportFormat !== undefined) {
-                value = column.config.alternateExportFormat(value);
+            if (column.config!.alternateExportFormat !== undefined) {
+                value = column.config!.alternateExportFormat(value);
             }
 
             return value;

--- a/src/SfxWeb/src/app/modules/detail-list-templates/full-description/full-description.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/full-description/full-description.component.ts
@@ -13,8 +13,8 @@ import { FabricEventBase } from 'src/app/Models/eventstore/Events';
 export class FullDescriptionComponent implements DetailBaseComponent, OnInit {
 
   copyText = '';
-  @Input() item: FabricEventBase;
-  listSetting: ListColumnSetting;
+  @Input() item!: FabricEventBase;
+  listSetting!: ListColumnSetting;
 
   color =  'white';
   constructor() { }

--- a/src/SfxWeb/src/app/modules/detail-list-templates/healthbadge/healthbadge.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/healthbadge/healthbadge.component.ts
@@ -13,9 +13,9 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 export class HealthbadgeComponent implements OnInit, DetailBaseComponent {
 
   item: any;
-  listSetting: ListColumnSettingForBadge;
+  listSetting!: ListColumnSettingForBadge;
 
-  value: ITextAndBadge;
+  value!: ITextAndBadge;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/hyper-link/hyper-link.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/hyper-link/hyper-link.component.ts
@@ -12,10 +12,10 @@ import { ListColumnSettingForLink } from 'src/app/Models/ListSettings';
 export class HyperLinkComponent implements OnInit, DetailBaseComponent {
 
   item: any;
-  listSetting: ListColumnSettingForLink;
+  listSetting!: ListColumnSettingForLink;
 
-  link: string;
-  value: string;
+  link!: string;
+  value!: string;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/question-tool-tip/question-tool-tip.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/question-tool-tip/question-tool-tip.component.ts
@@ -12,10 +12,10 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 })
 export class QuestionToolTipComponent implements  OnInit, DetailBaseComponent {
 
-  item: RepairTask;
-  listSetting: ListColumnSetting;
+  item!: RepairTask;
+  listSetting!: ListColumnSetting;
 
-  tooltipText: {tooltip: string, type: string};
+  tooltipText!: {tooltip: string, type: string};
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/shorten/shorten.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/shorten/shorten.component.ts
@@ -12,12 +12,12 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
 })
 export class ShortenComponent implements DetailBaseComponent, OnInit {
 
-  item: RepairTask;
-  listSetting: ListColumnSettingWithShorten;
-  value: string | any[];
+  item!: RepairTask;
+  listSetting!: ListColumnSettingWithShorten;
+  value!: string | any[];
   cache: any;
 
-  displayValue: string | any[];
+  displayValue!: string | any[];
   overflow = false;
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/shorten/shorten.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/shorten/shorten.component.ts
@@ -14,10 +14,10 @@ export class ShortenComponent implements DetailBaseComponent, OnInit {
 
   item!: RepairTask;
   listSetting!: ListColumnSettingWithShorten;
-  value!: string | any[];
+  value!: string | string[];
   cache: any;
 
-  displayValue!: string | any[];
+  displayValue!: string | string[];
   overflow = false;
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/detail-list-templates/utc-timestamp/utc-timestamp.component.ts
+++ b/src/SfxWeb/src/app/modules/detail-list-templates/utc-timestamp/utc-timestamp.component.ts
@@ -12,7 +12,7 @@ import { ListColumnSettingWithUtcTime } from 'src/app/Models/ListSettings';
 export class UtcTimestampComponent implements DetailBaseComponent, OnInit {
 
   item: any;
-  listSetting: ListColumnSettingWithUtcTime;
+  listSetting!: ListColumnSettingWithUtcTime;
   value: any;
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/event-store/event-store.component.ts
@@ -31,7 +31,7 @@ export interface IEventStoreData<IVisPresentEvent, S> {
   listSettings?: ListSettings;
   getEvents?(): S[];
   setDateWindow?(startDate: Date, endDate: Date): boolean;
-  objectResolver?(id: string): IDataModel<any>; //used to determine if the data contains a given event;
+  objectResolver?(id: string): IDataModel<any> | undefined; //used to determine if the data contains a given event;
 }
 
 export interface VisReference {
@@ -50,9 +50,9 @@ export class EventStoreComponent implements OnChanges, AfterViewInit {
   dataService = inject(DataService);
 
 
-  @ViewChildren(VisualizationDirective) vizDirs: QueryList<VisualizationDirective>;
-  @Input() listEventStoreData: IEventStoreData<any, any>[];
-  @Input() optionsConfig: IOptionConfig;
+  @ViewChildren(VisualizationDirective) vizDirs!: QueryList<VisualizationDirective>;
+  @Input() listEventStoreData!: IEventStoreData<any, any>[];
+  @Input() optionsConfig!: IOptionConfig;
   @Input() vizRefs: VisReference[] =
     [
       { name: "Timeline", component: TimelineComponent },
@@ -60,11 +60,11 @@ export class EventStoreComponent implements OnChanges, AfterViewInit {
     ];
 
   public failedRefresh = false;
-  public activeTab: string;
+  public activeTab!: string;
 
-  public startDate: Date;
-  public endDate: Date;
-  public dateMin: Date;
+  public startDate!: Date;
+  public endDate!: Date;
+  public dateMin!: Date;
 
   private visualizations: VisualizationComponent[] = [];
   private visualizationsReady = false;
@@ -120,21 +120,21 @@ export class EventStoreComponent implements OnChanges, AfterViewInit {
 
   public setSearch(id: string) {
     this.listEventStoreData.forEach((list, i) => {
-      if (list.objectResolver(id)) {
+      if (list.objectResolver!(id)) {
         this.activeTab = list.displayName
         setTimeout(() =>
-          list.listSettings.search = id, 1)
+          list.listSettings!.search = id, 1)
       }
     })
   }
 
   private updateColumn(update: EventColumnUpdate) {
 
-    const listSettings = this.listEventStoreData.find(list => list.displayName === update.listName).listSettings;
-    let columnSettings = listSettings.columnSettings;
+    const listSettings = this.listEventStoreData.find(list => list.displayName === update.listName)!.listSettings;
+    let columnSettings = listSettings!.columnSettings;
 
     if (update.isSecondRow) {
-      columnSettings = listSettings.secondRowColumnSettings;
+      columnSettings = listSettings!.secondRowColumnSettings;
     }
 
     const index = columnSettings.findIndex(setting => setting.id === update.columnSetting.id);

--- a/src/SfxWeb/src/app/modules/event-store/option-picker/option-picker.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/option-picker/option-picker.component.ts
@@ -27,8 +27,8 @@ export class OptionPickerComponent implements OnChanges {
   dataService = inject(DataService);
   settings = inject(SettingsService);
 
-  @Input() optionsConfig: IOptionConfig;
-  @Input() listEventStoreData: IEventStoreData<any, any>[];
+  @Input() optionsConfig!: IOptionConfig;
+  @Input() listEventStoreData!: IEventStoreData<any, any>[];
   @Output() selectedOption = new EventEmitter<IOptionData>();
   checkedStates: Record<string, boolean> = {};
   options: IEventStoreData<any, any>[] = [];

--- a/src/SfxWeb/src/app/modules/event-store/rca-visualization/rca-visualization.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/rca-visualization/rca-visualization.component.ts
@@ -18,17 +18,17 @@ export class RcaVisualizationComponent implements VisualizationComponent {
   changeDetector = inject(ChangeDetectorRef);
 
 
-  @Input() listEventStoreData: IEventStoreData<any, any>[];
+  @Input() listEventStoreData!: IEventStoreData<any, any>[];
   @Output() updateColumn = new EventEmitter<EventColumnUpdate>();
 
   public simulEvents: Record<string, IConcurrentEvents> = {};
   public simulEventsList: IConcurrentEvents[] = [];
 
   private getConcurrentEventsData() {
-    let sourceEvents = [];
+    let sourceEvents: any[] = [];
     for (const data of this.listEventStoreData) {
       if (data.eventsList.lastRefreshWasSuccessful) {
-        sourceEvents = sourceEvents.concat(data.getEvents());
+        sourceEvents = sourceEvents.concat(data.getEvents!());
       }
     }
 

--- a/src/SfxWeb/src/app/modules/event-store/rca-visualization/rca-visualization.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/rca-visualization/rca-visualization.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, Output, inject, ChangeDetectionStrategy } from '@angular/core';
-import { getSimultaneousEventsForEvent, IConcurrentEvents } from 'src/app/Models/eventstore/rcaEngine';
+import { getSimultaneousEventsForEvent, IConcurrentEvents, IRCAItem } from 'src/app/Models/eventstore/rcaEngine';
 import { RelatedEventsConfigs } from 'src/app/Models/eventstore/RelatedEventsConfigs';
 import { ListColumnSettingWithEmbeddedVis } from 'src/app/Models/ListSettings';
 import { VisualizationLogoComponent } from '../../concurrent-events-visualization/visualization-logo/visualization-logo.component';
@@ -25,7 +25,7 @@ export class RcaVisualizationComponent implements VisualizationComponent {
   public simulEventsList: IConcurrentEvents[] = [];
 
   private getConcurrentEventsData() {
-    let sourceEvents: any[] = [];
+    let sourceEvents: IRCAItem[] = [];
     for (const data of this.listEventStoreData) {
       if (data.eventsList.lastRefreshWasSuccessful) {
         sourceEvents = sourceEvents.concat(data.getEvents!());

--- a/src/SfxWeb/src/app/modules/event-store/row-display/row-display.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/row-display/row-display.component.ts
@@ -14,7 +14,7 @@ import { Utils } from 'src/app/Utils/Utils';
 export class RowDisplayComponent implements OnInit, DetailBaseComponent {
 
   item: any; // FabricEventInstanceModel
-  listSetting: ListColumnSetting;
+  listSetting!: ListColumnSetting;
 
   color =  'white';
   value = '';

--- a/src/SfxWeb/src/app/modules/event-store/timeline/timeline.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/timeline/timeline.component.ts
@@ -24,7 +24,7 @@ export class TimelineComponent implements VisualizationComponent {
   private timelineGeneratorFactoryService = inject(TimelineGeneratorFactoryService);
 
 
-  @Input() listEventStoreData: IEventStoreData<any, any>[];
+  @Input() listEventStoreData!: IEventStoreData<any, any>[];
   @Input() startDate: Date = new Date();
   @Input() endDate: Date = new Date();
   @Output() selectEvent = new EventEmitter<string>();
@@ -36,7 +36,7 @@ export class TimelineComponent implements VisualizationComponent {
     this.getTimelineData();
   }
 
-  public timeLineEventsData: ITimelineData;
+  public timeLineEventsData!: ITimelineData;
   public showCorrelatedBtn = false;
   public transformText = 'Category,Kind';
 
@@ -48,8 +48,8 @@ export class TimelineComponent implements VisualizationComponent {
 
   public setSearch(search?: string) {
     if (search) {
-      const item = this.timeLineEventsData.items.get(search);
-      const id = (item.id as string).split('---')[1];
+      const item = this.timeLineEventsData.items!.get(search);
+      const id = (item!.id as string).split('---')[1];
       this.selectEvent.emit(id);
     }
   }
@@ -64,7 +64,7 @@ export class TimelineComponent implements VisualizationComponent {
   }
 
   public getTimelineData() {
-    let rawEventlist = [];
+    let rawEventlist: any[] = [];
     let combinedTimelineData = this.initializeTimelineData();
     const addNestedGroups = this.listEventStoreData.length > 1;
 
@@ -78,13 +78,13 @@ export class TimelineComponent implements VisualizationComponent {
         try {
           if (!this.pshowCorrelatedEvents) {
             if (data.setDateWindow) {
-              rawEventlist = rawEventlist.concat(data.getEvents());
+              rawEventlist = rawEventlist.concat(data.getEvents!());
             }
 
           } else if (data.type) {
             // If we have more than one element in the timeline the events get grouped by the displayName of the element.
             const timelineGenerator = this.timelineGeneratorFactoryService.getTimelineGenerator(data.type);
-            const timelineData = timelineGenerator.generateTimeLineData(data.getEvents(), this.startDate, this.endDate, addNestedGroups ? data.displayName : null);
+            const timelineData = timelineGenerator.generateTimeLineData(data.getEvents!(), this.startDate, this.endDate, addNestedGroups ? data.displayName : null!);
 
             mergeTimelineData(combinedTimelineData, timelineData);
           }

--- a/src/SfxWeb/src/app/modules/event-store/timeline/timeline.component.ts
+++ b/src/SfxWeb/src/app/modules/event-store/timeline/timeline.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, In
 import { TelemetryEventNames } from 'src/app/Common/Constants';
 import { mergeTimelineData } from 'src/app/Models/eventstore/periodicEventParser';
 import { ITimelineData, ITimelineItem, parseEventsGenerically } from 'src/app/Models/eventstore/timelineGenerators';
+import { FabricEvent } from 'src/app/Models/eventstore/Events';
 import { DataService } from 'src/app/services/data.service';
 import { TelemetryService } from 'src/app/services/telemetry.service';
 import { TimelineGeneratorFactoryService } from 'src/app/services/timeline-generator-factory.service';
@@ -64,7 +65,7 @@ export class TimelineComponent implements VisualizationComponent {
   }
 
   public getTimelineData() {
-    let rawEventlist: any[] = [];
+    let rawEventlist: FabricEvent[] = [];
     let combinedTimelineData = this.initializeTimelineData();
     const addNestedGroups = this.listEventStoreData.length > 1;
 

--- a/src/SfxWeb/src/app/modules/event-store/visualization.directive.ts
+++ b/src/SfxWeb/src/app/modules/event-store/visualization.directive.ts
@@ -8,6 +8,6 @@ export class VisualizationDirective {
   viewContainerRef = inject(ViewContainerRef);
 
 
-  public name: string;
+  public name!: string;
 
 }

--- a/src/SfxWeb/src/app/modules/event-store/visualizationComponents.ts
+++ b/src/SfxWeb/src/app/modules/event-store/visualizationComponents.ts
@@ -15,7 +15,7 @@ export interface VisUpdateData {
     endDate: Date;
 }
 export interface VisualizationComponent {
-    update(data: VisUpdateData);
+    update(data: VisUpdateData): void;
     selectEvent?: EventEmitter<any>;
     updateColumn?: EventEmitter<EventColumnUpdate>;
 }

--- a/src/SfxWeb/src/app/modules/health-state/health-viewer/health-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/health-state/health-viewer/health-viewer.component.ts
@@ -15,11 +15,11 @@ export class HealthViewerComponent implements OnInit {
   private settings = inject(SettingsService);
 
 
-  @Input() unhealthyEvaluations: IRawUnhealthyEvaluation[];
-  @Input() healthyEvaluations: HealthEvaluation[];
+  @Input() unhealthyEvaluations!: IRawUnhealthyEvaluation[];
+  @Input() healthyEvaluations!: HealthEvaluation[];
 
-  unhealthyEvaluationsListSettings: ListSettings;
-  healthEventsListSettings: ListSettings;
+  unhealthyEvaluationsListSettings!: ListSettings;
+  healthEventsListSettings!: ListSettings;
 
   ngOnInit(): void {
     this.unhealthyEvaluationsListSettings = this.settings.getNewOrExistingUnhealthyEvaluationsListSettings();

--- a/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-name-column/display-name-column.component.ts
@@ -12,8 +12,8 @@ import { ImageStoreItem, ImageStore } from 'src/app/Models/DataModels/ImageStore
 })
 export class DisplayNameColumnComponent implements DetailBaseComponent {
 
-  item: ImageStoreItem;
-  listSetting: ListColumnSettingWithDisplayName;
+  item!: ImageStoreItem;
+  listSetting!: ListColumnSettingWithDisplayName;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
@@ -13,11 +13,11 @@ import { Utils } from 'src/app/Utils/Utils';
 })
 export class DisplaySizeColumnComponent implements OnChanges, OnInit, DetailBaseComponent {
 
-  item: ImageStoreItem;
-  listSetting: ListColumnSettingWithDisplaySize;
+  item!: ImageStoreItem;
+  listSetting!: ListColumnSettingWithDisplaySize;
 
   date: any;
-  loadButton: boolean;
+  loadButton!: boolean;
   size = '';
   loading = false;
   constructor() { }
@@ -55,8 +55,8 @@ export class DisplaySizeColumnComponent implements OnChanges, OnInit, DetailBase
                                                                                       date: new Date() };
         item.size = +size.FolderSize;
         item.displayedSize = Utils.getFriendlyFileSize(+size.FolderSize);
-        this.listSetting.imagestore.currentFolder.childrenFolders.find(folder => folder.path === item.path).size = +size.FolderSize;
-        this.listSetting.imagestore.allChildren = [].concat(this.listSetting.imagestore.allChildren);
+        this.listSetting.imagestore.currentFolder.childrenFolders.find(folder => folder.path === item.path)!.size = +size.FolderSize;
+        this.listSetting.imagestore.allChildren = ([] as ImageStoreItem[]).concat(this.listSetting.imagestore.allChildren);
         this.ngOnChanges();
       }, () => {
         this.listSetting.imagestore.cachedCurrentDirectoryFolderSizes[item.path].loading = false;

--- a/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/display-size-column/display-size-column.component.ts
@@ -56,7 +56,7 @@ export class DisplaySizeColumnComponent implements OnChanges, OnInit, DetailBase
         item.size = +size.FolderSize;
         item.displayedSize = Utils.getFriendlyFileSize(+size.FolderSize);
         this.listSetting.imagestore.currentFolder.childrenFolders.find(folder => folder.path === item.path)!.size = +size.FolderSize;
-        this.listSetting.imagestore.allChildren = ([] as ImageStoreItem[]).concat(this.listSetting.imagestore.allChildren);
+        this.listSetting.imagestore.allChildren = [...this.listSetting.imagestore.allChildren];
         this.ngOnChanges();
       }, () => {
         this.listSetting.imagestore.cachedCurrentDirectoryFolderSizes[item.path].loading = false;

--- a/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/folder-actions/folder-actions.component.ts
@@ -17,8 +17,8 @@ export class FolderActionsComponent  implements DetailBaseComponent {
 
 
 
-  item: ImageStoreItem;
-  listSetting: ListColumnSettingWithImageStoreActions;
+  item!: ImageStoreItem;
+  listSetting!: ListColumnSettingWithImageStoreActions;
 
   deleteItem() {
     new ActionWithConfirmationDialog(

--- a/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
+++ b/src/SfxWeb/src/app/modules/imagestore/imagestore-viewer/imagestore-viewer.component.ts
@@ -17,9 +17,9 @@ export class ImagestoreViewerComponent implements OnInit {
   private settings = inject(SettingsService);
 
 
-  @Input() imagestoreRoot: ImageStore;
+  @Input() imagestoreRoot!: ImageStore;
 
-  fileListSettings: ListSettings;
+  fileListSettings!: ListSettings;
 
   ngOnInit() {
     this.setup();

--- a/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-docs/infrastructure-docs.component.ts
+++ b/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-docs/infrastructure-docs.component.ts
@@ -10,7 +10,7 @@ import { InfrastructureDocumentCollection } from 'src/app/Models/DataModels/coll
     standalone: false
 })
 export class InfrastructureDocsComponent  {
-  @Input() infrastructureDocumentCollection: InfrastructureDocumentCollection;
+  @Input() infrastructureDocumentCollection!: InfrastructureDocumentCollection;
   selectedInfrastructureService: any = "None" ;
 
   JsonParsedDocument(doc: InfrastructureDoc): any {

--- a/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-job-tile/infrastructure-job-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-job-tile/infrastructure-job-tile.component.ts
@@ -19,16 +19,16 @@ export class InfrastructureJobTileComponent implements OnChanges, OnInit {
   dataService = inject(DataService);
 
 
-  @Input() job: InfrastructureJob;
+  @Input() job!: InfrastructureJob;
 
   essentialItems: IEssentialListItem[] = [];
   public progress: IProgressStatus[] = [];
   public index = -1;
-  impactingNodes: ListSettings;
+  impactingNodes!: ListSettings;
 
-  repairJobs: ListSettings;
-  repairTask: RepairTask[];
-  completed: RepairTask[];
+  repairJobs!: ListSettings;
+  repairTask!: RepairTask[];
+  completed!: RepairTask[];
   allCollapsed: boolean = true;
 
   ngOnInit()  {
@@ -67,7 +67,7 @@ export class InfrastructureJobTileComponent implements OnChanges, OnInit {
       Completed: 3
     };
 
-    this.index = phaseMap[this.job.raw.JobStatus];
+    this.index = (phaseMap as any)[this.job.raw.JobStatus];
 
     this.progress = [
       {

--- a/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-job-tile/infrastructure-job-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-job-tile/infrastructure-job-tile.component.ts
@@ -67,7 +67,7 @@ export class InfrastructureJobTileComponent implements OnChanges, OnInit {
       Completed: 3
     };
 
-    this.index = (phaseMap as any)[this.job.raw.JobStatus];
+    this.index = phaseMap[this.job.raw.JobStatus as keyof typeof phaseMap];
 
     this.progress = [
       {

--- a/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-overview/infrastructure-overview.component.ts
+++ b/src/SfxWeb/src/app/modules/infrastructure-job/infrastructure-overview/infrastructure-overview.component.ts
@@ -15,12 +15,12 @@ import { InfrastructureCollectionItem } from 'src/app/Models/DataModels/collecti
 export class InfrastructureOverviewComponent implements OnInit {
   private settings = inject(SettingsService);
 
-  @Input() collection: InfrastructureCollectionItem;
-  @Input() jobs: InfrastructureJob[];
-  @Input() repairCollection: RepairTaskCollection;
+  @Input() collection!: InfrastructureCollectionItem;
+  @Input() jobs!: InfrastructureJob[];
+  @Input() repairCollection!: RepairTaskCollection;
 
-  allPendingMRJobsList: ListSettings;
-  completedMRJobsList: ListSettings;
+  allPendingMRJobsList!: ListSettings;
+  completedMRJobsList!: ListSettings;
 
   ngOnInit(): void {
     this.allPendingMRJobsList = this.settings.getNewOrExistingInfrastructureSettings();

--- a/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
+++ b/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
@@ -20,14 +20,14 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
   public readonly seedNodeQuorumMessage = "This node deactivation is waiting on a Seed Node Quorom safety check. If this deactivation is going for an irregular amount of time, consider referring to the following TSG to potentially continue progress for this deactivation."
 
   @Input() hasDescription: boolean = false;
-  @Input() deactivationInfo: IRawNodeDeactivationInfo;
+  @Input() deactivationInfo!: IRawNodeDeactivationInfo;
 
   public progress: IProgressStatus[] = [];
   public index = -1;
 
   showSeedNodeTSG = false;
 
-  settings: ListSettings;
+  settings!: ListSettings;
 
   ngOnInit(): void {
 
@@ -52,7 +52,7 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
       Completed: 3
     };
 
-   this.index = phaseMap[this.deactivationInfo.NodeDeactivationStatus] + 1;
+   this.index = (phaseMap as any)[this.deactivationInfo.NodeDeactivationStatus] + 1;
 
    this.progress = [
       {

--- a/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
+++ b/src/SfxWeb/src/app/modules/node-deactivation/node-deactivation-info/node-deactivation-info.component.ts
@@ -52,7 +52,7 @@ export class NodeDeactivationInfoComponent implements OnInit, OnChanges {
       Completed: 3
     };
 
-   this.index = (phaseMap as any)[this.deactivationInfo.NodeDeactivationStatus] + 1;
+   this.index = phaseMap[this.deactivationInfo.NodeDeactivationStatus as keyof typeof phaseMap] + 1;
 
    this.progress = [
       {

--- a/src/SfxWeb/src/app/modules/partition-replication/replica-status-container/replica-status-container.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replica-status-container/replica-status-container.component.ts
@@ -10,7 +10,7 @@ export interface ITimedReplication extends IRawRemoteReplicatorStatus {
 }
 
 
-const reduceReplicators = (data, replica) => {
+const reduceReplicators = (data: any, replica: any) => {
   data[replica.ReplicaId] = replica;
   return data;
 };
@@ -24,14 +24,14 @@ const reduceReplicators = (data, replica) => {
 })
 export class ReplicaStatusContainerComponent implements OnChanges, OnDestroy {
 
-  @Input() replicas: ReplicaOnPartition[];
-  sortedReplicas = [];
+  @Input() replicas!: ReplicaOnPartition[];
+  sortedReplicas: ReplicaOnPartition[] = [];
 
   replicaDict = {};
   expandedDict = {};
   cachedData: Record<string, ITimedReplication[]> = {};
 
-  primaryReplica: ReplicaOnPartition;
+  primaryReplica!: ReplicaOnPartition;
 
   overviewItems: IEssentialListItem[] = [];
   replicationStatus: IEssentialListItem[] = [];
@@ -42,7 +42,7 @@ export class ReplicaStatusContainerComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(): void {
     // grab the primary on each reset
-    this.replicas.forEach(replica => {
+    this.replicas.forEach((replica: any) => {
       if (replica.raw.ReplicaRole === 'Primary') {
         this.primaryReplica = replica;
       }
@@ -116,7 +116,7 @@ export class ReplicaStatusContainerComponent implements OnChanges, OnDestroy {
     this.sub.unsubscribe();
   }
 
-  trackByFn(index, replicaStatus: IRawRemoteReplicatorStatus) {
+  trackByFn(index: any, replicaStatus: IRawRemoteReplicatorStatus) {
     return replicaStatus.ReplicaId + index;
   }
 }

--- a/src/SfxWeb/src/app/modules/partition-replication/replica-status-container/replica-status-container.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replica-status-container/replica-status-container.component.ts
@@ -10,7 +10,7 @@ export interface ITimedReplication extends IRawRemoteReplicatorStatus {
 }
 
 
-const reduceReplicators = (data: any, replica: any) => {
+const reduceReplicators = (data: Record<string, IRawRemoteReplicatorStatus>, replica: IRawRemoteReplicatorStatus) => {
   data[replica.ReplicaId] = replica;
   return data;
 };
@@ -42,7 +42,7 @@ export class ReplicaStatusContainerComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(): void {
     // grab the primary on each reset
-    this.replicas.forEach((replica: any) => {
+    this.replicas.forEach(replica => {
       if (replica.raw.ReplicaRole === 'Primary') {
         this.primaryReplica = replica;
       }
@@ -116,7 +116,7 @@ export class ReplicaStatusContainerComponent implements OnChanges, OnDestroy {
     this.sub.unsubscribe();
   }
 
-  trackByFn(index: any, replicaStatus: IRawRemoteReplicatorStatus) {
+  trackByFn(index: number, replicaStatus: IRawRemoteReplicatorStatus) {
     return replicaStatus.ReplicaId + index;
   }
 }

--- a/src/SfxWeb/src/app/modules/partition-replication/replica-status/replica-status.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replica-status/replica-status.component.ts
@@ -11,7 +11,7 @@ import { IEssentialListItem } from '../../charts/essential-health-tile/essential
 })
 export class ReplicaStatusComponent implements OnChanges {
 
-  @Input() replicator: IRawRemoteReplicatorStatus;
+  @Input() replicator!: IRawRemoteReplicatorStatus;
   copyItems: IEssentialListItem[] = [];
   replicationItems: IEssentialListItem[] = [];
   lastItems: IEssentialListItem[] = [];

--- a/src/SfxWeb/src/app/modules/partition-replication/replica-tile/replica-tile.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replica-tile/replica-tile.component.ts
@@ -14,15 +14,15 @@ import { IChartData } from '../replication-trend-line/replication-trend-line.com
     standalone: false
 })
 export class ReplicaTileComponent implements OnChanges {
-  @Input() replica: ReplicaOnPartition;
-  @Input() replicator: IRawRemoteReplicatorStatus;
-  @Input() replicatorHistory: ITimedReplication[];
+  @Input() replica!: ReplicaOnPartition;
+  @Input() replicator!: IRawRemoteReplicatorStatus;
+  @Input() replicatorHistory!: ITimedReplication[];
 
   @Input() showReplication = false;
   @Output() showReplicationChange = new EventEmitter<boolean>();
 
   overviewItems: IEssentialListItem[] = [];
-  status: IEssentialListItem;
+  status!: IEssentialListItem;
 
   leftBannerColor = '';
   fullScreen = false;

--- a/src/SfxWeb/src/app/modules/partition-replication/replication-trend-line/replication-trend-line.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replication-trend-line/replication-trend-line.component.ts
@@ -19,13 +19,13 @@ export interface IChartData {
 })
 export class ReplicationTrendLineComponent implements AfterViewInit, OnChanges, OnInit, OnDestroy {
 
-  @Input() data: ITimedReplication[];
-  @Input() fullScreen: boolean;
+  @Input() data!: ITimedReplication[];
+  @Input() fullScreen!: boolean;
   @Input() showUTC = false;
 
-  @ViewChild('chart') private chartContainer: ElementRef;
+  @ViewChild('chart') private chartContainer!: ElementRef;
 
-  private chart: Chart;
+  private chart!: Chart;
 
   fontColor = {
     color: '#fff'
@@ -49,7 +49,7 @@ export class ReplicationTrendLineComponent implements AfterViewInit, OnChanges, 
   ngAfterViewInit(): void {
     const options: Options = {
       chart: {
-        backgroundColor: null,
+        backgroundColor: null as any,
         type: 'area',
       },
       title: {

--- a/src/SfxWeb/src/app/modules/partition-replication/replication-trend-line/replication-trend-line.component.ts
+++ b/src/SfxWeb/src/app/modules/partition-replication/replication-trend-line/replication-trend-line.component.ts
@@ -49,7 +49,7 @@ export class ReplicationTrendLineComponent implements AfterViewInit, OnChanges, 
   ngAfterViewInit(): void {
     const options: Options = {
       chart: {
-        backgroundColor: null as any,
+        backgroundColor: 'transparent',
         type: 'area',
       },
       title: {

--- a/src/SfxWeb/src/app/modules/powershell-commands/command-input/command-input.component.ts
+++ b/src/SfxWeb/src/app/modules/powershell-commands/command-input/command-input.component.ts
@@ -12,8 +12,8 @@ import { PowershellCommandParameter, CommandParamTypes } from 'src/app/Models/Po
 })
 export class CommandInputComponent implements OnInit{
 
-  @Input() commandParam: PowershellCommandParameter;
-  @Input() inputGroup: UntypedFormGroup;
+  @Input() commandParam!: PowershellCommandParameter;
+  @Input() inputGroup!: UntypedFormGroup;
 
   value: UntypedFormControl = new UntypedFormControl('');
 

--- a/src/SfxWeb/src/app/modules/powershell-commands/command/command.component.ts
+++ b/src/SfxWeb/src/app/modules/powershell-commands/command/command.component.ts
@@ -14,15 +14,15 @@ export class CommandComponent implements OnInit{
   private cdr = inject(ChangeDetectorRef);
 
 
-  @Input() command: PowershellCommand;
+  @Input() command!: PowershellCommand;
   safetyLevelEnum = CommandSafetyLevel;
   BadgeConstants = BadgeConstants;
   
   inputForm: UntypedFormGroup = new UntypedFormGroup({ requiredInputs: new UntypedFormGroup({}), optionalInputs: new UntypedFormGroup({}) });
-  invalidInputs: string;
+  invalidInputs!: string;
   
-  requiredParams: PowershellCommandParameter[];
-  optionalParams: PowershellCommandParameter[];
+  requiredParams!: PowershellCommandParameter[];
+  optionalParams!: PowershellCommandParameter[];
   ngOnInit() {
  
     this.requiredParams = this.command.parameters.filter(p => p.required);

--- a/src/SfxWeb/src/app/modules/powershell-commands/powershell-commands/powershell-commands.component.ts
+++ b/src/SfxWeb/src/app/modules/powershell-commands/powershell-commands/powershell-commands.component.ts
@@ -29,8 +29,8 @@ export class PowershellCommandsComponent implements IModalData, OnChanges{
   activeId:any = 1;
   safetyLevelEnum = CommandSafetyLevel;
   
-  @Input() commands: PowershellCommand[];
-  @ViewChild('nav') nav: NgbNav;
+  @Input() commands!: PowershellCommand[];
+  @ViewChild('nav') nav!: NgbNav;
   
   safeCommands: PowershellCommand[] = [];
   unsafeCommands: PowershellCommand[] = [];

--- a/src/SfxWeb/src/app/modules/repair-tasks/repair-job-chart/repair-job-chart.component.ts
+++ b/src/SfxWeb/src/app/modules/repair-tasks/repair-job-chart/repair-job-chart.component.ts
@@ -17,14 +17,14 @@ export class RepairJobChartComponent implements OnInit, OnChanges {
   private sanitizer = inject(DomSanitizer);
 
 
-  @Input() jobs: RepairTask[];
-  @Input() sortOrder: ISortOrdering;
+  @Input() jobs!: RepairTask[];
+  @Input() sortOrder!: ISortOrdering;
 
   fontColor = {
     color: '#fff'
   };
 
-  private chart: Chart;
+  private chart!: Chart;
 
   ngOnInit(): void {
     const options: Options = {
@@ -75,7 +75,7 @@ export class RepairJobChartComponent implements OnInit, OnChanges {
         style: this.fontColor,
         formatter: (() => {
           const bind = this; return function () {
-            return bind.sanitizer.sanitize(SecurityContext.HTML, TimeUtils.getDuration(this.value));
+            return bind.sanitizer.sanitize(SecurityContext.HTML, TimeUtils.getDuration(this.value))!;
           }
         })()
       },

--- a/src/SfxWeb/src/app/modules/repair-tasks/repair-task-view/repair-task-view.component.ts
+++ b/src/SfxWeb/src/app/modules/repair-tasks/repair-task-view/repair-task-view.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@
 import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.component';
 import { ListColumnSetting } from 'src/app/Models/ListSettings';
 import { RepairTask } from 'src/app/Models/DataModels/repairTask';
+import { Node } from 'src/app/Models/DataModels/Node';
 import { DataService } from 'src/app/services/data.service';
 import { forkJoin, of, Subscription } from 'rxjs';
 import { RefreshService } from 'src/app/services/refresh.service';
@@ -21,10 +22,10 @@ export class RepairTaskViewComponent implements OnInit, DetailBaseComponent, OnD
   private refreshService = inject(RefreshService);
 
   phaseTooLongDuration = 1000 * 60 * 20;
-  listSetting: ListColumnSetting;
-  item: RepairTask;
+  listSetting!: ListColumnSetting;
+  item!: RepairTask;
   copyText = '';
-  nodes = [];
+  nodes: Node[] = [];
   subs: Subscription = new Subscription();
 
   healthCheckConfigs: IEssentialListItem[] = [];
@@ -72,7 +73,7 @@ export class RepairTaskViewComponent implements OnInit, DetailBaseComponent, OnD
     return forkJoin(nodeIds.map(id => {
       return this.dataService.getNode(id, true).pipe(catchError(err => of(null)));
     })).pipe(map(data => {
-      this.nodes = data.filter(node => node);
+      this.nodes = data.filter(node => node) as Node[];
     }));
   }
 }

--- a/src/SfxWeb/src/app/modules/repair-tasks/repair-task-view/repair-task-view.component.ts
+++ b/src/SfxWeb/src/app/modules/repair-tasks/repair-task-view/repair-task-view.component.ts
@@ -73,7 +73,7 @@ export class RepairTaskViewComponent implements OnInit, DetailBaseComponent, OnD
     return forkJoin(nodeIds.map(id => {
       return this.dataService.getNode(id, true).pipe(catchError(err => of(null)));
     })).pipe(map(data => {
-      this.nodes = data.filter(node => node) as Node[];
+      this.nodes = data.filter((node): node is Node => !!node);
     }));
   }
 }

--- a/src/SfxWeb/src/app/modules/time-picker/double-slider/double-slider.component.ts
+++ b/src/SfxWeb/src/app/modules/time-picker/double-slider/double-slider.component.ts
@@ -17,13 +17,13 @@ export class DoubleSliderComponent implements OnChanges, AfterViewInit {
 
   @Input() startDate: any;
   @Input() endDate: any;
-  @Input() minDate: Date;
+  @Input() minDate!: Date;
 
   @Output() dateChanged = new EventEmitter<IOnDateChange>();
 
-  slider: API;
+  slider!: API;
 
-  @ViewChild('slider') container: ElementRef;
+  @ViewChild('slider') container!: ElementRef;
 
 
   constructor() { }

--- a/src/SfxWeb/src/app/modules/time-picker/full-time-picker/full-time-picker.component.ts
+++ b/src/SfxWeb/src/app/modules/time-picker/full-time-picker/full-time-picker.component.ts
@@ -18,10 +18,10 @@ export interface IQuickDates {
 })
 export class FullTimePickerComponent implements OnInit, OnDestroy {
 
-  @Input() startDate: Date;
-  @Input() endDate: Date;
-  @Input() startDateMin: Date;
-  @Input() startDateMax: Date;
+  @Input() startDate!: Date;
+  @Input() endDate!: Date;
+  @Input() startDateMin!: Date;
+  @Input() startDateMax!: Date;
 
   @Output() datesChanged = new EventEmitter<IOnDateChange>();
 
@@ -34,7 +34,7 @@ export class FullTimePickerComponent implements OnInit, OnDestroy {
   ];
 
   private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
-  private debouncerHandlerSubscription: Subscription;
+  private debouncerHandlerSubscription!: Subscription;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/modules/time-picker/time-picker/time-picker.component.ts
+++ b/src/SfxWeb/src/app/modules/time-picker/time-picker/time-picker.component.ts
@@ -18,11 +18,11 @@ export interface IQuickDates {
 })
 export class TimePickerComponent implements OnInit, OnDestroy {
 
-  @Input() dateMin: Date;
-  @Input() dateMax: Date;
+  @Input() dateMin!: Date;
+  @Input() dateMax!: Date;
 
-  @Input() startDate: Date;
-  @Input() endDate: Date;
+  @Input() startDate!: Date;
+  @Input() endDate!: Date;
 
   @Output() dateChange = new EventEmitter<IOnDateChange>(); 
     
@@ -35,7 +35,7 @@ export class TimePickerComponent implements OnInit, OnDestroy {
   ];
 
   private debounceHandler: Subject<IOnDateChange> = new Subject<IOnDateChange>();
-  private debouncerHandlerSubscription: Subscription;
+  private debouncerHandlerSubscription!: Subscription;
 
   
   constructor() { }

--- a/src/SfxWeb/src/app/modules/tree/selected-node.directive.ts
+++ b/src/SfxWeb/src/app/modules/tree/selected-node.directive.ts
@@ -12,8 +12,8 @@ export class SeletedNodeDirective implements OnChanges {
   private focusService = inject(FocusService);
 
 
-  @Input() selected: boolean;
-  @Input() focused: boolean;
+  @Input() selected!: boolean;
+  @Input() focused!: boolean;
 
   ngOnChanges() {
     if (this.selected) {

--- a/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-node/tree-node.component.ts
@@ -13,7 +13,7 @@ import { environment } from 'src/environments/environment';
 export class TreeNodeComponent {
   treeService = inject(TreeService);
 
-  @Input() node: TreeNodeGroupViewModel;
+  @Input() node!: TreeNodeGroupViewModel;
   @Output() focusEmitter = new EventEmitter<boolean>();
 
   paginationId = PaginationId;

--- a/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
+++ b/src/SfxWeb/src/app/modules/tree/tree-view/tree-view.component.ts
@@ -26,8 +26,8 @@ export class TreeViewComponent implements DoCheck, AfterViewInit {
 
   public canExpand = false;
   public focused = false;
-  @ViewChild('treeContainer') treeContainer: ElementRef;
-  @ViewChild('tree') tree: ElementRef;
+  @ViewChild('treeContainer') treeContainer!: ElementRef;
+  @ViewChild('tree') tree!: ElementRef;
   
   focusSubject = new Subject<boolean>();
               

--- a/src/SfxWeb/src/app/modules/upgrade-progress/health-policy-check/health-policy-check.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/health-policy-check/health-policy-check.component.ts
@@ -13,20 +13,20 @@ import { IEssentialListItem } from '../../charts/essential-health-tile/essential
 })
 export class HealthPolicyCheckComponent implements OnChanges {
 
-  @Input() healthCheckPhase: string;
-  @Input() healthCheckPhaseDuration: string;
+  @Input() healthCheckPhase!: string;
+  @Input() healthCheckPhaseDuration!: string;
   @Input() healthCheckRetryFlips: number = 0;
-  @Input() monitoringPolicy: IRawMonitoringPolicy;
+  @Input() monitoringPolicy!: IRawMonitoringPolicy;
 
 
   healthPolicyProgress: IProgressStatus[] = []
 
   healthCheckPhaseText: string = "";
-  healthCheckTimeLeft: IEssentialListItem;
+  healthCheckTimeLeft!: IEssentialListItem;
 
   //duration graph
-  healthCheckDurationLeft: number;
-  HealthCheckDurationOverall: number;
+  healthCheckDurationLeft!: number;
+  HealthCheckDurationOverall!: number;
   displayTopText: string = "";
   displayBottomText: string = "";
   color: string = "";

--- a/src/SfxWeb/src/app/modules/upgrade-progress/load-cell/load-cell.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/load-cell/load-cell.component.ts
@@ -14,8 +14,8 @@ export class LoadCellComponent {
   cacheService = inject(PartitionCacheService);
 
 
-  item: IPartitionData;
-  listSetting: ListColumnSetting;
+  item!: IPartitionData;
+  listSetting!: ListColumnSetting;
 
   load() {
     this.cacheService.getPartitionInfo(this.item.SafetyCheck.PartitionId, this.item);

--- a/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
@@ -16,7 +16,7 @@ import { IProgressStatus } from 'src/app/shared/component/phase-diagram/phase-di
 })
 export class NodeProgressComponent implements OnChanges {
   @Input() failed = false;
-  @Input() node: IRawNodeUpgradeProgress;
+  @Input() node!: IRawNodeUpgradeProgress;
 
   public progress: IProgressStatus[] = [];
   public index = -1;
@@ -30,7 +30,7 @@ export class NodeProgressComponent implements OnChanges {
       PostUpgradeSafetyCheck: 3
     };
 
-    this.index = phaseMap[this.node.UpgradePhase];
+    this.index = (phaseMap as any)[this.node.UpgradePhase];
 
     // given the upgrading and post upgrade safety check phases refer to completed state
     // set the index 1 further to consider them completed effectively

--- a/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/node-progress/node-progress.component.ts
@@ -30,7 +30,7 @@ export class NodeProgressComponent implements OnChanges {
       PostUpgradeSafetyCheck: 3
     };
 
-    this.index = (phaseMap as any)[this.node.UpgradePhase];
+    this.index = phaseMap[this.node.UpgradePhase as keyof typeof phaseMap];
 
     // given the upgrading and post upgrade safety check phases refer to completed state
     // set the index 1 further to consider them completed effectively

--- a/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.ts
@@ -19,9 +19,9 @@ export class SafetyChecksComponent implements OnChanges, OnInit, OnDestroy {
   settingsService = inject(SettingsService);
 
 
-  @Input() safetyChecks: IRawSafetyCheckDescription[];
+  @Input() safetyChecks!: IRawSafetyCheckDescription[];
 
-  settings: ListSettings;
+  settings!: ListSettings;
   safetyChecksWithData: IRawSafetyCheckDescription[] = [];
   tooManySafetyChecks = false;
 
@@ -71,7 +71,7 @@ export class SafetyChecksComponent implements OnChanges, OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  safetyCheck(index, safetyCheck: IRawSafetyCheckDescription) {
+  safetyCheck(index: any, safetyCheck: IRawSafetyCheckDescription) {
     return safetyCheck.SafetyCheck.PartitionId || safetyCheck.SafetyCheck.Kind;
   }
 

--- a/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/safety-checks/safety-checks.component.ts
@@ -71,7 +71,7 @@ export class SafetyChecksComponent implements OnChanges, OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  safetyCheck(index: any, safetyCheck: IRawSafetyCheckDescription) {
+  safetyCheck(index: number, safetyCheck: IRawSafetyCheckDescription) {
     return safetyCheck.SafetyCheck.PartitionId || safetyCheck.SafetyCheck.Kind;
   }
 

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
@@ -13,11 +13,11 @@ export class UpgradeDomainProgressComponent{
 
   partitions: Record<string, IPartitionData> = {};
   @Input() failed = false;
-  @Input() upgradeDomain: IRawUpgradeDomainProgress | ICurrentUpgradeUnitsProgressInfo;
+  @Input() upgradeDomain!: IRawUpgradeDomainProgress | ICurrentUpgradeUnitsProgressInfo;
 
   constructor() { }
 
-  nodeTrackBy(index, node: IRawNodeUpgradeProgress) {
+  nodeTrackBy(index: any, node: IRawNodeUpgradeProgress) {
     return node.NodeName;
   }
 

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-domain-progress/upgrade-domain-progress.component.ts
@@ -17,7 +17,7 @@ export class UpgradeDomainProgressComponent{
 
   constructor() { }
 
-  nodeTrackBy(index: any, node: IRawNodeUpgradeProgress) {
+  nodeTrackBy(index: number, node: IRawNodeUpgradeProgress) {
     return node.NodeName;
   }
 

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
@@ -18,9 +18,9 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
   private settings = inject(SettingsService);
 
 
-  @Input() upgradeProgress: ClusterUpgradeProgress | ApplicationUpgradeProgress;
+  @Input() upgradeProgress!: ClusterUpgradeProgress | ApplicationUpgradeProgress;
 
-  upgradeProgressUnhealthyEvaluationsListSettings: ListSettings;
+  upgradeProgressUnhealthyEvaluationsListSettings!: ListSettings;
 
   essentialItems: IEssentialListItem[] = [];
   essentialItems2: IEssentialListItem[] = [];
@@ -29,14 +29,14 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
 
   healthPolicy: IEssentialListItem[] = [];
 
-  startTimeEssentialItem: IEssentialListItem;
+  startTimeEssentialItem!: IEssentialListItem;
 
   helpText = '';
   link = 'https://docs.microsoft.com/azure/service-fabric/service-fabric-application-upgrade#rolling-upgrades-overview';
 
   // When an upgrade is not in progress dont show a progress bar.
   // this is to avoid confusion
-  upgradeDuration: IEssentialListItem;
+  upgradeDuration!: IEssentialListItem;
 
   failed: boolean = false;
   manual: boolean = false;
@@ -54,9 +54,9 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
 
       this.failedUpgradeItems = [
         { descriptionName: 'Failure Reason', copyTextValue: raw.FailureReason, displayText: raw.FailureReason },
-         raw.FailureClassification ? { descriptionName: 'Failure Classification', copyTextValue: raw.FailureClassification, displayText: raw.FailureClassification } : null,
+         raw.FailureClassification ? { descriptionName: 'Failure Classification', copyTextValue: raw.FailureClassification, displayText: raw.FailureClassification } : null!,
         { descriptionName: 'Failure Timestamp', copyTextValue: raw.FailureTimestampUtc, displayText: raw.FailureTimestampUtc },
-        domainName ? { descriptionName: 'Failure Domain', copyTextValue: domainName, displayText: domainName } : null,
+        domainName ? { descriptionName: 'Failure Domain', copyTextValue: domainName, displayText: domainName } : null!,
       ].filter(Boolean);
     }
     const monitoringPolicy = this.upgradeProgress.raw?.UpgradeDescription?.MonitoringPolicy;
@@ -86,7 +86,7 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
     }
 
 
-    let entitySpecificInformation = [];
+    let entitySpecificInformation: any[] = [];
     if (this.upgradeProgress instanceof ClusterUpgradeProgress) {
       entitySpecificInformation = [
         {

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-info/upgrade-info.component.ts
@@ -86,7 +86,7 @@ export class UpgradeInfoComponent implements OnChanges, OnInit {
     }
 
 
-    let entitySpecificInformation: any[] = [];
+    let entitySpecificInformation: IEssentialListItem[] = [];
     if (this.upgradeProgress instanceof ClusterUpgradeProgress) {
       entitySpecificInformation = [
         {

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
@@ -21,12 +21,12 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
   private sanitizer = inject(DomSanitizer);
 
 
-  @Input() upgradeDomains: UpgradeDomain[];
+  @Input() upgradeDomains!: UpgradeDomain[];
   @Input() showChart = false;
 
-  @ViewChild('chart') private chartContainer: ElementRef;
+  @ViewChild('chart') private chartContainer!: ElementRef;
 
-  chart: Chart;
+  chart!: Chart;
 
   tiles: ITileCount[] = [];
   displayUd: UpgradeDomain[] = [];
@@ -39,7 +39,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
             type: 'pie',
             width: 350,
             height: 300,
-            backgroundColor: null,
+            backgroundColor: null as any,
             borderRadius: 0
         },
         title: {
@@ -116,7 +116,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
           type: 'pie',
           name: stateName + ' : ' + entry.value,
           y: entry.value,
-          color: colors[badgeClass],
+          color: (colors as any)[badgeClass],
           dataLabels: {
             style: {
               fontSize: '13px',
@@ -131,7 +131,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
           type: 'pie',
           name: p.prefix + p.name,
           y: 1,
-          color: colors[p.badgeClass],
+          color: (colors as any)[p.badgeClass],
           dataLabels: {
             style: {
                 fontSize: '13px',

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
@@ -116,7 +116,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
           type: 'pie',
           name: stateName + ' : ' + entry.value,
           y: entry.value,
-          color: (colors as any)[badgeClass],
+          color: colors[badgeClass as keyof typeof colors],
           dataLabels: {
             style: {
               fontSize: '13px',
@@ -131,7 +131,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
           type: 'pie',
           name: p.prefix + p.name,
           y: 1,
-          color: (colors as any)[p.badgeClass],
+          color: colors[p.badgeClass as keyof typeof colors],
           dataLabels: {
             style: {
                 fontSize: '13px',

--- a/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
+++ b/src/SfxWeb/src/app/modules/upgrade-progress/upgrade-progress/upgrade-progress.component.ts
@@ -39,7 +39,7 @@ export class UpgradeProgressComponent implements AfterViewInit, OnChanges {
             type: 'pie',
             width: 350,
             height: 300,
-            backgroundColor: null as any,
+            backgroundColor: 'transparent',
             borderRadius: 0
         },
         title: {

--- a/src/SfxWeb/src/app/services/adal.service.ts
+++ b/src/SfxWeb/src/app/services/adal.service.ts
@@ -39,8 +39,7 @@ export class AdalService {
 
           return this.context;
         }
-        return this.context;
-      }));
+      })) as Observable<AuthenticationContext>;
     }
   }
 

--- a/src/SfxWeb/src/app/services/adal.service.ts
+++ b/src/SfxWeb/src/app/services/adal.service.ts
@@ -12,8 +12,8 @@ import { StringUtils } from '../Utils/StringUtils';
 export class AdalService {
   private http = inject(RestClientService);
 
-  private context: AuthenticationContext;
-  public config: AadMetadata;
+  private context!: AuthenticationContext;
+  public config!: AadMetadata;
   public aadEnabled = false;
 
   load(): Observable<AuthenticationContext> {
@@ -39,6 +39,7 @@ export class AdalService {
 
           return this.context;
         }
+        return this.context;
       }));
     }
   }
@@ -76,12 +77,12 @@ export class AdalService {
 
   public getAccessToken(endpoint: string, callbacks: (message: string, token: string) => any) {
 
-      return this.context.acquireToken(endpoint, callbacks);
+      return this.context.acquireToken(endpoint, callbacks as any);
   }
 
   public acquireTokenResilient(resource: string): Observable<any> {
     return new Observable<any>((subscriber: Subscriber<any>) => {
-      this.context.acquireToken(resource, (message: string, token: string) => {
+      this.context.acquireToken(resource, (message: string | null, token: string | null) => {
         if (token) {
           subscriber.next(token);
         } else {

--- a/src/SfxWeb/src/app/services/adal.service.ts
+++ b/src/SfxWeb/src/app/services/adal.service.ts
@@ -74,9 +74,9 @@ export class AdalService {
       return this.context.getLoginError();
   }
 
-  public getAccessToken(endpoint: string, callbacks: (message: string, token: string) => any) {
+  public getAccessToken(endpoint: string, callbacks: (message: string | null, token: string | null) => any) {
 
-      return this.context.acquireToken(endpoint, callbacks as any);
+      return this.context.acquireToken(endpoint, callbacks);
   }
 
   public acquireTokenResilient(resource: string): Observable<any> {

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -65,14 +65,14 @@ export class DataService {
   public appTypeGroups: ApplicationTypeGroupCollection;
   public apps: ApplicationCollection;
   public nodes: NodeCollection;
-  public imageStore: ImageStore;
+  public imageStore!: ImageStore;
   public backupPolicies: BackupPolicyCollection;
   public repairCollection: RepairTaskCollection;
   public infrastructureCollection: InfrastructureCollection;
   public infrastructureDocCollection: InfrastructureDocumentCollection;
 
-  public readOnlyHeader: boolean =  null;
-  public clusterNameMetadata: string = null;
+  public readOnlyHeader: boolean | null =  null;
+  public clusterNameMetadata: string | null = null;
 
   constructor() {
     const standalone = this.standalone;
@@ -385,7 +385,7 @@ export class DataService {
         const list = new ApplicationEventList(this, applicationId);
         const d: IEventStoreData<ApplicationEventList, ApplicationEvent> = {
             eventsList : list,
-            type : applicationId ? "Application" : null,
+            type : applicationId ? "Application" : undefined,
             displayName : applicationId ? applicationId : 'Apps',
         };
 
@@ -395,9 +395,9 @@ export class DataService {
 
     public getServiceEventData(serviceId?: string): IEventStoreData<ServiceEventList, ServiceEvent> {
         const list = new ServiceEventList(this, serviceId);
-        const d = {
+        const d: IEventStoreData<ServiceEventList, ServiceEvent> = {
             eventsList : list,
-            displayName : serviceId
+            displayName : serviceId ?? ''
         };
 
         this.addFabricEventData<ServiceEventList, ServiceEvent>(d);
@@ -409,7 +409,7 @@ export class DataService {
         const d: IEventStoreData<PartitionEventList, PartitionEvent> = {
             eventsList : list,
             type : "Partition",
-            displayName : partitionId
+            displayName : partitionId ?? ''
         };
 
         this.addFabricEventData<PartitionEventList, PartitionEvent>(d);

--- a/src/SfxWeb/src/app/services/data.service.ts
+++ b/src/SfxWeb/src/app/services/data.service.ts
@@ -385,7 +385,7 @@ export class DataService {
         const list = new ApplicationEventList(this, applicationId);
         const d: IEventStoreData<ApplicationEventList, ApplicationEvent> = {
             eventsList : list,
-            type : applicationId ? "Application" : undefined,
+            type : applicationId ? "Application" : null!,
             displayName : applicationId ? applicationId : 'Apps',
         };
 
@@ -397,7 +397,7 @@ export class DataService {
         const list = new ServiceEventList(this, serviceId);
         const d: IEventStoreData<ServiceEventList, ServiceEvent> = {
             eventsList : list,
-            displayName : serviceId ?? ''
+            displayName : serviceId!
         };
 
         this.addFabricEventData<ServiceEventList, ServiceEvent>(d);
@@ -409,7 +409,7 @@ export class DataService {
         const d: IEventStoreData<PartitionEventList, PartitionEvent> = {
             eventsList : list,
             type : "Partition",
-            displayName : partitionId ?? ''
+            displayName : partitionId!
         };
 
         this.addFabricEventData<PartitionEventList, PartitionEvent>(d);

--- a/src/SfxWeb/src/app/services/focus.service.ts
+++ b/src/SfxWeb/src/app/services/focus.service.ts
@@ -7,7 +7,7 @@ import { Subject } from 'rxjs';
 export class FocusService{
 
   focusObservable : Subject<ElementRef<any>> = new Subject<ElementRef<any>>();  
-  focusElement : ElementRef<any>;  
+  focusElement !: ElementRef<any>;  
 
   constructor() {
     this.focusObservable.subscribe((element) => {

--- a/src/SfxWeb/src/app/services/message.service.ts
+++ b/src/SfxWeb/src/app/services/message.service.ts
@@ -36,11 +36,11 @@ export class MessageService {
 
   getClass(severity: MessageSeverity): string {
     const colors = {};
-    colors[MessageSeverity.Info] = 'bg-info';
-    colors[MessageSeverity.Warn] = 'bg-warning';
-    colors[MessageSeverity.Err] = 'bg-danger';
+    (colors as any)[MessageSeverity.Info] = 'bg-info';
+    (colors as any)[MessageSeverity.Warn] = 'bg-warning';
+    (colors as any)[MessageSeverity.Err] = 'bg-danger';
 
-    return colors[severity];
+    return (colors as any)[severity];
   }
 
   public get suppressMessage() {
@@ -64,13 +64,13 @@ export class MessageService {
   }
 
   public getSuccessMessage(apiDesc: string, response: HttpResponse<any>): string {
-    return null;
+    return null!;
   }
 
   public getErrorMessage(apiDesc: string, response: HttpErrorResponse): string {
       if (response.status === 404) {
           // By default exclude 404 error for all get requests
-          return null;
+          return null!;
       }
       return this.getErrorMessageInternal(apiDesc, response);
   }

--- a/src/SfxWeb/src/app/services/message.service.ts
+++ b/src/SfxWeb/src/app/services/message.service.ts
@@ -35,12 +35,13 @@ export class MessageService {
   }
 
   getClass(severity: MessageSeverity): string {
-    const colors = {};
-    (colors as any)[MessageSeverity.Info] = 'bg-info';
-    (colors as any)[MessageSeverity.Warn] = 'bg-warning';
-    (colors as any)[MessageSeverity.Err] = 'bg-danger';
+    const colors: Record<MessageSeverity, string> = {
+      [MessageSeverity.Info]: 'bg-info',
+      [MessageSeverity.Warn]: 'bg-warning',
+      [MessageSeverity.Err]: 'bg-danger'
+    };
 
-    return (colors as any)[severity];
+    return colors[severity];
   }
 
   public get suppressMessage() {

--- a/src/SfxWeb/src/app/services/refresh.service.ts
+++ b/src/SfxWeb/src/app/services/refresh.service.ts
@@ -11,9 +11,9 @@ export class RefreshService {
 
   public isRefreshing = false;
   public refreshRate = '';
-  private autoRefreshInterval: Observable<any> = null;
+  private autoRefreshInterval: Observable<any> | null = null;
   public refreshSubject: Subject<number> = new Subject();
-  private currentSync: Subscription;
+  private currentSync!: Subscription;
   private previousRefreshSetting = 0;
   public refreshTick = 0;
 

--- a/src/SfxWeb/src/app/services/rest-client.service.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.ts
@@ -385,12 +385,12 @@ export class RestClientService {
       url =  url + `?ExcludeApplicationParameters=true`;
     }
 
-    return this.getFullCollection<IRawApplication>(url, 'Get applications', undefined, messageHandler);
+    return this.getFullCollection<IRawApplication>(url, 'Get applications', null!, messageHandler);
   }
 
   public getServices(applicationId: string, messageHandler?: IResponseMessageHandler): Observable<IRawService[]> {
       const url = 'Applications/' + encodeURIComponent(applicationId) + '/$/GetServices';
-      return this.getFullCollection<IRawService>(url, 'Get services', undefined, messageHandler);
+    return this.getFullCollection<IRawService>(url, 'Get services', null!, messageHandler);
   }
 
   public getService(applicationId: string, serviceId: string, messageHandler?: IResponseMessageHandler): Observable<IRawService> {
@@ -600,7 +600,7 @@ export class RestClientService {
           + '/$/GetServices/' + encodeURIComponent(serviceId)
           + '/$/GetPartitions';
 
-      return this.getFullCollection<IRawPartition>(url, 'Get partitions', undefined, messageHandler);
+    return this.getFullCollection<IRawPartition>(url, 'Get partitions', null!, messageHandler);
   }
 
   public getPartition(applicationId: string, serviceId: string, partitionId: string, messageHandler?: IResponseMessageHandler): Observable<IRawPartition> {
@@ -655,7 +655,7 @@ export class RestClientService {
           + '/$/GetPartitions/' + encodeURIComponent(partitionId)
           + '/$/GetReplicas';
 
-      return this.getFullCollection<IRawReplicaOnPartition>(url, 'Get replicas on partition', undefined, messageHandler);
+    return this.getFullCollection<IRawReplicaOnPartition>(url, 'Get replicas on partition', null!, messageHandler);
   }
 
   public getReplicaOnPartition(applicationId: string, serviceId: string, partitionId: string, replicaId: string, messageHandler?: IResponseMessageHandler): Observable<IRawReplicaOnPartition> {
@@ -818,8 +818,8 @@ export class RestClientService {
       }
 
 
-      const fullUrl = this.getApiUrl(url + '?' + params.toString(), apiVersion, undefined, true);
-      return this.get<IRawList<{}>>(fullUrl, '', messageHandler).pipe(map(response => {
+    const fullUrl = this.getApiUrl(url + '?' + params.toString(), apiVersion, null!, true);
+    return this.get<IRawList<{}>>(fullUrl, null!, messageHandler).pipe(map(response => {
           return new EventsResponseAdapter(eventType).getEvents(response);
         }));
   }

--- a/src/SfxWeb/src/app/services/rest-client.service.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.ts
@@ -352,7 +352,7 @@ export class RestClientService {
       return this.get(this.getApiUrl(url), 'Get application manifest for application type');
   }
 
-  public provisionApplication(name: string, appTypeName: string, appTypeVersion, messageHandler?: IResponseMessageHandler): Observable<any> {
+  public provisionApplication(name: string, appTypeName: string, appTypeVersion: any, messageHandler?: IResponseMessageHandler): Observable<any> {
       const url = 'Applications/$/Create';
 
       const body: any = {
@@ -385,12 +385,12 @@ export class RestClientService {
       url =  url + `?ExcludeApplicationParameters=true`;
     }
 
-    return this.getFullCollection<IRawApplication>(url, 'Get applications', null, messageHandler);
+    return this.getFullCollection<IRawApplication>(url, 'Get applications', undefined, messageHandler);
   }
 
   public getServices(applicationId: string, messageHandler?: IResponseMessageHandler): Observable<IRawService[]> {
       const url = 'Applications/' + encodeURIComponent(applicationId) + '/$/GetServices';
-      return this.getFullCollection<IRawService>(url, 'Get services', null, messageHandler);
+      return this.getFullCollection<IRawService>(url, 'Get services', undefined, messageHandler);
   }
 
   public getService(applicationId: string, serviceId: string, messageHandler?: IResponseMessageHandler): Observable<IRawService> {
@@ -504,7 +504,7 @@ export class RestClientService {
       return this.post(this.getApiUrl(url, RestClientService.apiVersion64), 'Partition Backup trigger', { BackupStorage: storage }, messageHandler);
   }
 
-  public restorePartitionBackup(partitionId: string, storage: IRawStorage, timeOut: number, backupId: string, backupLocation: string, messageHandler?: IResponseMessageHandler): Observable<{}> {
+  public restorePartitionBackup(partitionId: string, storage: IRawStorage | null, timeOut: number | null, backupId: string, backupLocation: string, messageHandler?: IResponseMessageHandler): Observable<{}> {
       let url = 'Partitions/' + encodeURIComponent(partitionId) + '/$/Restore';
       if (timeOut) {
           url += '?RestoreTimeout=' + timeOut.toString();
@@ -600,7 +600,7 @@ export class RestClientService {
           + '/$/GetServices/' + encodeURIComponent(serviceId)
           + '/$/GetPartitions';
 
-      return this.getFullCollection<IRawPartition>(url, 'Get partitions', null, messageHandler);
+      return this.getFullCollection<IRawPartition>(url, 'Get partitions', undefined, messageHandler);
   }
 
   public getPartition(applicationId: string, serviceId: string, partitionId: string, messageHandler?: IResponseMessageHandler): Observable<IRawPartition> {
@@ -655,7 +655,7 @@ export class RestClientService {
           + '/$/GetPartitions/' + encodeURIComponent(partitionId)
           + '/$/GetReplicas';
 
-      return this.getFullCollection<IRawReplicaOnPartition>(url, 'Get replicas on partition', null, messageHandler);
+      return this.getFullCollection<IRawReplicaOnPartition>(url, 'Get replicas on partition', undefined, messageHandler);
   }
 
   public getReplicaOnPartition(applicationId: string, serviceId: string, partitionId: string, replicaId: string, messageHandler?: IResponseMessageHandler): Observable<IRawReplicaOnPartition> {
@@ -802,10 +802,10 @@ export class RestClientService {
     return this.get(this.getApiUrl(url, RestClientService.apiVersion114), 'Get Failover Manager Manager (FMM) information', messageHandler);
   }
 
-  private getEvents<T extends FabricEventBase>(eventType: new () => T, url: string, startTime: Date, endTime: Date, eventsTypesFilter: string[], messageHandler?: IResponseMessageHandler, apiVersion?: string): Observable<T[]> {
+  private getEvents<T extends FabricEventBase>(eventType: new () => T, url: string, startTime: Date | null, endTime: Date | null, eventsTypesFilter: string[], messageHandler?: IResponseMessageHandler, apiVersion?: string): Observable<T[]> {
       const paramObject = {
-        'starttimeutc': startTime.toISOString().substring(0, 19) + 'Z',
-        'endtimeutc': endTime.toISOString().substr(0, 19) + 'Z',
+        'starttimeutc': startTime!.toISOString().substring(0, 19) + 'Z',
+        'endtimeutc': endTime!.toISOString().substr(0, 19) + 'Z',
         ...(eventsTypesFilter.length && { eventsTypesFilter: eventsTypesFilter.join() })
       }
 
@@ -818,8 +818,8 @@ export class RestClientService {
       }
 
 
-      const fullUrl = this.getApiUrl(url + '?' + params.toString(), apiVersion, null, true);
-      return this.get<IRawList<{}>>(fullUrl, null, messageHandler).pipe(map(response => {
+      const fullUrl = this.getApiUrl(url + '?' + params.toString(), apiVersion, undefined, true);
+      return this.get<IRawList<{}>>(fullUrl, '', messageHandler).pipe(map(response => {
           return new EventsResponseAdapter(eventType).getEvents(response);
         }));
   }
@@ -923,7 +923,7 @@ export class RestClientService {
     return resultPromise.pipe(catchError((err: HttpErrorResponse) => {
         const header = `${err.status.toString()} : ${apiDesc}`;
 
-        const message = messageHandler.getErrorMessage(apiDesc, err);
+        const message = messageHandler!.getErrorMessage(apiDesc, err);
         let displayMessage = '';
         if (message) {
             displayMessage = message;

--- a/src/SfxWeb/src/app/services/rest-client.service.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.ts
@@ -884,7 +884,7 @@ export class RestClientService {
       if (!messageHandler) {
           messageHandler = ResponseMessageHandlers.getResponseMessageHandler;
       }
-      return this.handleResponse<T>(apiDesc, result as any, messageHandler);
+      return this.handleResponse<T>(apiDesc, result, messageHandler);
   }
 
   private post<T>(url: string, apiDesc: string, data?: any, messageHandler?: IResponseMessageHandler): Observable<T> {
@@ -892,7 +892,7 @@ export class RestClientService {
       if (!messageHandler) {
           messageHandler = ResponseMessageHandlers.postResponseMessageHandler;
       }
-      return this.handleResponse<T>(apiDesc, result as any, messageHandler);
+      return this.handleResponse<T>(apiDesc, result, messageHandler);
   }
 
   private put<T>(url: string, apiDesc: string, data?: any, messageHandler?: IResponseMessageHandler): Observable<T> {
@@ -900,7 +900,7 @@ export class RestClientService {
       if (!messageHandler) {
           messageHandler = ResponseMessageHandlers.putResponseMessageHandler;
       }
-      return this.handleResponse<T>(apiDesc, result as any, messageHandler);
+      return this.handleResponse<T>(apiDesc, result, messageHandler);
   }
 
   private delete<T>(url: string, apiDesc: string, messageHandler?: IResponseMessageHandler): Observable<T> {
@@ -908,7 +908,7 @@ export class RestClientService {
       if (!messageHandler) {
           messageHandler = ResponseMessageHandlers.deleteResponseMessageHandler;
       }
-      return this.handleResponse<T>(apiDesc, result as any, messageHandler);
+      return this.handleResponse<T>(apiDesc, result, messageHandler);
   }
 
   private handleResponse<T>(apiDesc: string, resultPromise: Observable<any>, messageHandler?: IResponseMessageHandler): Observable<T> {

--- a/src/SfxWeb/src/app/services/rest-client.service.ts
+++ b/src/SfxWeb/src/app/services/rest-client.service.ts
@@ -352,7 +352,7 @@ export class RestClientService {
       return this.get(this.getApiUrl(url), 'Get application manifest for application type');
   }
 
-  public provisionApplication(name: string, appTypeName: string, appTypeVersion: any, messageHandler?: IResponseMessageHandler): Observable<any> {
+  public provisionApplication(name: string, appTypeName: string, appTypeVersion: string, messageHandler?: IResponseMessageHandler): Observable<any> {
       const url = 'Applications/$/Create';
 
       const body: any = {

--- a/src/SfxWeb/src/app/services/routes.service.ts
+++ b/src/SfxWeb/src/app/services/routes.service.ts
@@ -176,20 +176,19 @@ export class RoutesService {
     RoutesService.singleEncode = force;
   }
 
-   getPathData(snapshot: ActivatedRouteSnapshot): { params: {}, pathPostFix: string, lastPaths: Type<any>[] } {
+   getPathData(snapshot: ActivatedRouteSnapshot | null): { params: {}, pathPostFix: string, lastPaths: Type<any>[] } {
     const data = {
-        params: snapshot.params,
+        params: snapshot!.params,
         pathPostFix: '',
         lastPaths: [] as Type<any>[]
     };
 
-    let current: ActivatedRouteSnapshot | null = snapshot;
-    while (current !== null) {
-        data.pathPostFix = current.routeConfig!.path!;
-        if (current.component) {
-            data.lastPaths.push(current.component);
+    while (snapshot !== null) {
+        data.pathPostFix = snapshot.routeConfig!.path!;
+        if (snapshot.component) {
+            data.lastPaths.push(snapshot.component);
         }
-        current = current.firstChild;
+        snapshot = snapshot.firstChild;
     }
     return data;
    }

--- a/src/SfxWeb/src/app/services/routes.service.ts
+++ b/src/SfxWeb/src/app/services/routes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Component, inject } from '@angular/core';
+import { Injectable, Type, inject } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router, ActivationEnd, NavigationEnd, ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
 
@@ -30,7 +30,7 @@ export class RoutesService {
   constructor() {
 
     // there can be multiple activationEnd events so we want to grab the last one.
-    let lastActivationEnd: ActivationEnd = null;
+    let lastActivationEnd: ActivationEnd | null = null;
 
     this.routing.events.subscribe( event => {
         // given there are multiple activation events we want to get the last one because it will have the activation data for the last child route.
@@ -40,7 +40,7 @@ export class RoutesService {
 
         // this event signifies the end of finding the right route.
         if (event instanceof NavigationEnd){
-            const data = this.getPathData(lastActivationEnd.snapshot);
+            const data = this.getPathData(lastActivationEnd!.snapshot);
 
             // check first if same entity views by comparing first component
             // given all routes are lazy loaded we check if the child routing components are the same.
@@ -68,7 +68,7 @@ export class RoutesService {
   private static singleEncode = true;
 
 // keep track of previous states to know when we changed
-  private previouslastPaths = [];
+  private previouslastPaths: Type<any>[] = [];
   private previousParams = {};
   private previousPathPostFix = '';
 
@@ -176,19 +176,20 @@ export class RoutesService {
     RoutesService.singleEncode = force;
   }
 
-   getPathData(snapshot: ActivatedRouteSnapshot): { params: {}, pathPostFix: string, lastPaths: Component[] } {
+   getPathData(snapshot: ActivatedRouteSnapshot): { params: {}, pathPostFix: string, lastPaths: Type<any>[] } {
     const data = {
         params: snapshot.params,
         pathPostFix: '',
-        lastPaths: []
+        lastPaths: [] as Type<any>[]
     };
 
-    while (snapshot !== null) {
-        data.pathPostFix = snapshot.routeConfig.path;
-        if (snapshot.component) {
-            data.lastPaths.push(snapshot.component);
+    let current: ActivatedRouteSnapshot | null = snapshot;
+    while (current !== null) {
+        data.pathPostFix = current.routeConfig!.path!;
+        if (current.component) {
+            data.lastPaths.push(current.component);
         }
-        snapshot = snapshot.firstChild;
+        current = current.firstChild;
     }
     return data;
    }

--- a/src/SfxWeb/src/app/services/routes.service.ts
+++ b/src/SfxWeb/src/app/services/routes.service.ts
@@ -177,10 +177,10 @@ export class RoutesService {
   }
 
    getPathData(snapshot: ActivatedRouteSnapshot | null): { params: {}, pathPostFix: string, lastPaths: Type<any>[] } {
-    const data = {
+    const data: { params: {}, pathPostFix: string, lastPaths: Type<any>[] } = {
         params: snapshot!.params,
         pathPostFix: '',
-        lastPaths: [] as Type<any>[]
+        lastPaths: []
     };
 
     while (snapshot !== null) {

--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -72,7 +72,7 @@ export class SettingsService {
       // Use URL + listName as unique key to track list settings on detail pages
       const key: string = listName; // TODO fix this this.$location.path() + "/" + listName;
       if (!this.listSettings[key]) {
-          this.listSettings[key] = new ListSettings(this.paginationLimit, defaultSortProperties ?? [], listName, columnSettings, secondRowColumnSettings, secondRowCollapsible, showSecondRow, searchable);
+          this.listSettings[key] = new ListSettings(this.paginationLimit, defaultSortProperties!, listName, columnSettings, secondRowColumnSettings, secondRowCollapsible, showSecondRow, searchable);
       }
       return this.listSettings[key];
   }

--- a/src/SfxWeb/src/app/services/settings.service.ts
+++ b/src/SfxWeb/src/app/services/settings.service.ts
@@ -23,7 +23,7 @@ export class SettingsService {
 
   private listSettings: Record<string, ListSettings>;
   private iPaginationLimit: number;
-  private iMetricsViewModel: MetricsViewModel;
+  private iMetricsViewModel!: MetricsViewModel;
   private sessionVariables: { [key: string]: any } = {};
 
   public treeWidth: ReplaySubject<string> = new ReplaySubject(1);
@@ -62,17 +62,17 @@ export class SettingsService {
 
   public getNewOrExistingListSettings(
       listName: string,
-      defaultSortProperties: string[] = [],
+      defaultSortProperties: string[] | null = [],
       columnSettings: ListColumnSetting[] = [],
       secondRowColumnSettings: ListColumnSetting[] = [],
       secondRowCollapsible: boolean = false,
-      showSecondRow: (item) => boolean = (item) => true,
+      showSecondRow: (item: any) => boolean = (item: any) => true,
       searchable: boolean = true) {
 
       // Use URL + listName as unique key to track list settings on detail pages
       const key: string = listName; // TODO fix this this.$location.path() + "/" + listName;
       if (!this.listSettings[key]) {
-          this.listSettings[key] = new ListSettings(this.paginationLimit, defaultSortProperties, listName, columnSettings, secondRowColumnSettings, secondRowCollapsible, showSecondRow, searchable);
+          this.listSettings[key] = new ListSettings(this.paginationLimit, defaultSortProperties ?? [], listName, columnSettings, secondRowColumnSettings, secondRowCollapsible, showSecondRow, searchable);
       }
       return this.listSettings[key];
   }
@@ -91,7 +91,7 @@ export class SettingsService {
   public getNewOrExistingUnhealthyEvaluationsListSettings(listKey: string = 'unhealthy Evaluations') {
       return this.getNewOrExistingListSettings(listKey, null,
           [
-              new ListColumnSettingForLink('kind', 'Kind', (item) =>  item.viewPath),
+              new ListColumnSettingForLink('kind', 'Kind', (item: any) =>  item.viewPath),
               new ListColumnSettingForBadge('healthState', 'Health State'),
               new ListColumnSettingWithCopyText('description', 'Description'),
               new ListColumnSettingWithUtcTime('sourceTimeStamp', 'Source UTC'),
@@ -116,7 +116,7 @@ export class SettingsService {
               new ListColumnSettingWithCopyText('description', 'Description', {enableFilter: false, colspan: 7})
           ],
           false,
-          (item) => item.description.length > 0
+          (item: any) => item.description.length > 0
           );
   }
 
@@ -142,7 +142,7 @@ export class SettingsService {
             enableFilter: false,
             cssClasses: "link",
             colspan: 1,
-            clickEvent: item => item.action.run()
+            clickEvent: (item: any) => item.action.run()
           }),
           new ListColumnSetting('raw.Schedule.ScheduleKind', 'ScheduleKind'),
           new ListColumnSetting('raw.Storage.StorageKind', 'StorageKind'),
@@ -192,7 +192,7 @@ export class SettingsService {
         })
     ],
     true,
-    (item) => (Object.keys(item).length > 0),
+    (item: any) => (Object.keys(item).length > 0),
     true);
   }
 
@@ -219,7 +219,7 @@ export class SettingsService {
         })
     ],
     true,
-    (item) => true,
+    (item: any) => true,
     true);
   }
 
@@ -255,7 +255,7 @@ export class SettingsService {
 
     return this.getNewOrExistingListSettings(listKey, ['raw.Version'], settings, nestedList,
       false,
-      (item) => item.raw.StatusDetails,
+      (item: any) => item.raw.StatusDetails,
       false);
   }
 

--- a/src/SfxWeb/src/app/services/standalone-integration.service.ts
+++ b/src/SfxWeb/src/app/services/standalone-integration.service.ts
@@ -38,8 +38,8 @@ export class StandaloneIntegrationService {
 
   constructor() { }
 
-  public clusterUrl: string = null;
-  public integrationConfig: IntegrationConfig = null;
+  public clusterUrl: string = null!;
+  public integrationConfig: IntegrationConfig = null!;
 
   public setConfiguration(configuration: IntegrationConfig) {
     try {
@@ -49,7 +49,7 @@ export class StandaloneIntegrationService {
     }
 
     try {
-      this.clusterUrl = configuration.clusterInfo;
+      this.clusterUrl = configuration.clusterInfo!;
       console.log(this.clusterUrl)
     } catch {
       console.log("could not load any cluster url")

--- a/src/SfxWeb/src/app/services/storage.service.ts
+++ b/src/SfxWeb/src/app/services/storage.service.ts
@@ -9,18 +9,18 @@ export class StorageService {
   }
 
   public getValueNumber(key: string, defaultValue: number): number {
-      return this.getValueT<number>(key, (item) => Number(item), defaultValue);
+      return this.getValueT<number>(key, (item: any) => Number(item), defaultValue);
   }
 
   public getValueString(key: string, defaultValue: string): string {
-      return this.getValueT<string>(key, (item) => item, defaultValue);
+      return this.getValueT<string>(key, (item: any) => item, defaultValue);
   }
 
   public getValueBoolean(key: string, defaultValue: boolean): boolean {
-      return this.getValueT<boolean>(key, (item) => item === 'true', defaultValue);
+      return this.getValueT<boolean>(key, (item: any) => item === 'true', defaultValue);
   }
 
-  public getValueT<T>(key: string, convert: (item) => T, defaultValue: T): T {
+  public getValueT<T>(key: string, convert: (item: any) => T, defaultValue: T): T {
       const value = localStorage.getItem(key);
       if (value !== null) {
           return convert(value);

--- a/src/SfxWeb/src/app/services/storage.service.ts
+++ b/src/SfxWeb/src/app/services/storage.service.ts
@@ -9,18 +9,18 @@ export class StorageService {
   }
 
   public getValueNumber(key: string, defaultValue: number): number {
-      return this.getValueT<number>(key, (item: any) => Number(item), defaultValue);
+      return this.getValueT<number>(key, (item: string) => Number(item), defaultValue);
   }
 
   public getValueString(key: string, defaultValue: string): string {
-      return this.getValueT<string>(key, (item: any) => item, defaultValue);
+      return this.getValueT<string>(key, (item: string) => item, defaultValue);
   }
 
   public getValueBoolean(key: string, defaultValue: boolean): boolean {
-      return this.getValueT<boolean>(key, (item: any) => item === 'true', defaultValue);
+      return this.getValueT<boolean>(key, (item: string) => item === 'true', defaultValue);
   }
 
-  public getValueT<T>(key: string, convert: (item: any) => T, defaultValue: T): T {
+  public getValueT<T>(key: string, convert: (item: string) => T, defaultValue: T): T {
       const value = localStorage.getItem(key);
       if (value !== null) {
           return convert(value);

--- a/src/SfxWeb/src/app/services/telemetry.service.ts
+++ b/src/SfxWeb/src/app/services/telemetry.service.ts
@@ -34,7 +34,7 @@ export class TelemetryService {
     this.appInsights.context.application.ver = environment.version;
 
     // there can be multiple activationEnd events so we want to grab the last one.
-    let lastActivationEnd = null;
+    let lastActivationEnd: ActivationEnd | null = null;
     this.routing.events.subscribe(event => {
       if (event instanceof ActivationEnd) {
         lastActivationEnd = event;
@@ -43,7 +43,7 @@ export class TelemetryService {
         try {
           let name =  '';
           // build up the URL this way to avoid passing in PII about stuff running in the cluster
-          let snapshot = lastActivationEnd.snapshot;
+          let snapshot: any = lastActivationEnd!.snapshot;
           while (snapshot) {
             const path = snapshot.routeConfig.path;
             if (path.length > 0) {
@@ -76,7 +76,7 @@ export class TelemetryService {
     if (uniqueSessionId && this.uniqueEmitCache.has(uniqueSessionId)) {
       return;
     }else{
-      this.uniqueEmitCache.add(uniqueSessionId);
+      this.uniqueEmitCache.add(uniqueSessionId!);
     }
 
     this.appInsights.trackEvent({name}, data);

--- a/src/SfxWeb/src/app/services/telemetry.service.ts
+++ b/src/SfxWeb/src/app/services/telemetry.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import { StorageService } from './storage.service';
 import { environment } from 'src/environments/environment';
-import { Router, NavigationEnd, ActivationEnd } from '@angular/router';
+import { Router, NavigationEnd, ActivationEnd, ActivatedRouteSnapshot } from '@angular/router';
 import { StringUtils } from '../Utils/StringUtils';
 
 @Injectable({
@@ -43,11 +43,11 @@ export class TelemetryService {
         try {
           let name =  '';
           // build up the URL this way to avoid passing in PII about stuff running in the cluster
-          let snapshot: any = lastActivationEnd!.snapshot;
+          let snapshot: ActivatedRouteSnapshot | null = lastActivationEnd!.snapshot;
           while (snapshot) {
-            const path = snapshot.routeConfig.path;
-            if (path.length > 0) {
-              name +=  StringUtils.EnsureStartsWith(snapshot.routeConfig.path, '/');
+            const path = snapshot.routeConfig?.path;
+            if (path && path.length > 0) {
+              name +=  StringUtils.EnsureStartsWith(path, '/');
             }
             snapshot = snapshot.firstChild;
           }

--- a/src/SfxWeb/src/app/services/timeline-generator-factory.service.ts
+++ b/src/SfxWeb/src/app/services/timeline-generator-factory.service.ts
@@ -53,7 +53,7 @@ export class TimelineGeneratorFactoryService {
 
 
       default:
-        return null;
+        return null!;
     }
   }
 }

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -25,16 +25,16 @@ export class TreeService {
         private focusService = inject(FocusService);
 
 
-        public containerRef: ElementRef;
-        public tree: TreeViewModel;
-        private clusterHealth: ClusterHealth;
+        public containerRef!: ElementRef;
+        public tree!: TreeViewModel;
+        private clusterHealth!: ClusterHealth;
         // controller views can get instantiated before this service and so a request to set the tree location might
         // get requested before the init function is called 
         private selectTreeNodeCalled = false;
-        private cachedTreeSelection: {path: string[], skipSelectAction?: boolean};
+        private cachedTreeSelection!: {path: string[], skipSelectAction?: boolean};
 
-        public get cachedTreeNodeSelection(): string {
-            return this.cachedTreeSelection ? this.cachedTreeSelection.path.slice(-1).pop() : null;
+        public get cachedTreeNodeSelection(): string | null {
+            return this.cachedTreeSelection ? this.cachedTreeSelection.path.slice(-1).pop() ?? null : null;
         }
 
         // AuthenticationController will call this function to initialize the tree view once authentication is cleared
@@ -174,11 +174,7 @@ export class TreeService {
 
 
             return forkJoin([getAppsPromise, getNodesPromise, systemNodePromise]).pipe(map(resp => {
-                if (resp[2] === null) {
-                    resp.splice(2);
-                    return resp;
-                }
-                return resp;
+                return resp.filter(node => node !== null) as ITreeNode[];
             }));
         }
 
@@ -288,7 +284,7 @@ export class TreeService {
         }
 
         private getDeployedServiceChildrenGroupNodes(nodeName: string, applicationId: string, servicePackageName: string, servicePackageActivationId: string): Observable<ITreeNode[]> {
-            let codePkgNode;
+            let codePkgNode!: ITreeNode;
             // No health chunk data for deployed code packages, need to do force refresh to retrieve health data from server
             const getCodePkgsPromise = this.data.getDeployedCodePackages(nodeName, applicationId, servicePackageName, servicePackageActivationId, true).pipe(map(codePkgs => {
                 codePkgNode = {
@@ -299,7 +295,7 @@ export class TreeService {
                 };
             }));
 
-            let replicasNode;
+            let replicasNode!: ITreeNode;
             // No health chunk data for deployed replicas, need to do force refresh to retrieve health data from server
             const getReplicasPromise = this.data.getDeployedReplicas(nodeName, applicationId, servicePackageName, servicePackageActivationId, true).pipe(map(replicas => {
                 replicasNode = {

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -33,8 +33,8 @@ export class TreeService {
         private selectTreeNodeCalled = false;
         private cachedTreeSelection!: {path: string[], skipSelectAction?: boolean};
 
-        public get cachedTreeNodeSelection(): string | null {
-            return this.cachedTreeSelection ? this.cachedTreeSelection.path.slice(-1).pop() ?? null : null;
+        public get cachedTreeNodeSelection(): string | null | undefined {
+            return this.cachedTreeSelection ? this.cachedTreeSelection.path.slice(-1).pop() : null;
         }
 
         // AuthenticationController will call this function to initialize the tree view once authentication is cleared
@@ -174,7 +174,11 @@ export class TreeService {
 
 
             return forkJoin([getAppsPromise, getNodesPromise, systemNodePromise]).pipe(map(resp => {
-                return resp.filter(node => node !== null) as ITreeNode[];
+                if (resp[2] === null) {
+                    resp.splice(2);
+                    return resp as ITreeNode[];
+                }
+                return resp as ITreeNode[];
             }));
         }
 

--- a/src/SfxWeb/src/app/services/tree.service.ts
+++ b/src/SfxWeb/src/app/services/tree.service.ts
@@ -119,7 +119,7 @@ export class TreeService {
 
         private getGroupNodes(): Observable<ITreeNode[]> {
 
-            const getAppsPromise = this.data.getApps().pipe(map(apps => {
+            const getAppsPromise = this.data.getApps().pipe(map((apps): ITreeNode => {
               return {
                     nodeId: IdGenerator.appGroup(),
                     displayName: () => 'Applications',
@@ -131,7 +131,7 @@ export class TreeService {
                 };
             }));
 
-            const getNodesPromise = this.data.getNodes().pipe(map(nodes => {
+            const getNodesPromise = this.data.getNodes().pipe(map((nodes): ITreeNode => {
               return {
                     nodeId: IdGenerator.nodeGroup(),
                     displayName: () => 'Nodes',
@@ -147,7 +147,7 @@ export class TreeService {
                             catchError(err => {
                 return of(null);
             }),
-            map(systemApp => {
+            map((systemApp): ITreeNode | null => {
               if (systemApp) {
                 return {
                     nodeId: IdGenerator.systemAppGroup(),
@@ -174,11 +174,7 @@ export class TreeService {
 
 
             return forkJoin([getAppsPromise, getNodesPromise, systemNodePromise]).pipe(map(resp => {
-                if (resp[2] === null) {
-                    resp.splice(2);
-                    return resp as ITreeNode[];
-                }
-                return resp as ITreeNode[];
+                return resp.filter((node): node is ITreeNode => node !== null);
             }));
         }
 

--- a/src/SfxWeb/src/app/shared/component/action-collection-drop-down/action-collection-drop-down.component.ts
+++ b/src/SfxWeb/src/app/shared/component/action-collection-drop-down/action-collection-drop-down.component.ts
@@ -16,8 +16,8 @@ export class ActionCollectionDropDownComponent {
   private liveAnnouncer = inject(LiveAnnouncer);
 
   @Input() treeView = false;
-  @Input() actionCollection: ActionCollection;
-  @Input() displayText: string;
+  @Input() actionCollection!: ActionCollection;
+  @Input() displayText!: string;
   @Input() tabindex = 0;
   @Output() changedState = new EventEmitter();
   @Output() actionFocus = new EventEmitter();

--- a/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
+++ b/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
@@ -29,8 +29,8 @@ export class AdvancedOptionComponent implements OnInit {
   public showBeta = environment.showBeta;
 
   status = false;
-  @ViewChild(NgbDropdown, {static: true}) dropdown: NgbDropdown;
-  @ViewChildren(NgbTooltip) tooltips: QueryList<NgbTooltip>;
+  @ViewChild(NgbDropdown, {static: true}) dropdown!: NgbDropdown;
+  @ViewChildren(NgbTooltip) tooltips!: QueryList<NgbTooltip>;
 
   ngOnInit() {
     this.status = this.storage.getValueBoolean(Constants.AdvancedModeKey, false);
@@ -50,7 +50,7 @@ export class AdvancedOptionComponent implements OnInit {
   @HostListener("document:click", ["$event"])
   handleClickEvent(event: PointerEvent) {
     try {
-      if(this.dropdown.isOpen() && !event.target['closest']("#advanced-options-container")) {
+      if(this.dropdown.isOpen() && !(event.target! as any)['closest']("#advanced-options-container")) {
         this.dropdown.close();
       }
     } catch(e) {
@@ -71,12 +71,12 @@ export class AdvancedOptionComponent implements OnInit {
     }
   }
 
-  pageSize(size) {
+  pageSize(size: any) {
     this.settingsService.paginationLimit = size;
     this.telemetryService.trackActionEvent(TelemetryEventNames.listSize, {value: size.toString()});
   }
 
-  suppressMessages(state) {
+  suppressMessages(state: any) {
     this.messageService.suppressMessage = state;
     this.telemetryService.trackActionEvent(TelemetryEventNames.supressMessage, null, TelemetryEventNames.supressMessage);
   }

--- a/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
+++ b/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
@@ -71,12 +71,12 @@ export class AdvancedOptionComponent implements OnInit {
     }
   }
 
-  pageSize(size: any) {
+  pageSize(size: number) {
     this.settingsService.paginationLimit = size;
     this.telemetryService.trackActionEvent(TelemetryEventNames.listSize, {value: size.toString()});
   }
 
-  suppressMessages(state: any) {
+  suppressMessages(state: boolean) {
     this.messageService.suppressMessage = state;
     this.telemetryService.trackActionEvent(TelemetryEventNames.supressMessage, null, TelemetryEventNames.supressMessage);
   }

--- a/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
+++ b/src/SfxWeb/src/app/shared/component/advanced-option/advanced-option.component.ts
@@ -50,7 +50,7 @@ export class AdvancedOptionComponent implements OnInit {
   @HostListener("document:click", ["$event"])
   handleClickEvent(event: PointerEvent) {
     try {
-      if(this.dropdown.isOpen() && !(event.target! as any)['closest']("#advanced-options-container")) {
+      if(this.dropdown.isOpen() && !(event.target! as Element).closest("#advanced-options-container")) {
         this.dropdown.close();
       }
     } catch(e) {

--- a/src/SfxWeb/src/app/shared/component/arm-warning/arm-warning.component.ts
+++ b/src/SfxWeb/src/app/shared/component/arm-warning/arm-warning.component.ts
@@ -10,6 +10,6 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 export class ArmWarningComponent{
 
   @Input() armWarningText = "This is an ARM managed resource. ARM managed resources should only be modified during ARM deployments.";
-  @Input() resourceId: string;
+  @Input() resourceId!: string;
 
 }

--- a/src/SfxWeb/src/app/shared/component/clip-board/clip-board.component.spec.ts
+++ b/src/SfxWeb/src/app/shared/component/clip-board/clip-board.component.spec.ts
@@ -7,7 +7,7 @@ import { ClipBoardComponent } from './clip-board.component';
 describe('ClipBoardComponent', () => {
   let component: ClipBoardComponent;
   let fixture: ComponentFixture<ClipBoardComponent>;
-  let spy;
+  let spy: any;
 
   beforeEach(waitForAsync(() => {
     spy = jasmine.createSpyObj('Clipboard', ['copy']);

--- a/src/SfxWeb/src/app/shared/component/clip-board/clip-board.component.ts
+++ b/src/SfxWeb/src/app/shared/component/clip-board/clip-board.component.ts
@@ -19,8 +19,8 @@ export class ClipBoardComponent implements OnChanges {
   @Input() tooltipText = '';
   @Input() disabled = false;
   @Input() name = '';
-  @ViewChild('ref') ref: ElementRef;
-  @ViewChild(NgbTooltip) tooltip: NgbTooltip; // First
+  @ViewChild('ref') ref!: ElementRef;
+  @ViewChild(NgbTooltip) tooltip!: NgbTooltip; // First
   public ariaLabel = '';
               
   copy() {

--- a/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
+++ b/src/SfxWeb/src/app/shared/component/cluster-upgrade-banner/cluster-upgrade-banner.component.ts
@@ -17,7 +17,7 @@ export class ClusterUpgradeBannerComponent implements OnInit {
 
   displayMiddleText = true;
   displayAllText = true;
-  @Input() clusterUpgradeProgress: ClusterUpgradeProgress;
+  @Input() clusterUpgradeProgress!: ClusterUpgradeProgress;
 
   ngOnInit() {
     this.refreshService.refreshSubject.subscribe(() => this.refresh().subscribe());

--- a/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
+++ b/src/SfxWeb/src/app/shared/component/detail-view-part/detail-view-part.component.ts
@@ -168,7 +168,7 @@ export class DetailViewPartComponent implements OnChanges {
           }
       });
 
-      return size(resolvedObject) > 0 ? resolvedObject : null;
+      return size(resolvedObject) > 0 ? resolvedObject : null!;
   }
 
   asIsOrder(a: any, b: any): number {

--- a/src/SfxWeb/src/app/shared/component/display-duration/display-duration.component.ts
+++ b/src/SfxWeb/src/app/shared/component/display-duration/display-duration.component.ts
@@ -15,11 +15,11 @@ export interface ISection {
 export class DisplayDurationComponent implements OnChanges {
 
   @Input() topText = '';
-  @Input() topInMilliseconds: number;
+  @Input() topInMilliseconds!: number;
   @Input() topHelpText = '';
 
   @Input() bottomText = '';
-  @Input() bottomInMilliseconds: number;
+  @Input() bottomInMilliseconds!: number;
   @Input() bottomHelpText = '';
   @Input() bottomHelpTextLink = '';
 
@@ -58,7 +58,7 @@ export class DisplayDurationComponent implements OnChanges {
     ]
   }
 
-  setColorCode(percent): string {
+  setColorCode(percent: any): string {
     const direction = Object.entries(this.colorMap).sort((a,b) => {
       return +b[0] - +a[0];
     });

--- a/src/SfxWeb/src/app/shared/component/display-time/display-time.component.ts
+++ b/src/SfxWeb/src/app/shared/component/display-time/display-time.component.ts
@@ -13,7 +13,7 @@ export class DisplayTimeComponent implements OnInit, OnChanges, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
 
 
-  @Input() time: string;
+  @Input() time!: string;
 
   localTime = '';
   timeSince = '';

--- a/src/SfxWeb/src/app/shared/component/dual-date-picker/dual-date-picker.component.ts
+++ b/src/SfxWeb/src/app/shared/component/dual-date-picker/dual-date-picker.component.ts
@@ -13,23 +13,23 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
   formatter = inject(NgbDateParserFormatter);
 
 
-  @Input() minDate: Date;
-  @Input() maxDate: Date;
+  @Input() minDate!: Date;
+  @Input() maxDate!: Date;
 
-  @Input() currentStartDate: Date;
-  @Input() currentEndDate: Date;
+  @Input() currentStartDate!: Date;
+  @Input() currentEndDate!: Date;
 
   @Output() dateChanged = new EventEmitter<{endDate: Date, startDate: Date}>();
 
-  private internalMinDate: NgbDateStruct;
-  private internalMaxDate: NgbDateStruct;
+  private internalMinDate!: NgbDateStruct;
+  private internalMaxDate!: NgbDateStruct;
 
-  hoveredDate: NgbDate;
+  hoveredDate!: NgbDate;
 
-  fromDate: NgbDate;
-  toDate: NgbDate;
-  currentStartTime: string;
-  currentEndTime: string;
+  fromDate!: NgbDate;
+  toDate!: NgbDate;
+  currentStartTime!: string;
+  currentEndTime!: string;
 
   ngOnChanges(simple: SimpleChanges) {
     this.toDate = this.dateToNgbDate(this.currentEndDate);
@@ -48,7 +48,7 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
       year: date.getFullYear(),
       month: date.getMonth() + 1,
       day: date.getDate()
-    });
+    })!;
   }
 
   onDateSelection(date: NgbDate) {
@@ -57,7 +57,7 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
     } else if (this.fromDate && !this.toDate && !date.before(this.fromDate)) {
       this.toDate = date;
     } else {
-      this.toDate = null;
+      this.toDate = null!;
       this.fromDate = date;
     }
     if (this.fromDate && this.toDate){
@@ -97,7 +97,7 @@ export class DualDatePickerComponent implements OnInit, OnChanges {
 
   validateInput(currentValue: NgbDate, input: string): NgbDate {
     const parsed = this.formatter.parse(input);
-    return parsed && this.calendar.isValid(NgbDate.from(parsed)) ? NgbDate.from(parsed) : currentValue;
+    return parsed && this.calendar.isValid(NgbDate.from(parsed)) ? NgbDate.from(parsed)! : currentValue;
   }
 
   isDisabled = (date: NgbDate, current: {month: number}) => {

--- a/src/SfxWeb/src/app/shared/component/essential-item/essential-item.component.ts
+++ b/src/SfxWeb/src/app/shared/component/essential-item/essential-item.component.ts
@@ -10,7 +10,7 @@ import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile
 })
 export class EssentialItemComponent {
 
-  @Input() item: IEssentialListItem;
+  @Input() item!: IEssentialListItem;
   @Input() underline = false;
 
   constructor() { }

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -34,8 +34,8 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
   private timeline!: Timeline;
   private start!: Date;
   private end!: Date;
-  private oldestEvent: DataItem | null = null;
-  private mostRecentEvent: DataItem | null = null;
+  private oldestEvent?: DataItem | null;
+  private mostRecentEvent?: DataItem | null;
 
   @ViewChild('visualization') container!: ElementRef;
 

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -19,7 +19,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
   private liveAnnouncer = inject(LiveAnnouncer);
 
 
-  @Input() events: ITimelineData;
+  @Input() events!: ITimelineData;
   @Input() additionalWhiteListClasses = [];
   @Input() fitOnDataChange = true;
   @Input() displayMoveToStart = true;
@@ -31,13 +31,13 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
 
   public showControls = false;
 
-  private timeline: Timeline;
-  private start: Date;
-  private end: Date;
-  private oldestEvent: DataItem;
-  private mostRecentEvent: DataItem;
+  private timeline!: Timeline;
+  private start!: Date;
+  private end!: Date;
+  private oldestEvent: DataItem | null = null;
+  private mostRecentEvent: DataItem | null = null;
 
-  @ViewChild('visualization') container: ElementRef;
+  @ViewChild('visualization') container!: ElementRef;
 
   ngOnChanges() {
     if (this.timeline) {
@@ -68,7 +68,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
       }
     });
 
-    this.timeline.on('click', data => {
+    this.timeline.on('click', (data: any) => {
       this.itemClicked.emit(data.item)
     })
 
@@ -79,9 +79,9 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
 
   private sanitizeData(items: DataSet<DataGroup | DataItem>) {
     items.forEach(item => {
-      item.content = this.sanitzer.sanitize(SecurityContext.HTML, item.content);
+      item.content = this.sanitzer.sanitize(SecurityContext.HTML, item.content)!;
       if(item.title) {
-        item.title = this.sanitzer.sanitize(SecurityContext.HTML, item.title);
+        item.title = this.sanitzer.sanitize(SecurityContext.HTML, item.title)!;
       }
     })
   }
@@ -157,15 +157,15 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
 
       const options = {
         selectable: false,
-        template: (itemData, element: HTMLElement, data) => {
+        template: (itemData: any, element: HTMLElement, data: any) => {
           if (data.isCluster) {
             const color = itemData.items[0].groupColor;
             if(color) {
               element.classList.add(color);
             }
-            return this.sanitzer.sanitize(SecurityContext.HTML, `<div class="${color}">${data.items.length} ${data.items[0].kind} events </div>`)
+            return this.sanitzer.sanitize(SecurityContext.HTML, `<div class="${color}">${data.items.length} ${data.items[0].kind} events </div>`)!
           } else {
-            return this.sanitzer.sanitize(SecurityContext.HTML, `<div>${data.content}</div>`);
+            return this.sanitzer.sanitize(SecurityContext.HTML, `<div>${data.content}</div>`)!;
           }
         },
         margin: {
@@ -175,7 +175,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
         },
         tooltip: {
           followMouse: true,
-          template: (itemData) => {
+          template: (itemData: any) => {
             let content = itemData.title;
 
             if(itemData.isCluster) {
@@ -191,7 +191,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
               </div>`
             }
 
-            return this.sanitzer.sanitize(SecurityContext.HTML, content);
+            return this.sanitzer.sanitize(SecurityContext.HTML, content)!;
           }
         },
         stack: true,
@@ -217,11 +217,11 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
         this.timeline.fit();
       }
 
-      if (events.items.length > 0) {
-        let oldest = null;
-        let newest = null;
+      if (events.items!.length > 0) {
+        let oldest: any = null;
+        let newest: any = null;
 
-        events.items.forEach(item => {
+        events.items!.forEach(item => {
           // cant easily grab the first elements of the collection, easier to set here
           if (!oldest && !newest) {
             oldest = item;
@@ -230,7 +230,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
           if (oldest.start > item.start) {
             oldest = item;
           }
-          if (newest.end < item.end) {
+          if (newest.end < item.end!) {
             newest = item;
           }
         });

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -4,7 +4,7 @@ import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { pregeneratedColors } from 'src/app/Common/Constants';
 import { ITimelineData } from 'src/app/Models/eventstore/timelineGenerators';
 import * as moment from 'moment';
-import { Timeline, DataItem, DataGroup, TimelineOptionsCluster } from 'vis-timeline/peer';
+import { Timeline, DataItem, DataGroup, TimelineOptionsCluster, MomentConstructor } from 'vis-timeline/peer';
 import { DataSet } from 'vis-data';
 
 @Component({
@@ -88,7 +88,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
 
   public flipTimeZone(utc: boolean) {
     this.timeline.setOptions({
-      moment: (utc ? moment.utc : moment) as any
+      moment: (utc ? moment.utc : moment) as MomentConstructor
     });
   }
 

--- a/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
+++ b/src/SfxWeb/src/app/shared/component/event-store-timeline/event-store-timeline.component.ts
@@ -4,7 +4,7 @@ import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { pregeneratedColors } from 'src/app/Common/Constants';
 import { ITimelineData } from 'src/app/Models/eventstore/timelineGenerators';
 import * as moment from 'moment';
-import { Timeline, DataItem, DataGroup } from 'vis-timeline/peer';
+import { Timeline, DataItem, DataGroup, TimelineOptionsCluster } from 'vis-timeline/peer';
 import { DataSet } from 'vis-data';
 
 @Component({
@@ -205,7 +205,7 @@ export class EventStoreTimelineComponent implements AfterViewInit, OnChanges, On
           clusterCriteria(firstItem: any, secondItem: any) {
             return firstItem.kind === secondItem.kind
           }
-        } : false as any,
+        } : false as unknown as TimelineOptionsCluster, // vis-timeline's cluster type omits `false`, the value that disables clustering
       }
       this.timeline.setOptions(options);
       setTimeout(() => {

--- a/src/SfxWeb/src/app/shared/component/health-badge/health-badge.component.ts
+++ b/src/SfxWeb/src/app/shared/component/health-badge/health-badge.component.ts
@@ -11,8 +11,8 @@ import { environment } from 'src/environments/environment';
 export class HealthBadgeComponent{
   public assetBase = environment.assetBase;
 
-  @Input() badgeClass: string;
-  @Input() text: string;
+  @Input() badgeClass!: string;
+  @Input() text!: string;
   @Input() showText = true;
   @Input() size = '15px';
 

--- a/src/SfxWeb/src/app/shared/component/input/input.component.ts
+++ b/src/SfxWeb/src/app/shared/component/input/input.component.ts
@@ -12,9 +12,9 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 export class InputComponent implements OnInit, OnDestroy {
 
   debounceHandler: Subject<string> = new Subject<string>();
-  debouncerHandlerSubscription: Subscription;
+  debouncerHandlerSubscription!: Subscription;
 
-  modelValue: string;
+  modelValue!: string;
 
   @Input() placeholder = 'Search list';
   @Input() label = 'Search list';

--- a/src/SfxWeb/src/app/shared/component/navbar/navbar.component.ts
+++ b/src/SfxWeb/src/app/shared/component/navbar/navbar.component.ts
@@ -16,7 +16,7 @@ export class NavbarComponent {
   @Input() type = '';
   @Input() name = '';
   @Input() tabs: ITab[] = [];
-  @Input() actions: ActionCollection;
+  @Input() actions!: ActionCollection;
   @Input() showCopy = true;
 
   navigateBySpaceBar(route: string) {

--- a/src/SfxWeb/src/app/shared/component/node-filter/node-filter.component.ts
+++ b/src/SfxWeb/src/app/shared/component/node-filter/node-filter.component.ts
@@ -16,7 +16,7 @@ export class NodeFilterComponent implements OnInit, OnChanges {
 
   @Input() showGroupByNodeType = true;
 
-  @Input() nodes: Node[];
+  @Input() nodes!: Node[];
   @Input() groupByNodeType = false;
   @Output() groupByNodeTypeChange = new EventEmitter();
 

--- a/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.ts
+++ b/src/SfxWeb/src/app/shared/component/phase-diagram/phase-diagram.component.ts
@@ -9,8 +9,8 @@ import { Component, Input, OnChanges, OnInit, TemplateRef, ChangeDetectionStrate
 })
 export class PhaseDiagramComponent implements OnChanges {
 
-  @Input() middleItem: TemplateRef<any>;
-  @Input() items: IProgressStatus[];
+  @Input() middleItem!: TemplateRef<any>;
+  @Input() items!: IProgressStatus[];
   @Input() currentIndex = 0;
   @Input() vertical = false;
   @Input() failed: boolean = false; //treat in progress phases as failed

--- a/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
+++ b/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
@@ -14,7 +14,7 @@ export class RefreshRateComponent {
   @Input() refresh = false;
   @Input()
   set value( val: number) {
-    this.change( +(Object.keys(this.mapping).find(key => this.mapping[key] === val) || 4), false );
+    this.change( +(Object.keys(this.mapping).find(key => (this.mapping as any)[key] === val) || 4), false );
   }
 
   @Input() condensedVersion = false;
@@ -23,7 +23,7 @@ export class RefreshRateComponent {
   @Output() forceRefreshed = new EventEmitter<any>();
   refreshRate = 0;
 
-  displayRate: string | number;
+  displayRate!: string | number;
 
   private mapping: Record<number, string> = {
     0: '0',

--- a/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
+++ b/src/SfxWeb/src/app/shared/component/refresh-rate/refresh-rate.component.ts
@@ -13,8 +13,8 @@ export class RefreshRateComponent {
 
   @Input() refresh = false;
   @Input()
-  set value( val: number) {
-    this.change( +(Object.keys(this.mapping).find(key => (this.mapping as any)[key] === val) || 4), false );
+  set value( val: string) {
+    this.change( +(Object.keys(this.mapping).find(key => this.mapping[+key] === val) || 4), false );
   }
 
   @Input() condensedVersion = false;

--- a/src/SfxWeb/src/app/shared/component/resource-item/resource-item.component.ts
+++ b/src/SfxWeb/src/app/shared/component/resource-item/resource-item.component.ts
@@ -10,7 +10,7 @@ import { IResourceItem } from 'src/app/modules/charts/resources-tile/resources-t
 })
 export class ResourceItemComponent {
 
-  @Input() item: IResourceItem;
+  @Input() item!: IResourceItem;
   @Input() underline = false;
 
   constructor() { }

--- a/src/SfxWeb/src/app/shared/component/state-info/state-info.component.ts
+++ b/src/SfxWeb/src/app/shared/component/state-info/state-info.component.ts
@@ -13,7 +13,7 @@ import { IRawPartition, IRawServiceDescription } from 'src/app/Models/RawDataTyp
 export class StateInfoComponent {
 
   @Input() stateful = false;
-  @Input() data: IRawServiceDescription | IRawPartition;
+  @Input() data!: IRawServiceDescription | IRawPartition;
 
   constructor() { }
 }

--- a/src/SfxWeb/src/app/shared/component/status-resolver/status-resolver.component.ts
+++ b/src/SfxWeb/src/app/shared/component/status-resolver/status-resolver.component.ts
@@ -10,8 +10,8 @@ import { HealthStateConstants, NodeStatusConstants } from 'src/app/Common/Consta
 })
 export class StatusResolverComponent implements  OnInit, OnChanges {
 
-  @Input() status: string;
-  @Input() healthState: HealthStateConstants;
+  @Input() status!: string;
+  @Input() healthState!: HealthStateConstants;
   @Input() showText = true;
 
   statusIconResolver: Record<string, string> = {};

--- a/src/SfxWeb/src/app/shared/component/warning/warning.component.ts
+++ b/src/SfxWeb/src/app/shared/component/warning/warning.component.ts
@@ -13,8 +13,8 @@ export class WarningComponent {
   @Input() iconSize: string = "mif-4x";
   //provide additional data in a list format
   @Input() descriptionList: string[] = [];
-  @Input() link: string;
-  @Input() linkText: string;
+  @Input() link!: string;
+  @Input() linkText!: string;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/views/application-type/ApplicationTypeBase.ts
+++ b/src/SfxWeb/src/app/views/application-type/ApplicationTypeBase.ts
@@ -12,8 +12,8 @@ import { ApplicationTypeGroup } from 'src/app/Models/DataModels/ApplicationType'
 export class ApplicationTypeBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    appTypeName: string;
-    appTypeGroup: ApplicationTypeGroup;
+    appTypeName!: string;
+    appTypeGroup!: ApplicationTypeGroup;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getAppTypeGroup(this.appTypeName, true, messageHandler).pipe(map( appTypeGroup => {

--- a/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/action-row/action-row.component.ts
@@ -12,8 +12,8 @@ import { ApplicationType } from 'src/app/Models/DataModels/ApplicationType';
 })
 export class ActionRowComponent implements DetailBaseComponent {
 
-  item: ApplicationType;
-  listSetting: ListColumnSettingForApplicationType;
+  item!: ApplicationType;
+  listSetting!: ListColumnSettingForApplicationType;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/views/application-type/create-application/create-application.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/create-application/create-application.component.ts
@@ -20,10 +20,10 @@ export class CreateApplicationComponent implements OnInit, OnDestroy {
   private formBuilder = inject(UntypedFormBuilder);
 
 
-  @Input() inputs: { appType: ApplicationType };
-  form: UntypedFormGroup;
+  @Input() inputs!: { appType: ApplicationType };
+  form!: UntypedFormGroup;
   @Output() disableSubmit = new EventEmitter<boolean>();
-  validityCheckerSubscription: Subscription;
+  validityCheckerSubscription!: Subscription;
   disableSubmitSubscription: Subscription = new Subscription();
 
   ngOnInit(): void {

--- a/src/SfxWeb/src/app/views/application-type/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/details/details.component.ts
@@ -16,8 +16,8 @@ import { ApplicationTypeBaseControllerDirective } from '../ApplicationTypeBase';
 export class DetailsComponent extends ApplicationTypeBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
-  appTypeName: string;
-  appTypeGroup: ApplicationTypeGroup;
+  appTypeName!: string;
+  appTypeGroup!: ApplicationTypeGroup;
 
   setup() { }
 

--- a/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application-type/essentials/essentials.component.ts
@@ -19,8 +19,8 @@ export class EssentialsComponent extends ApplicationTypeBaseControllerDirective 
   protected data: DataService = inject(DataService);
   private settings = inject(SettingsService);
 
-  appTypeGroup: ApplicationTypeGroup;
-  appsListSettings: ListSettings;
+  appTypeGroup!: ApplicationTypeGroup;
+  appsListSettings!: ListSettings;
 
   setup() {
    

--- a/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
+++ b/src/SfxWeb/src/app/views/application/action-row/action-row.component.ts
@@ -17,8 +17,8 @@ export class ActionRowComponent implements DetailBaseComponent {
   private data = inject(DataService);
 
 
-  item: ServiceType;
-  listSetting: ListColumnSettingForApplicationServiceRow;
+  item!: ServiceType;
+  listSetting!: ListColumnSettingForApplicationServiceRow;
 
   createService() {
     new IsolatedAction(

--- a/src/SfxWeb/src/app/views/application/applicationBase.ts
+++ b/src/SfxWeb/src/app/views/application/applicationBase.ts
@@ -12,10 +12,10 @@ import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 export class ApplicationBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    appTypeName: string;
-    appId: string;
+    appTypeName!: string;
+    appId!: string;
 
-    app: Application;
+    app!: Application;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getApp(this.appId, true, messageHandler).pipe(map(data => {

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -25,8 +25,8 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
   private telemetry = inject(TelemetryService);
 
 
-  applicationBackupConfigurationInfoListSettings: ListSettings;
-  actions: ActionCollection;
+  applicationBackupConfigurationInfoListSettings!: ListSettings;
+  actions!: ActionCollection;
 
   setup() {
     this.applicationBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('backupConfigurationInfoCollection', ['raw.PolicyName'], [
@@ -84,9 +84,9 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
             data: this
         },
         PartitionDisableBackUpComponent,
-        () => this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
-              this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application',
+              this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application'),
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -97,10 +97,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.suspendApplicationBackup(this.app.id).pipe(map(() => {
               this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false,
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
         {
           title:  'Confirm Application Backup Suspension'
         },
@@ -119,10 +119,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.resumeApplicationBackup(this.app.id).pipe(map(() => {
             this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true,
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
         {
           title:  'Confirm Application Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -84,9 +84,9 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
             data: this
         },
         PartitionDisableBackUpComponent,
-        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+          () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
-              this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application'),
+            this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application') as unknown as boolean,
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -97,10 +97,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.suspendApplicationBackup(this.app.id).pipe(map(() => {
               this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false) as unknown as boolean,
         {
           title:  'Confirm Application Backup Suspension'
         },
@@ -119,10 +119,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.resumeApplicationBackup(this.app.id).pipe(map(() => {
             this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true) as unknown as boolean,
         {
           title:  'Confirm Application Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/application/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/application/backup/backup.component.ts
@@ -84,9 +84,9 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
             data: this
         },
         PartitionDisableBackUpComponent,
-          () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+          () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
-            this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application') as unknown as boolean,
+            this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application'),
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -97,10 +97,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.suspendApplicationBackup(this.app.id).pipe(map(() => {
               this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false) as unknown as boolean,
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
         {
           title:  'Confirm Application Backup Suspension'
         },
@@ -119,10 +119,10 @@ export class BackupComponent extends ApplicationBaseControllerDirective  {
         () => this.data.restClient.resumeApplicationBackup(this.app.id).pipe(map(() => {
             this.app.applicationBackupConfigurationInfoCollection.refresh();
         })),
-        () => (this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.app.applicationBackupConfigurationInfoCollection.collection.length && this.app.applicationBackupConfigurationInfoCollection.collection[0].raw &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Application' &&
               this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Application' &&
-          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true) as unknown as boolean,
+          this.app.applicationBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
         {
           title:  'Confirm Application Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/application/create-service/create-service.component.ts
+++ b/src/SfxWeb/src/app/views/application/create-service/create-service.component.ts
@@ -17,8 +17,8 @@ export class CreateServiceComponent implements OnInit {
   private dataService = inject(DataService);
 
 
-  description: CreateServiceDescription;
-  serviceType: ServiceType;
+  description!: CreateServiceDescription;
+  serviceType!: ServiceType;
 
   ngOnInit() {
     this.serviceType = this.data.data;

--- a/src/SfxWeb/src/app/views/application/deployments/deployments.component.ts
+++ b/src/SfxWeb/src/app/views/application/deployments/deployments.component.ts
@@ -20,7 +20,7 @@ export class DeploymentsComponent extends ApplicationBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  deployedApplicationsHealthStatesListSettings: ListSettings;
+  deployedApplicationsHealthStatesListSettings!: ListSettings;
   deployedApplicationsHealthStates: DeployedApplicationHealthState[] = [];
 
   setup() {

--- a/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/application/essentials/essentials.component.ts
@@ -29,18 +29,18 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  upgradeProgress: ApplicationUpgradeProgress;
-  listSettings: ListSettings;
-  upgradeProgressUnhealthyEvaluationsListSettings: ListSettings;
-  serviceTypesListSettings: ListSettings;
+  upgradeProgress!: ApplicationUpgradeProgress;
+  listSettings!: ListSettings;
+  upgradeProgressUnhealthyEvaluationsListSettings!: ListSettings;
+  serviceTypesListSettings!: ListSettings;
 
-  servicesDashboard: IDashboardViewModel;
-  partitionsDashboard: IDashboardViewModel;
-  replicasDashboard: IDashboardViewModel;
+  servicesDashboard!: IDashboardViewModel;
+  partitionsDashboard!: IDashboardViewModel;
+  replicasDashboard!: IDashboardViewModel;
   essentialItems: IEssentialListItem[] = [];
 
-  eventStoreHandler: IEventStoreData<ApplicationEventList, ApplicationEvent>;
-  highValueEvents: IConcurrentEvents[] = null;
+  eventStoreHandler!: IEventStoreData<ApplicationEventList, ApplicationEvent>;
+  highValueEvents: IConcurrentEvents[] | null = null;
   failedToLoadEvents = false;
 
   setup() {
@@ -70,7 +70,7 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
         this.eventStoreHandler.eventsList.setEventFilter(['ProcessDeactivated', 'ContainerDeactivated']);
         this.eventStoreHandler.eventsList.refresh().subscribe((success) => {
           if(success) {
-            this.highValueEvents = getSimultaneousEventsForEvent(RelatedEventsConfigs, this.eventStoreHandler.getEvents(), this.eventStoreHandler.getEvents());
+            this.highValueEvents = getSimultaneousEventsForEvent(RelatedEventsConfigs, this.eventStoreHandler.getEvents!(), this.eventStoreHandler.getEvents!());
           }else{
             this.failedToLoadEvents = true;
           }
@@ -90,7 +90,7 @@ export class EssentialsComponent extends ApplicationBaseControllerDirective {
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
     this.data.clusterManifest.ensureInitialized().subscribe(() => {
       if (this.data.clusterManifest.isBackupRestoreEnabled) {
-        this.data.refreshBackupPolicies(messageHandler);
+        this.data.refreshBackupPolicies(messageHandler!);
       }
     });
 

--- a/src/SfxWeb/src/app/views/application/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/application/events/events.component.ts
@@ -15,9 +15,9 @@ export class EventsComponent extends ApplicationBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  visEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  visEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
   setup() {
     // grab event data for all nodes for concurrent events visualization tool

--- a/src/SfxWeb/src/app/views/applications/all/all.component.ts
+++ b/src/SfxWeb/src/app/views/applications/all/all.component.ts
@@ -16,7 +16,7 @@ export class AllComponent extends ApplicationsBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  listSettings: ListSettings;
+  listSettings!: ListSettings;
 
   setup() {
     this.listSettings = this.settings.getNewOrExistingListSettings('apps', ['name'], [

--- a/src/SfxWeb/src/app/views/applications/applicationsBase.ts
+++ b/src/SfxWeb/src/app/views/applications/applicationsBase.ts
@@ -11,9 +11,9 @@ export class ApplicationsBaseControllerDirective extends BaseControllerDirective
     protected data = inject(DataService);
 
 
-    apps: ApplicationCollection;
-    usage: IAppTypeUsage;
-    hasArmManagedAppType: boolean;
+    apps!: ApplicationCollection;
+    usage!: IAppTypeUsage;
+    hasArmManagedAppType!: boolean;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return forkJoin([

--- a/src/SfxWeb/src/app/views/applications/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/applications/events/events.component.ts
@@ -13,8 +13,8 @@ import { ApplicationsBaseControllerDirective } from '../applicationsBase';
 })
 export class EventsComponent extends ApplicationsBaseControllerDirective {
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
    setup() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
+++ b/src/SfxWeb/src/app/views/applications/upgrading/upgrading.component.ts
@@ -20,7 +20,7 @@ export class UpgradingComponent extends ApplicationsBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  upgradeAppsListSettings: ListSettings;
+  upgradeAppsListSettings!: ListSettings;
   upgradeProgresses: ApplicationUpgradeProgress[] = [];
 
   setup() {

--- a/src/SfxWeb/src/app/views/applications/view-upgrades-list-item/view-upgrades-list-item.component.ts
+++ b/src/SfxWeb/src/app/views/applications/view-upgrades-list-item/view-upgrades-list-item.component.ts
@@ -11,8 +11,8 @@ import { DetailBaseComponent } from 'src/app/ViewModels/detail-table-base.compon
     standalone: false
 })
 export class ViewUpgradesListItemComponent implements DetailBaseComponent {
-  listSetting: ListColumnSetting;
-  item: ApplicationUpgradeProgress;
+  listSetting!: ListColumnSetting;
+  item!: ApplicationUpgradeProgress;
 
   constructor() { }
 

--- a/src/SfxWeb/src/app/views/cluster-insights/expanded-details/expanded-details.component.ts
+++ b/src/SfxWeb/src/app/views/cluster-insights/expanded-details/expanded-details.component.ts
@@ -11,7 +11,7 @@ import { ListColumnSetting } from 'src/app/Models/ListSettings';
 })
 export class ExpandedDetailsComponent implements DetailBaseComponent {
   item: any;
-  listSetting: ListColumnSetting;
+  listSetting!: ListColumnSetting;
 }
 
 export class ListColumnSettingForExpandedDetails extends ListColumnSetting {

--- a/src/SfxWeb/src/app/views/cluster-insights/fmm-info/fmm-info.component.ts
+++ b/src/SfxWeb/src/app/views/cluster-insights/fmm-info/fmm-info.component.ts
@@ -17,7 +17,7 @@ export class FmmInfoComponent extends BaseControllerDirective {
   private restClientService = inject(RestClientService);
   private dataService = inject(DataService);
 
-  fmmInfo: IRawFailoverManagerManagerInformation;
+  fmmInfo!: IRawFailoverManagerManagerInformation;
   isLoading = true;
   isFmmEstimate = false;
 

--- a/src/SfxWeb/src/app/views/cluster-insights/recovery-progress/recovery-progress.component.ts
+++ b/src/SfxWeb/src/app/views/cluster-insights/recovery-progress/recovery-progress.component.ts
@@ -178,7 +178,7 @@ export class RecoveryProgressComponent extends BaseControllerDirective {
     const warningApps = apps.filter((app) => app.healthState.text === HealthStateConstants.Warning).length;
     const errorApps = apps.filter((app) => app.healthState.text === HealthStateConstants.Error).length;
 
-    let status: RecoveryStep['status'] = 'success';
+    let status!: RecoveryStep['status'];
     const tooltipParts: string[] = [];
 
     if (errorApps > 0) {

--- a/src/SfxWeb/src/app/views/cluster-insights/recovery-progress/recovery-progress.component.ts
+++ b/src/SfxWeb/src/app/views/cluster-insights/recovery-progress/recovery-progress.component.ts
@@ -178,7 +178,7 @@ export class RecoveryProgressComponent extends BaseControllerDirective {
     const warningApps = apps.filter((app) => app.healthState.text === HealthStateConstants.Warning).length;
     const errorApps = apps.filter((app) => app.healthState.text === HealthStateConstants.Error).length;
 
-    let status: RecoveryStep['status'];
+    let status: RecoveryStep['status'] = 'success';
     const tooltipParts: string[] = [];
 
     if (errorApps > 0) {

--- a/src/SfxWeb/src/app/views/cluster-insights/replica-list/replica-list.component.ts
+++ b/src/SfxWeb/src/app/views/cluster-insights/replica-list/replica-list.component.ts
@@ -198,7 +198,7 @@ export class ReplicaListComponent extends BaseControllerDirective {
         existing.raw = replica;
         existing.nodeStatus = nodeStatus;
         existing.isSeedNode = node?.raw.IsSeedNode ?? false;
-        existing.replicaRoleSortPriority = (SortPriorities.ReplicaRolesToSortPriorities as any)[replica.ReplicaRole] || 0;
+        existing.replicaRoleSortPriority = SortPriorities.ReplicaRolesToSortPriorities[replica.ReplicaRole as keyof typeof SortPriorities.ReplicaRolesToSortPriorities] || 0;
         existing.replicaStatusBadge = {
           text: replica.ReplicaStatus,
           badgeClass: replica.ReplicaStatus === 'Ready' ? 'badge-ok' : 'badge-error'
@@ -222,7 +222,7 @@ export class ReplicaListComponent extends BaseControllerDirective {
         raw: replica,
         nodeStatus,
         isSeedNode: node?.raw.IsSeedNode ?? false,
-        replicaRoleSortPriority: (SortPriorities.ReplicaRolesToSortPriorities as any)[replica.ReplicaRole] || 0,
+        replicaRoleSortPriority: SortPriorities.ReplicaRolesToSortPriorities[replica.ReplicaRole as keyof typeof SortPriorities.ReplicaRolesToSortPriorities] || 0,
         replicaStatusBadge: {
           text: replica.ReplicaStatus,
           badgeClass: replica.ReplicaStatus === 'Ready' ? 'badge-ok' : 'badge-error'

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.html
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.html
@@ -117,7 +117,7 @@
               <input type="checkbox" formControlName="retentionPolicyRequired"/>
             </dd>
           </dl>
-          <dl class="dl-horizontal" [ngStyle]="{'display': ( form.get('retentionPolicyRequired').value ? 'initial' : 'none') }" formGroupName="RetentionPolicy">
+          <dl class="dl-horizontal" [ngStyle]="{'display': ( form.get('retentionPolicyRequired')?.value ? 'initial' : 'none') }" formGroupName="RetentionPolicy">
             <dt>MinNumberOfBackups</dt>
             <dd>
               <input type="number" class="input-flat" formControlName="MinimumNumberOfBackups">

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.html
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.html
@@ -117,7 +117,7 @@
               <input type="checkbox" formControlName="retentionPolicyRequired"/>
             </dd>
           </dl>
-          <dl class="dl-horizontal" [ngStyle]="{'display': ( form.get('retentionPolicyRequired')?.value ? 'initial' : 'none') }" formGroupName="RetentionPolicy">
+          <dl class="dl-horizontal" [ngStyle]="{'display': ( form.get('retentionPolicyRequired')!.value ? 'initial' : 'none') }" formGroupName="RetentionPolicy">
             <dt>MinNumberOfBackups</dt>
             <dd>
               <input type="number" class="input-flat" formControlName="MinimumNumberOfBackups">

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
@@ -19,7 +19,7 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
 
-  form: UntypedFormGroup;
+  form!: UntypedFormGroup;
 
   public date = '';
   public weekDay: string[]  = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
@@ -39,7 +39,7 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
     delete data.Storage.IsEmptySecondaryCredential;
 
     if (data.Schedule.ScheduleKind === 'TimeBased' && data.Schedule.ScheduleFrequencyType === 'Weekly') {
-      data.Schedule.RunDays = data.Schedule.RunDays.map( (status: boolean, index: number ) => status ? this.weekDay[index] : null).filter( day => day !== null);
+      data.Schedule.RunDays = data.Schedule.RunDays.map( (status: boolean, index: number ) => status ? this.weekDay[index] : null).filter( (day: any) => day !== null);
     }else{
       data.Schedule.RunDays = [];
     }
@@ -79,13 +79,13 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
       })
     });
 
-    this.form.get('retentionPolicyRequired').valueChanges.subscribe(required => {
-      this.form.get('RetentionPolicy').get('RetentionDuration').setValidators(required ? [Validators.required, Validators.minLength(1)] : null);
-      this.form.get('RetentionPolicy').get('RetentionDuration').updateValueAndValidity();
+    this.form.get('retentionPolicyRequired')!.valueChanges.subscribe(required => {
+      this.form.get('RetentionPolicy')!.get('RetentionDuration')!.setValidators(required ? [Validators.required, Validators.minLength(1)] : null);
+      this.form.get('RetentionPolicy')!.get('RetentionDuration')!.updateValueAndValidity();
       this.cdr.detectChanges();
     });
 
-    this.form.get('Schedule').get('ScheduleKind').valueChanges.subscribe(type => {
+    this.form.get('Schedule')!.get('ScheduleKind')!.valueChanges.subscribe(type => {
       this.updateSchedule(type);
     });
 
@@ -96,7 +96,7 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
           this.form.patchValue({retentionPolicyRequired : true});
         }
 
-        this.form.get('Name').disable();
+        this.form.get('Name')!.disable();
         if (this.data.data.Schedule.ScheduleFrequencyType === 'Weekly') {
           this.setDays(this.data.data.Schedule.RunDays);
         }
@@ -104,27 +104,27 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
       this.setDays([]);
     }
 
-    this.updateSchedule(this.form.get('Schedule').get('ScheduleKind').value);
+    this.updateSchedule(this.form.get('Schedule')!.get('ScheduleKind')!.value);
 
     this.cdr.detectChanges();
   }
 
   updateSchedule(state: string) {
-    this.form.get('Schedule').get('ScheduleFrequencyType').setValidators(state === 'TimeBased' ? [Validators.required] : null);
-    this.form.get('Schedule').get('Interval').setValidators(state === 'FrequencyBased' ? [Validators.required] : null);
+    this.form.get('Schedule')!.get('ScheduleFrequencyType')!.setValidators(state === 'TimeBased' ? [Validators.required] : null);
+    this.form.get('Schedule')!.get('Interval')!.setValidators(state === 'FrequencyBased' ? [Validators.required] : null);
 
-    this.form.get('Schedule').get('ScheduleFrequencyType').updateValueAndValidity();
-    this.form.get('Schedule').get('Interval').updateValueAndValidity();
+    this.form.get('Schedule')!.get('ScheduleFrequencyType')!.updateValueAndValidity();
+    this.form.get('Schedule')!.get('Interval')!.updateValueAndValidity();
     this.cdr.detectChanges();
 
   }
 
   get RunTimes() {
-    return this.form.get('Schedule').get('RunTimes') as UntypedFormArray;
+    return this.form.get('Schedule')!.get('RunTimes') as UntypedFormArray;
   }
 
   get RunDays() {
-    return this.form.get('Schedule').get('RunDays') as UntypedFormArray;
+    return this.form.get('Schedule')!.get('RunDays') as UntypedFormArray;
   }
 
   addRunTime() {
@@ -141,13 +141,13 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
   }
 
   getRunDaysControl() {
-    const arr = this.weekDay.map(day => this.formBuilder.control(false)); // TODO set this with initial data
+    const arr = this.weekDay.map((day: any) => this.formBuilder.control(false)); // TODO set this with initial data
     return this.formBuilder.array(arr);
   }
 
   setDays(days: string[]) {
     const runDays = this.form.get(['Schedule', 'RunDays']) as UntypedFormArray;
-    this.weekDay.forEach( (day, i) => {
+    this.weekDay.forEach( (day: any, i) => {
       runDays.at(i).setValue(days.includes(day));
     });
   }

--- a/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/action-create-backup-policy/action-create-backup-policy.component.ts
@@ -39,7 +39,8 @@ export class ActionCreateBackupPolicyComponent implements OnInit {
     delete data.Storage.IsEmptySecondaryCredential;
 
     if (data.Schedule.ScheduleKind === 'TimeBased' && data.Schedule.ScheduleFrequencyType === 'Weekly') {
-      data.Schedule.RunDays = data.Schedule.RunDays.map( (status: boolean, index: number ) => status ? this.weekDay[index] : null).filter( (day: any) => day !== null);
+      const runDays: boolean[] = data.Schedule.RunDays;
+      data.Schedule.RunDays = runDays.map((status, index) => status ? this.weekDay[index] : null).filter((day): day is string => day !== null);
     }else{
       data.Schedule.RunDays = [];
     }

--- a/src/SfxWeb/src/app/views/cluster/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/backups/backups.component.ts
@@ -22,9 +22,9 @@ export class BackupsComponent extends BaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  backupPolicyListSettings: ListSettings;
-  backupPolicies: BackupPolicyCollection;
-  actions: ActionCollection;
+  backupPolicyListSettings!: ListSettings;
+  backupPolicies!: BackupPolicyCollection;
+  actions!: ActionCollection;
 
   setup(){
     this.backupPolicyListSettings = this.settings.getNewOrExistingBackupPolicyListSettings();

--- a/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/clustermap/clustermap.component.ts
@@ -14,8 +14,8 @@ import { BaseControllerDirective } from 'src/app/ViewModels/BaseController';
 export class ClustermapComponent extends BaseControllerDirective {
   private dataService = inject(DataService);
 
-  nodes: NodeCollection;
-  filteredNodes = [];
+  nodes!: NodeCollection;
+  filteredNodes: Node[] = [];
 
   groupByNodeType = false;
 

--- a/src/SfxWeb/src/app/views/cluster/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/details/details.component.ts
@@ -23,14 +23,14 @@ export class DetailsComponent extends BaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  clusterUpgradeProgress: ClusterUpgradeProgress;
-  clusterLoadInformation: ClusterLoadInformation;
-  clusterHealth: ClusterHealth;
-  nodes: NodeCollection;
-  nodesStatuses: INodesStatusDetails[];
+  clusterUpgradeProgress!: ClusterUpgradeProgress;
+  clusterLoadInformation!: ClusterLoadInformation;
+  clusterHealth!: ClusterHealth;
+  nodes!: NodeCollection;
+  nodesStatuses!: INodesStatusDetails[];
 
-  nodeStatusListSettings: ListSettings;
-  upgradeProgressUnhealthyEvaluationsListSettings: ListSettings;
+  nodeStatusListSettings!: ListSettings;
+  upgradeProgressUnhealthyEvaluationsListSettings!: ListSettings;
 
   setup(){
     this.clusterUpgradeProgress = this.data.clusterUpgradeProgress;

--- a/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/essentials/essentials.component.ts
@@ -30,22 +30,22 @@ export class EssentialsComponent extends BaseControllerDirective {
   private routes = inject(RoutesService);
 
 
-  clusterUpgradeProgress: ClusterUpgradeProgress;
-  nodes: NodeCollection;
-  clusterHealth: ClusterHealth;
-  systemApp: SystemApplication;
-  clusterManifest: ClusterManifest;
-  repairtaskCollection: RepairTaskCollection;
-  repairTaskListSettings: ListSettings;
-  infraCollection: InfrastructureCollection;
-  infraSettings: ListSettings;
+  clusterUpgradeProgress!: ClusterUpgradeProgress;
+  nodes!: NodeCollection;
+  clusterHealth!: ClusterHealth;
+  systemApp!: SystemApplication;
+  clusterManifest!: ClusterManifest;
+  repairtaskCollection!: RepairTaskCollection;
+  repairTaskListSettings!: ListSettings;
+  infraCollection!: InfrastructureCollection;
+  infraSettings!: ListSettings;
 
-  nodesDashboard: IDashboardViewModel;
-  appsDashboard: IDashboardViewModel;
-  servicesDashboard: IDashboardViewModel;
-  partitionsDashboard: IDashboardViewModel;
-  replicasDashboard: IDashboardViewModel;
-  upgradesDashboard: IDashboardViewModel;
+  nodesDashboard!: IDashboardViewModel;
+  appsDashboard!: IDashboardViewModel;
+  servicesDashboard!: IDashboardViewModel;
+  partitionsDashboard!: IDashboardViewModel;
+  replicasDashboard!: IDashboardViewModel;
+  upgradesDashboard!: IDashboardViewModel;
   upgradeAppsCount = 0;
 
   essentialItems: IEssentialListItem[] = [];

--- a/src/SfxWeb/src/app/views/cluster/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/events/events.component.ts
@@ -16,8 +16,8 @@ export class EventsComponent implements OnInit {
   private settings = inject(SettingsService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
   ngOnInit() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/cluster/imagestore/imagestore.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/imagestore/imagestore.component.ts
@@ -18,7 +18,7 @@ export class ImagestoreComponent extends BaseControllerDirective {
   settings = inject(SettingsService);
 
 
-  imageStore: ImageStore;
+  imageStore!: ImageStore;
 
   setup() {
     this.imageStore = new ImageStore(this.data);

--- a/src/SfxWeb/src/app/views/cluster/infrastructure-view/infrastructure-view.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/infrastructure-view/infrastructure-view.component.ts
@@ -20,9 +20,9 @@ export class InfrastructureViewComponent extends BaseControllerDirective {
   private data = inject(DataService);
   private settings = inject(SettingsService);
 
-  public collection: InfrastructureCollection;
-  public repairTaskCollection: RepairTaskCollection;
-  public infrastructureDocumentCollection: InfrastructureDocumentCollection;
+  public collection!: InfrastructureCollection;
+  public repairTaskCollection!: RepairTaskCollection;
+  public infrastructureDocumentCollection!: InfrastructureDocumentCollection;
 
   allPendingMRJobs: InfrastructureJob[] = [];
   executingMRJobs: InfrastructureJob[] = [];

--- a/src/SfxWeb/src/app/views/cluster/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/manifest/manifest.component.ts
@@ -16,7 +16,7 @@ export class ManifestComponent extends BaseControllerDirective {
   private data = inject(DataService);
 
 
-  clusterManifest: ClusterManifest;
+  clusterManifest!: ClusterManifest;
 
   setup() {
     this.clusterManifest = this.data.clusterManifest;

--- a/src/SfxWeb/src/app/views/cluster/metric-tile/metric-tile.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/metric-tile/metric-tile.component.ts
@@ -9,7 +9,7 @@ import { LoadMetricInformation } from 'src/app/Models/DataModels/Shared';
     standalone: false
 })
 export class MetricTileComponent {
-  @Input() metric: LoadMetricInformation;
+  @Input() metric!: LoadMetricInformation;
   @Output() toggleSelected = new EventEmitter<void>();
 
   constructor() { }

--- a/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
@@ -7,6 +7,7 @@ import { map, mergeMap } from 'rxjs/operators';
 import { SettingsService } from 'src/app/services/settings.service';
 import { ClusterLoadInformation } from 'src/app/Models/DataModels/Cluster';
 import { NodeCollection } from 'src/app/Models/DataModels/collections/NodeCollection';
+import { Node } from 'src/app/Models/DataModels/Node';
 import { IMetricsViewModel, MetricsViewModel } from 'src/app/ViewModels/MetricsViewModel';
 import { LoadMetricInformation } from 'src/app/Models/DataModels/Shared';
 
@@ -27,10 +28,10 @@ export class MetricsComponent extends BaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  clusterLoadInformation: ClusterLoadInformation;
-  nodes: NodeCollection;
-  metricsViewModel: MetricsViewModel;
-  tableData = {
+  clusterLoadInformation!: ClusterLoadInformation;
+  nodes!: NodeCollection;
+  metricsViewModel!: MetricsViewModel;
+  tableData: { dataPoints: IChartSeries[]; categories: string[]; title: string; tooltipFunction: (() => any) | null } = {
     dataPoints: [],
     categories: [],
     title: '',
@@ -39,7 +40,7 @@ export class MetricsComponent extends BaseControllerDirective {
 
   // groupByNodeType = false;
   showOptions = true;
-  filteredNodes = [];
+  filteredNodes: Node[] = [];
 
   setup() {
     this.clusterLoadInformation = this.data.clusterLoadInformation;
@@ -78,18 +79,18 @@ export class MetricsComponent extends BaseControllerDirective {
       this.metricsViewModel.selectedMetrics.forEach((selectedmetric, index) => {
         const normalize = selectedmetric.hasCapacity && this.metricsViewModel.normalizeMetricsData;
         const selectedNodeLoadMetricInfo = metric.nodeLoadMetricInformation.find(lmi => lmi.name === selectedmetric.name);
-        let dataPoint = +selectedNodeLoadMetricInfo.raw.NodeLoad;
+        let dataPoint = +selectedNodeLoadMetricInfo!.raw.NodeLoad;
 
         if (normalize) {
           addNormalizationTooltip = true;
-          dataPoint = selectedNodeLoadMetricInfo.loadCapacityRatio;
+          dataPoint = selectedNodeLoadMetricInfo!.loadCapacityRatio;
 
           const d = selectedNodeLoadMetricInfo;
-          const tooltip = `${d.parent.name}: ${d.raw.NodeLoad}${d.hasCapacity ? ` / ${d.raw.NodeCapacity} (${d.loadCapacityRatioString})` : ""}`;
-          tooltipMap[`${metric.raw.NodeName}-${selectedmetric.displayName}`] = tooltip;
+          const tooltip = `${d!.parent.name}: ${d!.raw.NodeLoad}${d!.hasCapacity ? ` / ${d!.raw.NodeCapacity} (${d!.loadCapacityRatioString})` : ""}`;
+          (tooltipMap as any)[`${metric.raw.NodeName}-${selectedmetric.displayName}`] = tooltip;
 
         } else if (selectedmetric.hasCapacity) {
-          dataPoint = Math.max(+selectedNodeLoadMetricInfo.raw.NodeLoad, +selectedNodeLoadMetricInfo.raw.NodeCapacity);
+          dataPoint = Math.max(+selectedNodeLoadMetricInfo!.raw.NodeLoad, +selectedNodeLoadMetricInfo!.raw.NodeCapacity);
         }
 
           chartMetricSeriesList[index].data.push(dataPoint);
@@ -100,8 +101,8 @@ export class MetricsComponent extends BaseControllerDirective {
     });
 
     if (addNormalizationTooltip) {
-      this.tableData.tooltipFunction = function() {
-        return tooltipMap[`${this.x}-${this.series.name}`]
+      this.tableData.tooltipFunction = function(this: any) {
+        return (tooltipMap as any)[`${this.x}-${this.series.name}`]
       }
     }
 

--- a/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
@@ -73,7 +73,7 @@ export class MetricsComponent extends BaseControllerDirective {
 
     //for some of the metrics, we normailize and show their value so its necessary to have both.
     let addNormalizationTooltip = false;
-    const tooltipMap =  {};
+    const tooltipMap: Record<string, string> =  {};
 
     this.metricsViewModel.filteredNodeLoadInformation(this.filteredNodes).sort((a, b) => a.name.localeCompare(b.name)).forEach(metric => {
       this.metricsViewModel.selectedMetrics.forEach((selectedmetric, index) => {
@@ -87,7 +87,7 @@ export class MetricsComponent extends BaseControllerDirective {
 
           const d = selectedNodeLoadMetricInfo;
           const tooltip = `${d!.parent.name}: ${d!.raw.NodeLoad}${d!.hasCapacity ? ` / ${d!.raw.NodeCapacity} (${d!.loadCapacityRatioString})` : ""}`;
-          (tooltipMap as any)[`${metric.raw.NodeName}-${selectedmetric.displayName}`] = tooltip;
+          tooltipMap[`${metric.raw.NodeName}-${selectedmetric.displayName}`] = tooltip;
 
         } else if (selectedmetric.hasCapacity) {
           dataPoint = Math.max(+selectedNodeLoadMetricInfo!.raw.NodeLoad, +selectedNodeLoadMetricInfo!.raw.NodeCapacity);
@@ -102,7 +102,7 @@ export class MetricsComponent extends BaseControllerDirective {
 
     if (addNormalizationTooltip) {
       this.tableData.tooltipFunction = function(this: any) {
-        return (tooltipMap as any)[`${this.x}-${this.series.name}`]
+        return tooltipMap[`${this.x}-${this.series.name}`]
       }
     }
 

--- a/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/metrics/metrics.component.ts
@@ -16,6 +16,13 @@ interface IChartSeries {
   data: number[];
 }
 
+interface IMetricsTableData {
+  dataPoints: IChartSeries[];
+  categories: string[];
+  title: string;
+  tooltipFunction: (() => any) | null;
+}
+
 @Component({
     selector: 'app-metrics',
     templateUrl: './metrics.component.html',
@@ -31,7 +38,7 @@ export class MetricsComponent extends BaseControllerDirective {
   clusterLoadInformation!: ClusterLoadInformation;
   nodes!: NodeCollection;
   metricsViewModel!: MetricsViewModel;
-  tableData: { dataPoints: IChartSeries[]; categories: string[]; title: string; tooltipFunction: (() => any) | null } = {
+  tableData: IMetricsTableData = {
     dataPoints: [],
     categories: [],
     title: '',
@@ -101,7 +108,7 @@ export class MetricsComponent extends BaseControllerDirective {
     });
 
     if (addNormalizationTooltip) {
-      this.tableData.tooltipFunction = function(this: any) {
+      this.tableData.tooltipFunction = function(this: { x: string | number; series: { name: string } }) {
         return tooltipMap[`${this.x}-${this.series.name}`]
       }
     }

--- a/src/SfxWeb/src/app/views/cluster/naming-viewer-page/naming-viewer-page.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/naming-viewer-page/naming-viewer-page.component.ts
@@ -26,7 +26,7 @@ export class NamingViewerPageComponent implements OnInit {
     enableRepairTasks: true
   };
 
-  public namingService: Service;
+  public namingService!: Service;
 
   public vizRefs: VisReference[] = [
     { name: "Timeline", component: TimelineComponent },

--- a/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
@@ -36,7 +36,7 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
 
   partitionEvents!: PartitionEvent[];
   partitionId!: string;
-  selectedEvent: PartitionEvent | null = null;
+  selectedEvent?: PartitionEvent | null;
 
   dateMin!: Date;
   startDate!: Date;
@@ -47,7 +47,7 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
   constrainCheckToggle = true;
   otherToggle = true;
 
-  timeLineEventsData: ITimelineData | null = null;
+  timeLineEventsData?: ITimelineData | null;
 
   ngOnInit(): void {
     if (!this.dataService.clusterManifest.isEventStoreEnabled) {
@@ -114,7 +114,7 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
   }
 
   selectEvent(index: string) {
-    this.selectedEvent = this.partitionEvents[+index];
+    this.selectedEvent = this.partitionEvents[index as any];
   }
 
   private fillInOperationEventsData(partitionEventData: IEventStoreData<PartitionEventList, PartitionEvent>) {

--- a/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
@@ -34,20 +34,20 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
   readonly constraintCheckEventColor = "Orange";
   readonly otherEventColor = "Red";
 
-  partitionEvents: PartitionEvent[];
-  partitionId: string;
-  selectedEvent: PartitionEvent;
+  partitionEvents!: PartitionEvent[];
+  partitionId!: string;
+  selectedEvent: PartitionEvent | null = null;
 
-  dateMin: Date;
-  startDate: Date;
-  endDate: Date;
+  dateMin!: Date;
+  startDate!: Date;
+  endDate!: Date;
 
   balancingToggle = true;
   placementToggle = true;
   constrainCheckToggle = true;
   otherToggle = true;
 
-  timeLineEventsData: ITimelineData;
+  timeLineEventsData: ITimelineData | null = null;
 
   ngOnInit(): void {
     if (!this.dataService.clusterManifest.isEventStoreEnabled) {
@@ -103,7 +103,7 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
 
     const partitionEventData = this.dataService.getPartitionEventData(this.partitionId);
     partitionEventData.eventsList.setEventFilter(["Operation"]);
-    partitionEventData.setDateWindow(this.startDate, this.endDate);
+    partitionEventData.setDateWindow!(this.startDate, this.endDate);
     partitionEventData.eventsList.refresh().subscribe((success) => {
       if (!success) {
         console.error("Failed to refresh event data");
@@ -114,11 +114,11 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
   }
 
   selectEvent(index: string) {
-    this.selectedEvent = this.partitionEvents[index];
+    this.selectedEvent = this.partitionEvents[+index];
   }
 
   private fillInOperationEventsData(partitionEventData: IEventStoreData<PartitionEventList, PartitionEvent>) {
-    this.partitionEvents = partitionEventData.getEvents().filter((event) => this.shouldIncludeEvent(event));
+    this.partitionEvents = partitionEventData.getEvents!().filter((event) => this.shouldIncludeEvent(event));
     this.addNodeNames();
     const items = this.generateTimelineItems();
     this.timeLineEventsData = {

--- a/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/orchestration-view/orchestration-view.component.ts
@@ -114,7 +114,7 @@ export class OrchestrationViewComponent implements OnInit, AfterViewInit {
   }
 
   selectEvent(index: string) {
-    this.selectedEvent = this.partitionEvents[index as any];
+    this.selectedEvent = this.partitionEvents[+index];
   }
 
   private fillInOperationEventsData(partitionEventData: IEventStoreData<PartitionEventList, PartitionEvent>) {

--- a/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
+++ b/src/SfxWeb/src/app/views/cluster/repair-tasks/repair-tasks.component.ts
@@ -35,7 +35,7 @@ export class RepairTasksComponent extends BaseControllerDirective {
   private telemService = inject(TelemetryService);
   private timelineGeneratorFactoryService = inject(TimelineGeneratorFactoryService);
 
-  public repairTaskCollection: RepairTaskCollection;
+  public repairTaskCollection!: RepairTaskCollection;
 
   longestRunning: ITileListItem[] = [];
   MostCommonActions: ICounterMostCommonEntry[] = [];
@@ -44,16 +44,16 @@ export class RepairTasksComponent extends BaseControllerDirective {
   sortedRepairTasks: RepairTask[] = [];
   sortedCompletedRepairTasks: RepairTask[] = [];
 
-  repairTaskListSettings: ListSettings;
-  completedRepairTaskListSettings: ListSettings;
+  repairTaskListSettings!: ListSettings;
+  completedRepairTaskListSettings!: ListSettings;
 
-  timelineData: ITimelineData;
+  timelineData!: ITimelineData;
   chartJobs: RepairTask[] = [];
 
-  timelineGenerator: RepairTaskTimelineGenerator;
+  timelineGenerator!: RepairTaskTimelineGenerator;
 
   // will be initially set by detail list component.
-  ordering: ISortOrdering;
+  ordering!: ISortOrdering;
 
   setup() {
     this.repairTaskCollection = this.data.repairCollection;

--- a/src/SfxWeb/src/app/views/debugging/nested-table/nested-table.component.ts
+++ b/src/SfxWeb/src/app/views/debugging/nested-table/nested-table.component.ts
@@ -15,9 +15,9 @@ export class NestedTableComponent implements DetailBaseComponent, OnInit {
   private settings = inject(SettingsService);
 
 
-  item: IRequestsData;
-  listSetting: ListColumnSetting;
-  listSettings: ListSettings;
+  item!: IRequestsData;
+  listSetting!: ListColumnSetting;
+  listSettings!: ListSettings;
 
   ngOnInit(): void {
     this.listSettings = this.settings.getNewOrExistingNetworkRequestListSettings();

--- a/src/SfxWeb/src/app/views/debugging/request-logging/request-logging.component.ts
+++ b/src/SfxWeb/src/app/views/debugging/request-logging/request-logging.component.ts
@@ -16,8 +16,8 @@ export class RequestLoggingComponent implements OnInit {
   networkService = inject(RestClientService);
 
 
-  listSettings: ListSettings;
-  listSettingsRecent: ListSettings;
+  listSettings!: ListSettings;
+  listSettingsRecent!: ListSettings;
 
   ngOnInit(): void {
     this.listSettingsRecent = this.settings.getNewOrExistingNetworkRequestListSettings(true);

--- a/src/SfxWeb/src/app/views/deployed-application/DeployedApplicationBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/DeployedApplicationBase.ts
@@ -12,10 +12,10 @@ import { DeployedApplication } from 'src/app/Models/DataModels/DeployedApplicati
 export class DeployedAppBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    nodeName: string;
-    appId: string;
+    nodeName!: string;
+    appId!: string;
 
-    deployedApp: DeployedApplication;
+    deployedApp!: DeployedApplication;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
       return this.data.getDeployedApplication(this.nodeName, this.appId, true, messageHandler).pipe(mergeMap( deployedApp => {

--- a/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-application/essentials/essentials.component.ts
@@ -18,7 +18,7 @@ export class EssentialsComponent extends DeployedAppBaseControllerDirective {
   protected data: DataService = inject(DataService);
   private settings = inject(SettingsService);
 
-  listSettings: ListSettings;
+  listSettings!: ListSettings;
 
   essentialItems: IEssentialListItem[] = [];
 

--- a/src/SfxWeb/src/app/views/deployed-code-package/DeployedCodePackageBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/DeployedCodePackageBase.ts
@@ -12,13 +12,13 @@ import { DeployedCodePackage } from 'src/app/Models/DataModels/DeployedCodePacka
 export class DeployedCodePackageBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    serviceId: string;
-    activationId: string;
-    appId: string;
-    nodeName: string;
-    codePackageName: string;
+    serviceId!: string;
+    activationId!: string;
+    appId!: string;
+    nodeName!: string;
+    codePackageName!: string;
 
-    deployedCodePackage: DeployedCodePackage;
+    deployedCodePackage!: DeployedCodePackage;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getDeployedCodePackage(this.nodeName, this.appId, this.serviceId, this.activationId, this.codePackageName, true, messageHandler)

--- a/src/SfxWeb/src/app/views/deployed-code-package/container-logs/container-logs.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-package/container-logs/container-logs.component.ts
@@ -15,7 +15,7 @@ import { map } from 'rxjs/operators';
 export class ContainerLogsComponent extends DeployedCodePackageBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
-  containerLogs: string;
+  containerLogs!: string;
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{
     return this.deployedCodePackage.containerLogs.refresh(messageHandler).pipe(map(containerLogs => {

--- a/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-code-packages/base/base.component.ts
@@ -26,13 +26,13 @@ export class BaseComponent extends BaseControllerDirective implements IBaseView 
   private settings = inject(SettingsService);
   el = inject(ElementRef);
 
-  public nodeName: string;
-  public appId: string;
-  public serviceId: string;
-  public activationId: string;
+  public nodeName!: string;
+  public appId!: string;
+  public serviceId!: string;
+  public activationId!: string;
 
-  codePackages: DeployedCodePackageCollection;
-  listSettings: ListSettings;
+  codePackages!: DeployedCodePackageCollection;
+  listSettings!: ListSettings;
 
   setup() {
     this.tree.selectTreeNode([

--- a/src/SfxWeb/src/app/views/deployed-replica/DeployedReplicaBase.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/DeployedReplicaBase.ts
@@ -12,15 +12,15 @@ import { DeployedReplica } from 'src/app/Models/DataModels/DeployedReplica';
 export class DeployedReplicaBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    replicaStatus: number;
+    replicaStatus!: number;
 
-    nodeName: string;
-    applicationId: string;
-    partitionId: string;
-    serviceId: string;
-    activationId: string;
+    nodeName!: string;
+    applicationId!: string;
+    partitionId!: string;
+    serviceId!: string;
+    activationId!: string;
 
-    replica: DeployedReplica;
+    replica!: DeployedReplica;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getDeployedReplica(this.nodeName, this.applicationId, this.serviceId, this.activationId, this.partitionId, true, messageHandler)

--- a/src/SfxWeb/src/app/views/deployed-replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replica/essentials/essentials.component.ts
@@ -16,7 +16,7 @@ import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile
 export class EssentialsComponent extends DeployedReplicaBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
-  appView: string;
+  appView!: string;
 
   essentialItems: IEssentialListItem[] = [];
   essentialItems2: IEssentialListItem[] = [];

--- a/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-replicas/base/base.component.ts
@@ -26,15 +26,15 @@ export class BaseComponent extends BaseControllerDirective implements IBaseView{
   private settings = inject(SettingsService);
   el = inject(ElementRef);
 
-  nodeName: string;
-  appId: string;
-  serviceId: string;
-  activationId: string;
+  nodeName!: string;
+  appId!: string;
+  serviceId!: string;
+  activationId!: string;
 
-  replicas: DeployedReplicaCollection;
-  listSettings: ListSettings;
+  replicas!: DeployedReplicaCollection;
+  listSettings!: ListSettings;
 
-  type: string;
+  type!: string;
 
   setup() {
     this.tree.selectTreeNode([
@@ -46,7 +46,7 @@ export class BaseComponent extends BaseControllerDirective implements IBaseView{
       IdGenerator.deployedReplicaGroup()
     ], true);
 
-    this.listSettings = null;
+    this.listSettings = null!;
   }
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any>{

--- a/src/SfxWeb/src/app/views/deployed-service-package/DeployedServicePackage.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/DeployedServicePackage.ts
@@ -12,12 +12,12 @@ import { DeployedServicePackage } from 'src/app/Models/DataModels/DeployedServic
 export class DeployedServicePackageBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    public serviceId: string;
-    public activationId: string;
-    public appId: string;
-    public nodeName: string;
+    public serviceId!: string;
+    public activationId!: string;
+    public appId!: string;
+    public nodeName!: string;
 
-    servicePackage: DeployedServicePackage;
+    servicePackage!: DeployedServicePackage;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getDeployedServicePackage(this.nodeName, this.appId, this.serviceId, this.activationId, true, messageHandler)

--- a/src/SfxWeb/src/app/views/deployed-service-package/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/deployed-service-package/manifest/manifest.component.ts
@@ -16,7 +16,7 @@ import { ServiceManifest } from 'src/app/Models/DataModels/Service';
 export class ManifestComponent extends DeployedServicePackageBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
-  serviceManifest: ServiceManifest;
+  serviceManifest!: ServiceManifest;
 
   setup() {}
 

--- a/src/SfxWeb/src/app/views/node/NodeBase.ts
+++ b/src/SfxWeb/src/app/views/node/NodeBase.ts
@@ -12,8 +12,8 @@ import { Node } from 'src/app/Models/DataModels/Node';
 export class NodeBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    nodeName: string;
-    node: Node;
+    nodeName!: string;
+    node!: Node;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getNode(this.nodeName, true, messageHandler).pipe(mergeMap( node => {

--- a/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/node/essentials/essentials.component.ts
@@ -10,6 +10,7 @@ import { NodeBaseControllerDirective } from '../NodeBase';
 import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile/essential-health-tile.component';
 import { TimeUtils } from 'src/app/Utils/TimeUtils';
 import { INodeTypeInfo } from 'src/app/Models/DataModels/Cluster';
+import { RepairTask } from 'src/app/Models/DataModels/repairTask';
 
 @Component({
     selector: 'app-essentials',
@@ -23,16 +24,16 @@ export class EssentialsComponent extends NodeBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  deployedApps: DeployedApplicationCollection;
-  listSettings: ListSettings;
+  deployedApps!: DeployedApplicationCollection;
+  listSettings!: ListSettings;
 
   essentialItems: IEssentialListItem[] = [];
   ringInfo: IEssentialListItem[] = [];
 
-  repairJobs = [];
-  repairJobSettings: ListSettings;
+  repairJobs: RepairTask[] = [];
+  repairJobSettings!: ListSettings;
 
-  placementProperties: INodeTypeInfo;
+  placementProperties!: INodeTypeInfo;
 
   setup() {
     this.repairJobSettings = this.settings.getNewOrExistingPendingRepairTaskListSettings();
@@ -107,7 +108,7 @@ export class EssentialsComponent extends NodeBaseControllerDirective {
         this.deployedApps = this.node.deployedApps;
       })),
       this.data.clusterManifest.ensureInitialized().pipe(mergeMap(() => {
-        this.placementProperties = this.data.clusterManifest.getNodeProperties(this.node.raw.Type);
+        this.placementProperties = this.data.clusterManifest.getNodeProperties(this.node.raw.Type)!;
         if (this.data.clusterManifest.isRepairManagerEnabled) {
           return this.data.repairCollection.refresh().pipe(map(() => {
             this.repairJobs = this.data.repairCollection.getRepairJobsForANode(this.node.name);

--- a/src/SfxWeb/src/app/views/node/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/node/events/events.component.ts
@@ -15,8 +15,8 @@ export class EventsComponent extends NodeBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
   setup() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/all-nodes/all-nodes.component.ts
@@ -21,8 +21,8 @@ export class AllNodesComponent extends BaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  nodes: NodeCollection;
-  listSettings: ListSettings;
+  nodes!: NodeCollection;
+  listSettings!: ListSettings;
   tiles: IDashboardViewModel[] = [];
 
   setup() {

--- a/src/SfxWeb/src/app/views/nodes/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/nodes/events/events.component.ts
@@ -16,8 +16,8 @@ export class EventsComponent implements OnInit {
   settings = inject(SettingsService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
   ngOnInit() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/partition/PartitionBase.ts
+++ b/src/SfxWeb/src/app/views/partition/PartitionBase.ts
@@ -12,12 +12,12 @@ import { Partition } from 'src/app/Models/DataModels/Partition';
 export class PartitionBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    public appId: string;
-    public serviceId: string;
-    public partitionId: string;
-    public appTypeName: string;
+    public appId!: string;
+    public serviceId!: string;
+    public partitionId!: string;
+    public appTypeName!: string;
 
-    partition: Partition;
+    partition!: Partition;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getPartition(this.appId, this.serviceId, this.partitionId, true, messageHandler)

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
@@ -28,8 +28,8 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
   telemetry = inject(TelemetryService);
 
 
-  partitionBackupListSettings: ListSettings;
-  actions: ActionCollection;
+  partitionBackupListSettings!: ListSettings;
+  actions!: ActionCollection;
   startDate: Date = new Date();
   endDate: Date = new Date();
   minDate: Date = new Date();
@@ -37,10 +37,10 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
   startTime: any;
   endTime: any;
   backupList: any;
-  dateRefresh: boolean;
+  dateRefresh!: boolean;
 
   setup(){
-    this.partitionBackupListSettings = this.settings.getNewOrExistingListSettings('partitionBackups', [null], [
+    this.partitionBackupListSettings = this.settings.getNewOrExistingListSettings('partitionBackups', [null!], [
       new ListColumnSetting('raw.BackupId', 'BackupId', {
         enableFilter: false,
         cssClasses: "link",
@@ -73,7 +73,7 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
   setNewPartitionBackupList(startDate: Date, endDate: Date)
   {
     this.backupList = this.partition.partitionBackupInfo.partitionBackupList.collection;
-    this.backupList = this.backupList.filter((info) => {
+    this.backupList = this.backupList.filter((info: any) => {
       return (new Date(info.raw.CreationTimeUtc) >= startDate && new Date(info.raw.CreationTimeUtc) <= endDate);
     });
   }
@@ -100,7 +100,7 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
       this.backupList = this.partition.partitionBackupInfo.partitionBackupList.collection;
       if (this.backupList.length !== 0)
       {
-        const templist = this.backupList.sort((left, right): number => {
+        const templist = this.backupList.sort((left: any, right: any): number => {
           if (left.CreationTimeUtc < right.CreationTimeUtc) {
             return -1;
           }

--- a/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
+++ b/src/SfxWeb/src/app/views/partition/backups/backups.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ListSettings, ListColumnSetting } from 'src/app/Models/ListSettings';
+import { PartitionBackup } from 'src/app/Models/DataModels/PartitionBackupInfo';
 import { DataService } from 'src/app/services/data.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { PartitionBaseControllerDirective } from '../PartitionBase';
@@ -36,7 +37,7 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
   maxDate: Date = new Date();
   startTime: any;
   endTime: any;
-  backupList: any;
+  backupList: PartitionBackup[] = [];
   dateRefresh!: boolean;
 
   setup(){
@@ -73,7 +74,7 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
   setNewPartitionBackupList(startDate: Date, endDate: Date)
   {
     this.backupList = this.partition.partitionBackupInfo.partitionBackupList.collection;
-    this.backupList = this.backupList.filter((info: any) => {
+    this.backupList = this.backupList.filter((info) => {
       return (new Date(info.raw.CreationTimeUtc) >= startDate && new Date(info.raw.CreationTimeUtc) <= endDate);
     });
   }
@@ -100,11 +101,11 @@ export class BackupsComponent extends PartitionBaseControllerDirective {
       this.backupList = this.partition.partitionBackupInfo.partitionBackupList.collection;
       if (this.backupList.length !== 0)
       {
-        const templist = this.backupList.sort((left: any, right: any): number => {
-          if (left.CreationTimeUtc < right.CreationTimeUtc) {
+        const templist = this.backupList.sort((left, right): number => {
+          if (left.raw.CreationTimeUtc < right.raw.CreationTimeUtc) {
             return -1;
           }
-          if (left.CreationTimeUtc > right.CreationTimeUtc) {
+          if (left.raw.CreationTimeUtc > right.raw.CreationTimeUtc) {
             return 1;
           }
           return 0;

--- a/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/partition/essentials/essentials.component.ts
@@ -25,7 +25,7 @@ export class EssentialsComponent extends PartitionBaseControllerDirective {
 
 
   public hideReplicator = true;
-  listSettings: ListSettings;
+  listSettings!: ListSettings;
   replicaViewModels: any[] = [];
 
   essentialItems: IEssentialListItem[] = [];

--- a/src/SfxWeb/src/app/views/partition/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/partition/events/events.component.ts
@@ -16,8 +16,8 @@ export class EventsComponent extends PartitionBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
-  optionsConfig: IOptionConfig;
+  listEventStoreData!: IEventStoreData<any, any> [];
+  optionsConfig!: IOptionConfig;
 
   setup() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/partition/partition-restore-back-up/partition-restore-back-up.component.ts
+++ b/src/SfxWeb/src/app/views/partition/partition-restore-back-up/partition-restore-back-up.component.ts
@@ -19,7 +19,7 @@ export class PartitionRestoreBackUpComponent implements OnInit {
   dialogRef = inject<MatDialogRef<PartitionRestoreBackUpComponent>>(MatDialogRef);
 
 
-  form: UntypedFormGroup;
+  form!: UntypedFormGroup;
 
   ngOnInit() {
     this.form = this.formBuilder.group({

--- a/src/SfxWeb/src/app/views/partition/partition-trigger-back-up/partition-trigger-back-up.component.ts
+++ b/src/SfxWeb/src/app/views/partition/partition-trigger-back-up/partition-trigger-back-up.component.ts
@@ -19,7 +19,7 @@ export class PartitionTriggerBackUpComponent implements OnInit {
   dialogRef = inject<MatDialogRef<PartitionTriggerBackUpComponent>>(MatDialogRef);
 
 
-  form: UntypedFormGroup;
+  form!: UntypedFormGroup;
   ngOnInit() {
     // storage gets set by nested component
     this.form = this.formBuilder.group({

--- a/src/SfxWeb/src/app/views/replica/ReplicaBase.ts
+++ b/src/SfxWeb/src/app/views/replica/ReplicaBase.ts
@@ -13,14 +13,14 @@ import { Constants } from 'src/app/Common/Constants';
 export class ReplicaBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    public appId: string;
-    public serviceId: string;
-    public partitionId: string;
-    public replicaId: string;
-    public appTypeName: string;
-    public isSystem: boolean;
+    public appId!: string;
+    public serviceId!: string;
+    public partitionId!: string;
+    public replicaId!: string;
+    public appTypeName!: string;
+    public isSystem!: boolean;
 
-    replica: ReplicaOnPartition;
+    replica!: ReplicaOnPartition;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         this.isSystem = this.appTypeName === Constants.SystemAppTypeName;

--- a/src/SfxWeb/src/app/views/replica/commands/commands.component.ts
+++ b/src/SfxWeb/src/app/views/replica/commands/commands.component.ts
@@ -17,7 +17,7 @@ export class CommandsComponent extends ReplicaBaseControllerDirective{
 
 
   commands: PowershellCommand[] = [];
-  replicaRole: string;
+  replicaRole!: string;
 
   refresh(messageHandler?: IResponseMessageHandler): Observable<any> {
     if (this.replicaRole !== this.replica?.raw.ReplicaRole) {

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -20,7 +20,7 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
   protected data: DataService = inject(DataService);
   private settings = inject(SettingsService);
 
-  nodeView: string;
+  nodeView!: string;
 
   essentialItems: IEssentialListItem[] = [];
 
@@ -40,7 +40,7 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
     map(() => {
       if (!this.isSystem) {
           const rawDataProperty = this.replica.isStatefulService ? 'DeployedServiceReplica' : 'DeployedServiceReplicaInstance';
-          const detailRaw = this.replica.detail.raw[rawDataProperty];
+          const detailRaw = (this.replica.detail.raw as any)[rawDataProperty];
 
           const serviceNameOnly = detailRaw.ServiceManifestName;
           const activationId = detailRaw.ServicePackageActivationId || null;

--- a/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/replica/essentials/essentials.component.ts
@@ -8,6 +8,7 @@ import { map, tap, catchError } from 'rxjs/operators';
 import { ReplicaBaseControllerDirective } from '../ReplicaBase';
 import { RoutesService } from 'src/app/services/routes.service';
 import { IEssentialListItem } from 'src/app/modules/charts/essential-health-tile/essential-health-tile.component';
+import { IRawInstanceInfo, IRawReplicaInfo } from 'src/app/Models/RawDataTypes';
 
 @Component({
     selector: 'app-essentials',
@@ -39,11 +40,12 @@ export class EssentialsComponent extends ReplicaBaseControllerDirective {
   const safeDetailRefresh$ = this.replica.detail.refresh(messageHandler).pipe(
     map(() => {
       if (!this.isSystem) {
-          const rawDataProperty = this.replica.isStatefulService ? 'DeployedServiceReplica' : 'DeployedServiceReplicaInstance';
-          const detailRaw = (this.replica.detail.raw as any)[rawDataProperty];
+          const detailRaw = this.replica.isStatefulService
+              ? (this.replica.detail.raw as IRawReplicaInfo).DeployedServiceReplica
+              : (this.replica.detail.raw as IRawInstanceInfo).DeployedServiceReplicaInstance;
 
           const serviceNameOnly = detailRaw.ServiceManifestName;
-          const activationId = detailRaw.ServicePackageActivationId || null;
+          const activationId = detailRaw.ServicePackageActivationId;
           this.nodeView = RoutesService.getDeployedReplicaViewPath(this.replica.raw.NodeName, this.appId, serviceNameOnly, activationId, this.partitionId, this.replicaId);
       }
       return true;

--- a/src/SfxWeb/src/app/views/replica/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/replica/events/events.component.ts
@@ -14,7 +14,7 @@ export class EventsComponent extends ReplicaBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
+  listEventStoreData!: IEventStoreData<any, any> [];
 
   setup() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/service/ServiceBase.ts
+++ b/src/SfxWeb/src/app/views/service/ServiceBase.ts
@@ -12,10 +12,10 @@ import { Service } from 'src/app/Models/DataModels/Service';
 export class ServiceBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    appId: string;
-    serviceId: string;
-    appTypeName: string;
-    service: Service;
+    appId!: string;
+    serviceId!: string;
+    appTypeName!: string;
+    service!: Service;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getService(this.appId, this.serviceId, true, messageHandler).pipe(mergeMap(service => {

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -83,9 +83,9 @@ export class BackupComponent extends ServiceBaseControllerDirective {
             data: this
         },
         PartitionDisableBackUpComponent,
-        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service'),
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service') as unknown as boolean,
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -96,10 +96,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.suspendServiceBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false) as unknown as boolean,
         {
           title: 'Confirm Service Backup Suspension'
         },
@@ -118,10 +118,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.resumeApplicationBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true) as unknown as boolean,
         {
           title: 'Confirm Service Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -24,8 +24,8 @@ export class BackupComponent extends ServiceBaseControllerDirective {
   private settings = inject(SettingsService);
   telemetry = inject(TelemetryService);
 
-  serviceBackupConfigurationInfoListSettings: ListSettings;
-  actions: ActionCollection;
+  serviceBackupConfigurationInfoListSettings!: ListSettings;
+  actions!: ActionCollection;
 
   setup() {
     this.serviceBackupConfigurationInfoListSettings = this.settings.getNewOrExistingListSettings('serviceBackupConfigurationInfoListSettings', ['raw.PolicyName'], [
@@ -50,7 +50,7 @@ export class BackupComponent extends ServiceBaseControllerDirective {
 
 
     this.service.serviceBackupConfigurationInfoCollection.refresh(messageHandler);
-    return this.data.refreshBackupPolicies(messageHandler);
+    return this.data.refreshBackupPolicies(messageHandler!);
   }
 
   setupActions() {
@@ -83,9 +83,9 @@ export class BackupComponent extends ServiceBaseControllerDirective {
             data: this
         },
         PartitionDisableBackUpComponent,
-        () => this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service',
+              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service'),
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -96,10 +96,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.suspendServiceBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-        () => this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false,
+              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
         {
           title: 'Confirm Service Backup Suspension'
         },
@@ -118,10 +118,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.resumeApplicationBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-        () => this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+        () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true,
+              this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
         {
           title: 'Confirm Service Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/service/backup/backup.component.ts
+++ b/src/SfxWeb/src/app/views/service/backup/backup.component.ts
@@ -83,9 +83,9 @@ export class BackupComponent extends ServiceBaseControllerDirective {
             data: this
         },
         PartitionDisableBackUpComponent,
-          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
-            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service') as unknown as boolean,
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service'),
     ));
 
       this.actions.add(new ActionWithConfirmationDialog(
@@ -96,10 +96,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.suspendServiceBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false) as unknown as boolean,
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === false),
         {
           title: 'Confirm Service Backup Suspension'
         },
@@ -118,10 +118,10 @@ export class BackupComponent extends ServiceBaseControllerDirective {
         () => this.data.restClient.resumeApplicationBackup(this.service.id).pipe(map(() => {
             return this.service.serviceBackupConfigurationInfoCollection.refresh();
         })),
-          () => (this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
+          () => !!(this.service.serviceBackupConfigurationInfoCollection.collection.length && this.service.serviceBackupConfigurationInfoCollection.collection[0].raw &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.Kind === 'Service' &&
               this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.PolicyInheritedFrom === 'Service' &&
-            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true) as unknown as boolean,
+            this.service.serviceBackupConfigurationInfoCollection.collection[0].raw.SuspensionInfo.IsSuspended === true),
         {
           title: 'Confirm Service Backup Resumption'
         },

--- a/src/SfxWeb/src/app/views/service/details/details.component.ts
+++ b/src/SfxWeb/src/app/views/service/details/details.component.ts
@@ -19,7 +19,7 @@ export class DetailsComponent extends ServiceBaseControllerDirective {
     if (this.data.clusterManifest.isBackupRestoreEnabled && this.service.isStatefulService
       && this.appTypeName !== Constants.SystemAppTypeName) {
       this.service.serviceBackupConfigurationInfoCollection.refresh(messageHandler);
-      this.data.refreshBackupPolicies(messageHandler);
+      this.data.refreshBackupPolicies(messageHandler!);
     }
 
     return forkJoin([

--- a/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/service/essentials/essentials.component.ts
@@ -23,9 +23,9 @@ export class EssentialsComponent extends ServiceBaseControllerDirective {
   private settings = inject(SettingsService);
 
 
-  listSettings: ListSettings;
-  partitionsDashboard: IDashboardViewModel;
-  replicasDashboard: IDashboardViewModel;
+  listSettings!: ListSettings;
+  partitionsDashboard!: IDashboardViewModel;
+  replicasDashboard!: IDashboardViewModel;
 
   essentialItems: IEssentialListItem[] = [];
 

--- a/src/SfxWeb/src/app/views/service/events/events.component.ts
+++ b/src/SfxWeb/src/app/views/service/events/events.component.ts
@@ -14,7 +14,7 @@ export class EventsComponent extends ServiceBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
 
-  listEventStoreData: IEventStoreData<any, any> [];
+  listEventStoreData!: IEventStoreData<any, any> [];
 
   setup() {
     this.listEventStoreData = [

--- a/src/SfxWeb/src/app/views/service/manifest/manifest.component.ts
+++ b/src/SfxWeb/src/app/views/service/manifest/manifest.component.ts
@@ -15,7 +15,7 @@ import { map, mergeMap } from 'rxjs/operators';
 export class ManifestComponent extends ServiceBaseControllerDirective {
   protected data: DataService = inject(DataService);
 
-  serviceManifest: string;
+  serviceManifest!: string;
 
   setup() {}
 

--- a/src/SfxWeb/src/app/views/service/resources/resources.component.ts
+++ b/src/SfxWeb/src/app/views/service/resources/resources.component.ts
@@ -80,7 +80,7 @@ export class ResourcesComponent extends ServiceBaseControllerDirective {
       let name  = row.match(/Name="([^"]+)"/);
       let value = row.match(/DefaultValue="([^"]+)"/);
       if (name && value) {
-        parameters[name[1]]=value[1];
+        (parameters as any)[name[1]]=value[1];
       }
       content = content.substring(i2+1);
     }
@@ -200,7 +200,7 @@ export class ResourcesComponent extends ServiceBaseControllerDirective {
       case 0:
         return "Value has not been specified by the cluster owner.";
       default:
-        return null;
+        return null!;
     }
   }
 

--- a/src/SfxWeb/src/app/views/service/resources/resources.component.ts
+++ b/src/SfxWeb/src/app/views/service/resources/resources.component.ts
@@ -60,7 +60,7 @@ export class ResourcesComponent extends ServiceBaseControllerDirective {
   }
 
   getAppManifestParameters(manifest: string) : { [key: string]: string }  {
-    let parameters = {};
+    let parameters: Record<string, string> = {};
     let tagStart = "<Parameters>", tagEnd = "</Parameters>";
     let start = manifest.indexOf(tagStart);
     let end = manifest.indexOf(tagEnd);
@@ -80,7 +80,7 @@ export class ResourcesComponent extends ServiceBaseControllerDirective {
       let name  = row.match(/Name="([^"]+)"/);
       let value = row.match(/DefaultValue="([^"]+)"/);
       if (name && value) {
-        (parameters as any)[name[1]]=value[1];
+        parameters[name[1]]=value[1];
       }
       content = content.substring(i2+1);
     }

--- a/src/SfxWeb/src/app/views/service/scale-service/scale-service.component.ts
+++ b/src/SfxWeb/src/app/views/service/scale-service/scale-service.component.ts
@@ -21,15 +21,15 @@ export class ScaleServiceComponent implements OnInit, OnDestroy, DialogBodyCompo
   private formBuilder = inject(UntypedFormBuilder);
 
 
-  @Input() inputs: { service: Service };
-  count: number;
+  @Input() inputs!: { service: Service };
+  count!: number;
 
-  updateServiceDescription: IRawUpdateServiceDescription;
+  updateServiceDescription!: IRawUpdateServiceDescription;
 
-  form: UntypedFormGroup;
+  form!: UntypedFormGroup;
   @Output() disableSubmit = new EventEmitter<boolean>();
 
-  validityCheckerSubscription: Subscription;
+  validityCheckerSubscription!: Subscription;
   disableSubmitSubscription: Subscription = new Subscription();
 
   ngOnInit() {

--- a/src/SfxWeb/src/app/views/system-applications/SystemApplicationBase.ts
+++ b/src/SfxWeb/src/app/views/system-applications/SystemApplicationBase.ts
@@ -11,9 +11,9 @@ import { ListSettings } from 'src/app/Models/ListSettings';
 export class ServiceApplicationsBaseControllerDirective extends BaseControllerDirective {
     protected data = inject(DataService);
 
-    systemApp: SystemApplication;
-    listSettings: ListSettings;
-    unhealthyEvaluationsListSettings: ListSettings;
+    systemApp!: SystemApplication;
+    listSettings!: ListSettings;
+    unhealthyEvaluationsListSettings!: ListSettings;
 
     common(messageHandler?: IResponseMessageHandler): Observable<any> {
         return this.data.getSystemApp(true, messageHandler).pipe(map(systemApp => {

--- a/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.ts
+++ b/src/SfxWeb/src/app/views/system-applications/essentials/essentials.component.ts
@@ -19,7 +19,7 @@ export class EssentialsComponent extends ServiceApplicationsBaseControllerDirect
   private settings = inject(SettingsService);
 
 
-  listSettings: ListSettings;
+  listSettings!: ListSettings;
   essentialItems: IEssentialListItem[] = [];
 
   setup() {

--- a/src/SfxWeb/tsconfig.json
+++ b/src/SfxWeb/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "strict": false,
+    "strict": true,
     "paths": {
       "src/*": ["./src/*"]
     },


### PR DESCRIPTION
**Stacked — base `pr/1-angular22` (1a, #1029).** Part **1b** of the Angular 22 upgrade; merge after **1a**.

Splits the TypeScript **strict mode** enablement out of the upgrade so it can be reviewed on its own.

### Scope
- Enable `strict` in the TS config and **fix all resulting violations**.
- Preserve runtime behavior where the strict migration would have changed it.
- Keeps master's numeric `NodeCollection` upgrade-domain sort intact under strict.

### Verification
- `npm run build:prod` ✅ (strict)
- `npm run ci:test` (Karma) ✅ — 96 passing

The rest of the stack ([2/5] onward) builds on top of this.